### PR TITLE
feat: env platform work on CommonJS

### DIFF
--- a/packages/rax-webpack-plugin/src/__test__/TraverseImport.import.test.js
+++ b/packages/rax-webpack-plugin/src/__test__/TraverseImport.import.test.js
@@ -2,8 +2,21 @@
 
 import traverseImport from '../TraverseImport';
 
+// Remove padding from a string.
+function unpad(str) {
+  const lines = str.split('\n');
+  const m = lines[1] && lines[1].match(/^\s+/);
+  if (!m) {
+    return str;
+  }
+  const spaces = m[0].length;
+  return lines.map(
+    line => line.slice(spaces)
+  ).join('\n').trim();
+}
+
 describe('PlatformLoader.traverseImport', function() {
-  it('isWeex true ', function() {
+  it('isWeex true', function() {
     const { code } = traverseImport(
       { name: 'universal-env', platform: 'weex' },
       'import { isWeex } from "universal-env";'
@@ -12,16 +25,18 @@ describe('PlatformLoader.traverseImport', function() {
     expect(code).toBe('const isWeex = true;');
   });
 
-  it('isWeex as iw ', function() {
+  it('isWeex as iw', function() {
     const { code } = traverseImport(
       { name: 'universal-env', platform: 'weex' },
       'import { isWeex as iw } from "universal-env";'
     );
 
-    expect(code).toBe(
-`const iw = true;
-const isWeex = true;`
-    );
+    const expected = unpad(`
+      const iw = true;
+      const isWeex = true;
+    `);
+
+    expect(code).toBe(expected);
   });
 
   it('isWeex and isWeb', function() {
@@ -30,10 +45,12 @@ const isWeex = true;`
       'import { isWeex, isWeb } from "universal-env";'
     );
 
-    expect(code).toBe(
-`const isWeb = false;
-const isWeex = true;`
-    );
+    const expected = unpad(`
+      const isWeb = false;
+      const isWeex = true;
+    `);
+
+    expect(code).toBe(expected);
   });
 
   it('isWeb true', function() {
@@ -48,15 +65,19 @@ const isWeex = true;`
   it('skin other module', function() {
     const { code } = traverseImport(
       { name: 'universal-env', platform: 'web' },
-`import { isWeb } from "universal-env";
-import { XXX } from "universal-other";
-`
+      unpad(`
+        import { isWeb } from "universal-env";
+        import { XXX } from "universal-other";
+      `)
     );
 
-    expect(code).toBe(
-`const isWeb = true;
+    const expected = unpad(`
+      const isWeb = true;
 
-import { XXX } from "universal-other";`);
+      import { XXX } from "universal-other";
+    `);
+
+    expect(code).toBe(expected);
   });
 
   it('not platform specified', function() {

--- a/packages/rax-webpack-plugin/src/__test__/TraverseImport.require.test.js
+++ b/packages/rax-webpack-plugin/src/__test__/TraverseImport.require.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+import traverseImport from '../TraverseImport';
+
+// Remove padding from a string.
+function unpad(str) {
+  const lines = str.split('\n');
+  const m = lines[1] && lines[1].match(/^\s+/);
+  if (!m) {
+    return str;
+  }
+  const spaces = m[0].length;
+  return lines.map(
+    line => line.slice(spaces)
+  ).join('\n').trim();
+}
+
+describe('PlatformLoader.traverseImport work on CommonJS', function() {
+  it('isWeex true', function() {
+    const { code } = traverseImport(
+      { name: 'universal-env', platform: 'weex' },
+      'const env = require("universal-env");'
+    );
+
+    const expected = unpad(`
+      const env = {
+        isWeex: true,
+        isWeb: false,
+        isNode: false,
+        isReactNative: false
+      };
+    `);
+
+    expect(code).toBe(expected);
+  });
+
+  it('isWeex as iw', function() {
+    const { code } = traverseImport(
+      { name: 'universal-env', platform: 'weex' },
+      unpad(`
+        const env = require("universal-env");
+        const iw = env.isWeex;
+      `)
+    );
+
+    const expected = unpad(`
+      const env = {
+        isWeex: true,
+        isWeb: false,
+        isNode: false,
+        isReactNative: false
+      };
+      const iw = env.isWeex;
+    `);
+
+    expect(code).toBe(expected);
+  });
+
+  it('skin other module', function() {
+    const { code } = traverseImport(
+      { name: 'universal-env', platform: 'web' },
+      unpad(`
+        const xxx = require("universal-env").xxx;
+      `)
+    );
+
+    const expected = unpad(`
+      const xxx = {
+        isWeex: false,
+        isWeb: true,
+        isNode: false,
+        isReactNative: false
+      }.xxx;
+    `);
+
+    expect(code).toBe(expected);
+  });
+
+  it('not platform specified', function() {
+    const { code } = traverseImport(
+      { name: 'universal-env'},
+      'const env = require("universal-env");'
+    );
+
+    const expected = 'const env = require("universal-env");';
+
+    expect(code).toBe(expected);
+  });
+
+  it('unknown platform', function() {
+    const { code } = traverseImport(
+      { name: 'universal-env', platform: 'xxxx'},
+      'const env = require("universal-env");'
+    );
+
+    const expected = 'const env = require("universal-env");';
+
+    expect(code).toBe(expected);
+  });
+
+  it('unknown platform and unknown name', function() {
+    const { code } = traverseImport(
+      { name: 'universal-xxx'},
+      'const env = require("universal-env");'
+    );
+
+    expect(code).toBe('const env = require("universal-env");');
+  });
+});


### PR DESCRIPTION
```js
const env = require("universal-env");
```
When specified platform is `weex` tranform to:

```js
const env = {
  isWeex: true,
  isWeb: false,
  isNode: false,
  isReactNative: false
}
```