### PR TITLE
fix: memory leak while server-rendering

### DIFF
--- a/packages/universal-rx/src/server/renderToString.js
+++ b/packages/universal-rx/src/server/renderToString.js
@@ -5,6 +5,7 @@ import Serializer from './serializer';
 
 export default function renderToString(element) {
   Host.driver = ServerDriver;
+  Host.roots = {};
   let body = ServerDriver.createBody();
   render(element, body);
   return new Serializer(body).serialize();


### PR DESCRIPTION
- fix memory leak while calling `renderToString` in universal-rx


before: memory usage increasing
![image](https://cloud.githubusercontent.com/assets/3922719/20378451/3349915e-acd1-11e6-9bbd-221c0c9dfd94.png)

after: memory usage stable
![image](https://cloud.githubusercontent.com/assets/3922719/20378403/d0ae75be-acd0-11e6-8035-f64e651843df.png)
