### PR TITLE
feat: support yarn

### DIFF
--- a/packages/rax-cli/src/generator/index.js
+++ b/packages/rax-cli/src/generator/index.js
@@ -2,23 +2,35 @@ var path = require('path');
 var chalk = require('chalk');
 var spawn = require('cross-spawn');
 var easyfile = require('easyfile');
+var execSync = require('child_process').execSync;
+
+function shouldUseYarn() {
+  try {
+    execSync('yarnpkg --version', {stdio: 'ignore'});
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
 
 function install(projectDir, projectName, verbose) {
   console.log(chalk.white.bold('Install dependencies:'));
 
-  var proc = spawn('npm', [
-    'install',
-    verbose ? '--verbose' : ''
-  ], {stdio: 'inherit'});
+  var pkgManager = shouldUseYarn() ? 'yarnpkg' : 'npm';
+  var args = ['install'];
+  if (verbose) {
+    args.push('--verbose');
+  }
+  var proc = spawn(pkgManager, args, {stdio: 'inherit'});
 
   proc.on('close', function(code) {
     if (code !== 0) {
-      console.error('`npm install` failed');
+      console.error('`' + pkgManager + ' install` failed');
       return;
     } else {
       console.log(chalk.white.bold('To run your app:'));
       console.log(chalk.white('   cd ' + projectName));
-      console.log(chalk.white('   npm run start'));
+      console.log(chalk.white('   ' + pkgManager + ' run start'));
     }
   });
 }


### PR DESCRIPTION
Use [yarn](https://github.com/yarnpkg/yarn) if possible, fallback to npm when yarn is not installed.