### PR TITLE
docs: update ssr data

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,17 @@ Rax is a universal JavaScript library with a largely React-compatible API. If yo
 <img width="14.44%" height="5" src="https://cloud.githubusercontent.com/assets/2505411/20559178/59a527a0-b1ae-11e6-9b71-581323ac22f8.png">
 
 ## Server-side Rendering Comparison
-> [Benchmark repository](https://github.com/taobaofed/server-side-rendering-comparison): Run on a MacBook Air Intel Core i5 @1.4 GHz x 2 with 8 GB memory.
 
-| Library      | renderToString (per second)  |
-|--------------|-----------------------------|
-| React@15.3.2 | 297 op/s                    |
-| Vue@2.0.8    | 1092 op/s                   |
-| Rax@0.0.2    | 1553 op/s (fastest)         |
+> [Benchmark repository](https://github.com/taobaofed/server-side-rendering-comparison): Run on a MacBook Air Intel Core i5 @1.4 GHz x 2 with 8 GB memory with Node.js v6.9.2.
 
+|Library\Version|renderToSring   | QPS [#/sec] |
+|--------------|-----------------|-------------|
+| React@15.4.2 | 152.73ms        |  444.10    |
+| Rax@0.1.2    | 89.70ms         |  513.54 |
+| Vue@2.1.8    | 100.06ms        |  599.58   |
+
+- renderToSring: Independent process serial execution 10 times, each process parallel rendering 100 times, without cache.
+- QPS: `ab -n1000 -c50 url`, without cache
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Rax is a universal JavaScript library with a largely React-compatible API. If yo
 
 ## Server-side Rendering Comparison
 
+Benchmark run on a MacBook Pro 2.4GHz Intel Core i5 and 8GB 1600MHz DDR3 with Node.js v6.9.2. For more information, please refer to [benchmark repository](https://github.com/taobaofed/server-side-rendering-comparison).
+
 |Library       |renderToSring   |
 |--------------|-----------------|
 | React@15.4.2 | 94.93 ops/sec   |

--- a/README.md
+++ b/README.md
@@ -45,16 +45,12 @@ Rax is a universal JavaScript library with a largely React-compatible API. If yo
 
 ## Server-side Rendering Comparison
 
-> [Benchmark repository](https://github.com/taobaofed/server-side-rendering-comparison): Run on a MacBook Air Intel Core i5 @1.4 GHz x 2 with 8 GB memory with Node.js v6.9.2.
+> [Benchmark repository](https://github.com/taobaofed/server-side-rendering-comparison): Run on a  MacBook Pro (Late 2013) 2.4GHz Intel Core i5 and 8GB 1600MHz DDR3 with Node.js v6.9.2.
 
-|Library\Version|renderToSring   | QPS [#/sec] |
-|--------------|-----------------|-------------|
-| React@15.4.2 | 152.73ms        |  444.10    |
-| Rax@0.1.2    | 89.70ms         |  513.54 |
-| Vue@2.1.8    | 100.06ms        |  599.58   |
-
-- renderToSring: Independent process serial execution 10 times, each process parallel rendering 100 times, without cache.
-- QPS: `ab -n1000 -c50 url`, without cache
+|Library\Version|renderToSring   |
+|--------------|-----------------|
+| React@15.4.2 | 94.93 ops/sec   |
+| Rax@0.1.2    | 154 ops/sec(faster)     |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -52,13 +52,6 @@ Benchmark run on a MacBook Pro 2.4GHz Intel Core i5 and 8GB 1600MHz DDR3 with No
 | React@15.4.2 | 94.93 ops/sec   |
 | Rax@0.1.2    | 154 ops/sec(faster) |
 
-Benchmark info:
-
-- Benchmark repository: https://github.com/taobaofed/server-side-rendering-comparison
-- Platform info: MacBook Pro (Late 2013) 2.4GHz Intel Core i5 and 8GB 1600MHz DDR3
-- Node.js v6.9.2 and with `NODE_ENV=production`. `RenderToString` Both require from `lib` not `dist`
-- with about 600 dom nodes
-
 ## Quick Start
 
 Install the Rax CLI tools to init project:

--- a/README.md
+++ b/README.md
@@ -45,12 +45,17 @@ Rax is a universal JavaScript library with a largely React-compatible API. If yo
 
 ## Server-side Rendering Comparison
 
-> [Benchmark repository](https://github.com/taobaofed/server-side-rendering-comparison): Run on a  MacBook Pro (Late 2013) 2.4GHz Intel Core i5 and 8GB 1600MHz DDR3 with Node.js v6.9.2.
-
-|Library\Version|renderToSring   |
+|Library       |renderToSring   |
 |--------------|-----------------|
 | React@15.4.2 | 94.93 ops/sec   |
-| Rax@0.1.2    | 154 ops/sec(faster)     |
+| Rax@0.1.2    | 154 ops/sec(faster) |
+
+Benchmark info:
+
+- Benchmark repository: https://github.com/taobaofed/server-side-rendering-comparison
+- Platform info: MacBook Pro (Late 2013) 2.4GHz Intel Core i5 and 8GB 1600MHz DDR3
+- Node.js v6.9.2 and with `NODE_ENV=production`. `RenderToString` Both require from `lib` not `dist`
+- with about 600 dom nodes
 
 ## Quick Start
 


### PR DESCRIPTION

- Amend ssr code https://github.com/taobaofed/server-side-rendering-comparison/pull/3 https://github.com/taobaofed/server-side-rendering-comparison/pull/4
- Replace opt/s by ms. Because I think `ms` can't transform to `opt/s` in this situation.