### PR TITLE
Use proper Vue build for file size comparison in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Rax is a universal JavaScript library with a largely React-compatible API. If yo
 
 <img width="78.88%" height="5" src="https://cloud.githubusercontent.com/assets/2505411/20559178/59a527a0-b1ae-11e6-9b71-581323ac22f8.png">
 
-[Vue 2.0.8](https://unpkg.com/vue@2.0.8/dist/vue.min.js) - 24.4kb (gzip)
+[Vue 2.1.8](https://unpkg.com/vue@2.1.8/dist/vue.runtime.min.js) - 17.9kb (gzip)
 
-<img width="44.04%" height="5" src="https://cloud.githubusercontent.com/assets/2505411/20559178/59a527a0-b1ae-11e6-9b71-581323ac22f8.png">
+<img width="32.25%" height="5" src="https://cloud.githubusercontent.com/assets/2505411/20559178/59a527a0-b1ae-11e6-9b71-581323ac22f8.png">
 
 [Rax 0.0.2](https://unpkg.com/rax@0.0.2/dist/rax.min.js) - 8.0kb (gzip)
 


### PR DESCRIPTION
Use the Vue runtime build for size comparison. This is the file used in projects with build tools. The standalone `vue.js` is used only in projects that do not use build tools.