### PR TITLE
feat: input support blur&focus

### DIFF
--- a/packages/rax-components/src/TextInput.js
+++ b/packages/rax-components/src/TextInput.js
@@ -51,6 +51,13 @@ class TextInput extends Component {
   handleFocus = (e) => this.props.onFocus(e);
   handleBlur = (e) => this.props.onBlur(e);
 
+  focus = () => {
+    this.refs.input.focus && this.refs.input.focus();
+  };
+  blur = () => {
+    this.refs.input.blur && this.refs.input.blur();
+  };
+
   render() {
     const {
       accessibilityLabel,
@@ -90,7 +97,8 @@ class TextInput extends Component {
         ...style
       },
       value,
-      id
+      id,
+      ref: 'input'
     };
 
     if (typeof editable !== 'undefined' && !editable) {


### PR DESCRIPTION


Weex has supported sync methods for some components, like `input.blur()`, `input.focus()`. And this feature is consistent with browser. So TextInput need exposed this two methods.