### PR TITLE
build: use webpack-rax-framework v0.1.2 cdn for rax-cli

### DIFF
--- a/packages/rax-cli/src/generator/templates/public/index.html
+++ b/packages/rax-cli/src/generator/templates/public/index.html
@@ -22,6 +22,6 @@
   </style>
 </head>
 <body>
-  <script src="//unpkg.com/web-rax-framework@0.1.0/dist/framework.web.js"></script>
+  <script src="//unpkg.com/web-rax-framework@0.1.2/dist/framework.web.js"></script>
 </body>
 </html>


### PR DESCRIPTION
link and fix #68 

Trying to following the step in the readme file,

1. `rax init myDemo` after fresh install
2. run `cd myDemo && npm run start` 
3. open `localhost:8080` but get this error from debug tool

This is broken with the latest version of `web-rax-framework` which is loaded from https://unpkg.com/web-rax-framework@0.1.0/dist/framework.web.js
 
<img width="431" alt="screen shot 2017-01-13 at 10 22 26 pm" src="https://cloud.githubusercontent.com/assets/1183541/21928497/45cb14c0-d9df-11e6-88fe-c88e0e6e7f26.png">

However an older version(0.0.10) https://unpkg.com/web-rax-framework@0.0.10/dist/framework.web.js (which is the one used on [rax playground](http://rax.taobaofed.org/playground/)) seems work without any issue.

This is because the bundled source code is using `define` which is not available yet.

```
// {"framework" : "Rax"}
define("framework.web", function(require) {/******/ (function(modules) { // webpackBootstrap
```

Tested with 0.1.2 and it's working.


