### PR TITLE
fix: server renderToString duplicate render in browser

### DIFF
--- a/packages/rax/src/markupChecksum.js
+++ b/packages/rax/src/markupChecksum.js
@@ -1,44 +1,15 @@
-const MOD = 65521;
 const CHECKSUM_ATTR_NAME = 'data-rax-checksum';
 const TAG_END = /\/?>/;
-
-// adler32 is not cryptographically strong, and is only used to sanity check that
-// markup generated on the server matches the markup generated on the client.
-// This implementation (a modified version of the SheetJS version) has been optimized
-// for our use case, at the expense of conforming to the adler32 specification
-// for non-ascii inputs.
-export function adler32(data) {
-  let a = 1;
-  let b = 0;
-  let i = 0;
-  let l = data.length;
-  let m = l & ~0x3;
-  while (i < m) {
-    let n = Math.min(i + 4096, m);
-    for (; i < n; i += 4) {
-      b += (a += data.charCodeAt(i)) + (a += data.charCodeAt(i + 1)) + (a += data.charCodeAt(i + 2)) + (a += data.charCodeAt(i + 3));
-    }
-    a %= MOD;
-    b %= MOD;
-  }
-  for (; i < l; i++) {
-    b += a += data.charCodeAt(i);
-  }
-  a %= MOD;
-  b %= MOD;
-  return a | b << 16;
-}
-
+const CHECKSUM = 'rax-checksum';
 
 /**
   * add checksum to markup
 */
 export function addChecksumToMarkup(markup) {
   markup = markup || '';
-  let checksum = adler32(markup);
 
   // Add checksum (handle both parent tags, comments and self-closing tags)
-  return markup.replace(TAG_END, ' ' + CHECKSUM_ATTR_NAME + '="' + checksum + '"$&');
+  return `<div ${CHECKSUM_ATTR_NAME}="${CHECKSUM}">${markup}</div>`;
 }
 
 /**
@@ -50,4 +21,3 @@ export function canReuseMarkup(element) {
   let existingChecksum = element.getAttribute && element.getAttribute(CHECKSUM_ATTR_NAME);
   return !!existingChecksum;
 }
-

--- a/packages/rax/src/markupChecksum.js
+++ b/packages/rax/src/markupChecksum.js
@@ -1,0 +1,53 @@
+const MOD = 65521;
+const CHECKSUM_ATTR_NAME = 'data-rax-checksum';
+const TAG_END = /\/?>/;
+
+// adler32 is not cryptographically strong, and is only used to sanity check that
+// markup generated on the server matches the markup generated on the client.
+// This implementation (a modified version of the SheetJS version) has been optimized
+// for our use case, at the expense of conforming to the adler32 specification
+// for non-ascii inputs.
+export function adler32(data) {
+  let a = 1;
+  let b = 0;
+  let i = 0;
+  let l = data.length;
+  let m = l & ~0x3;
+  while (i < m) {
+    let n = Math.min(i + 4096, m);
+    for (; i < n; i += 4) {
+      b += (a += data.charCodeAt(i)) + (a += data.charCodeAt(i + 1)) + (a += data.charCodeAt(i + 2)) + (a += data.charCodeAt(i + 3));
+    }
+    a %= MOD;
+    b %= MOD;
+  }
+  for (; i < l; i++) {
+    b += a += data.charCodeAt(i);
+  }
+  a %= MOD;
+  b %= MOD;
+  return a | b << 16;
+}
+
+
+/**
+  * add checksum to markup
+*/
+export function addChecksumToMarkup(markup) {
+  markup = markup || '';
+  let checksum = adler32(markup);
+  
+  // Add checksum (handle both parent tags, comments and self-closing tags)
+  return markup.replace(TAG_END, ' ' + CHECKSUM_ATTR_NAME + '="' + checksum + '"$&');
+}
+
+/**
+  * @param {DOMElement} element root React element
+  * @returns {boolean} whether or not there has checksum
+*/
+
+export function canReuseMarkup(element) {
+  let existingChecksum = element.getAttribute && element.getAttribute(CHECKSUM_ATTR_NAME);
+  return !!existingChecksum;
+}
+

--- a/packages/rax/src/markupChecksum.js
+++ b/packages/rax/src/markupChecksum.js
@@ -36,7 +36,7 @@ export function adler32(data) {
 export function addChecksumToMarkup(markup) {
   markup = markup || '';
   let checksum = adler32(markup);
-  
+
   // Add checksum (handle both parent tags, comments and self-closing tags)
   return markup.replace(TAG_END, ' ' + CHECKSUM_ATTR_NAME + '="' + checksum + '"$&');
 }

--- a/packages/rax/src/server/__tests__/renderToString.js
+++ b/packages/rax/src/server/__tests__/renderToString.js
@@ -25,7 +25,7 @@ describe('Server renderToString', () => {
 
     let foo = <Foo tag="foo" className="bar" />;
     let str = renderToString(foo);
-    expect(str).toBe('<foo data-rax-checksum="369099692"></foo>');
+    expect(str).toBe('<div data-rax-checksum="rax-checksum"><foo></foo></div>');
   });
 
 
@@ -73,7 +73,7 @@ describe('Server renderToString', () => {
 
     let messages = <MessageList messages={['foo', 'bar']} />;
     let str = renderToString(messages);
-    expect(str).toBe('<div data-rax-checksum="1167864591"><div>foo <button style="background:purple;">Delete</button></div><div>bar <button style="background:purple;">Delete</button></div></div>');
+    expect(str).toBe('<div data-rax-checksum="rax-checksum"><div><div>foo <button style="background:purple;">Delete</button></div><div>bar <button style="background:purple;">Delete</button></div></div></div>');
   });
 
   it('renders based on ref', () => {
@@ -93,7 +93,7 @@ describe('Server renderToString', () => {
     }
 
     let str = renderToString(<MyComponent />);
-    expect(str).toBe('<div data-rax-checksum="518852032"><input id="myInput"/><input/></div>');
+    expect(str).toBe('<div data-rax-checksum="rax-checksum"><div><input id="myInput"/><input/></div></div>');
   });
 
   it('renders with lifecycle methods', () => {
@@ -147,6 +147,6 @@ describe('Server renderToString', () => {
     }
 
     let str = renderToString(<MyComponent />);
-    expect(str).toBe('<div data-rax-checksum="-1454634200">componentWillMount</div>');
+    expect(str).toBe('<div data-rax-checksum="rax-checksum"><div>componentWillMount</div></div>');
   });
 });

--- a/packages/rax/src/server/__tests__/renderToString.js
+++ b/packages/rax/src/server/__tests__/renderToString.js
@@ -25,7 +25,7 @@ describe('Server renderToString', () => {
 
     let foo = <Foo tag="foo" className="bar" />;
     let str = renderToString(foo);
-    expect(str).toBe('<foo></foo>');
+    expect(str).toBe('<foo data-rax-checksum="369099692"></foo>');
   });
 
 
@@ -73,7 +73,7 @@ describe('Server renderToString', () => {
 
     let messages = <MessageList messages={['foo', 'bar']} />;
     let str = renderToString(messages);
-    expect(str).toBe('<div><div>foo <button style="background:purple;">Delete</button></div><div>bar <button style="background:purple;">Delete</button></div></div>');
+    expect(str).toBe('<div data-rax-checksum="1167864591"><div>foo <button style="background:purple;">Delete</button></div><div>bar <button style="background:purple;">Delete</button></div></div>');
   });
 
   it('renders based on ref', () => {
@@ -93,7 +93,7 @@ describe('Server renderToString', () => {
     }
 
     let str = renderToString(<MyComponent />);
-    expect(str).toBe('<div><input id="myInput"/><input/></div>');
+    expect(str).toBe('<div data-rax-checksum="518852032"><input id="myInput"/><input/></div>');
   });
 
   it('renders with lifecycle methods', () => {
@@ -147,6 +147,6 @@ describe('Server renderToString', () => {
     }
 
     let str = renderToString(<MyComponent />);
-    expect(str).toBe('<div>componentWillMount</div>');
+    expect(str).toBe('<div data-rax-checksum="-1454634200">componentWillMount</div>');
   });
 });

--- a/packages/rax/src/server/renderToString.js
+++ b/packages/rax/src/server/renderToString.js
@@ -3,6 +3,10 @@ import ServerDriver from '../drivers/server';
 import render from '../render';
 import Serializer from './serializer';
 import {setDriver} from '../driver';
+import {adler32, addChecksumToMarkup} from '../markupChecksum';
+
+const CHECKSUM_ATTR_NAME = 'data-rax-checksum';
+const TAG_END = /\/?>/;
 
 export default function renderToString(element) {
   // Reset driver iternal state
@@ -18,5 +22,6 @@ export default function renderToString(element) {
 
   let body = ServerDriver.createBody();
   render(element, body);
-  return new Serializer(body).serialize();
+  let markup = new Serializer(body).serialize() || '';
+  return addChecksumToMarkup(markup);
 }

--- a/packages/rax/src/server/renderToString.js
+++ b/packages/rax/src/server/renderToString.js
@@ -5,9 +5,6 @@ import Serializer from './serializer';
 import {setDriver} from '../driver';
 import {adler32, addChecksumToMarkup} from '../markupChecksum';
 
-const CHECKSUM_ATTR_NAME = 'data-rax-checksum';
-const TAG_END = /\/?>/;
-
 export default function renderToString(element) {
   // Reset driver iternal state
   ServerDriver.nodeMaps = {};

--- a/packages/rax/src/server/renderToString.js
+++ b/packages/rax/src/server/renderToString.js
@@ -3,7 +3,6 @@ import ServerDriver from '../drivers/server';
 import render from '../render';
 import Serializer from './serializer';
 import {setDriver} from '../driver';
-import {adler32, addChecksumToMarkup} from '../markupChecksum';
 
 export default function renderToString(element) {
   // Reset driver iternal state
@@ -19,6 +18,5 @@ export default function renderToString(element) {
 
   let body = ServerDriver.createBody();
   render(element, body);
-  let markup = new Serializer(body).serialize() || '';
-  return addChecksumToMarkup(markup);
+  return new Serializer(body).serialize();
 }

--- a/packages/rax/src/server/serializer.js
+++ b/packages/rax/src/server/serializer.js
@@ -1,5 +1,6 @@
 import escapeText from './escapeText';
 import styleToCSS from '../style/styleToCSS';
+import {addChecksumToMarkup} from '../markupChecksum';
 
 const ELEMENT_NODE = 1;
 const TEXT_NODE = 3;
@@ -117,7 +118,7 @@ class Serializer {
 
   serialize() {
     this.serializeChildren(this.startNode);
-    return this.html;
+    return addChecksumToMarkup(this.html);
   }
 
   serializeChildren(parentNode) {

--- a/packages/rax/src/vdom/__tests__/context.js
+++ b/packages/rax/src/vdom/__tests__/context.js
@@ -58,7 +58,7 @@ describe('Context', function() {
     }
 
     let html = renderToString(<Parent />);
-    expect(html).toBe('<div>bar</div>');
+    expect(html).toBe('<div data-rax-checksum="615777503">bar</div>');
   });
 
 

--- a/packages/rax/src/vdom/__tests__/context.js
+++ b/packages/rax/src/vdom/__tests__/context.js
@@ -58,7 +58,7 @@ describe('Context', function() {
     }
 
     let html = renderToString(<Parent />);
-    expect(html).toBe('<div data-rax-checksum="615777503">bar</div>');
+    expect(html).toBe('<div data-rax-checksum="rax-checksum"><div>bar</div></div>');
   });
 
 

--- a/packages/rax/src/vdom/__tests__/stateless.js
+++ b/packages/rax/src/vdom/__tests__/stateless.js
@@ -25,7 +25,7 @@ describe('StatelessComponent', function() {
 
   it('should render functional stateless component', function() {
     let html = renderToString(<StatelessComponent name="A" />);
-    expect(html).toBe('<div data-rax-checksum="426181611">A</div>');
+    expect(html).toBe('<div data-rax-checksum="rax-checksum"><div>A</div></div>');
   });
 
   it('should render class stateless component', function() {
@@ -36,7 +36,7 @@ describe('StatelessComponent', function() {
     }
 
     let html = renderToString(<MyComponent name="A" />);
-    expect(html).toBe('<div data-rax-checksum="426181611">A</div>');
+    expect(html).toBe('<div data-rax-checksum="rax-checksum"><div>A</div></div>');
   });
 
   it('should update stateless component', function() {
@@ -47,10 +47,10 @@ describe('StatelessComponent', function() {
     }
 
     let html = renderToString(<Parent name="A" />);
-    expect(html).toBe('<div data-rax-checksum="426181611">A</div>');
+    expect(html).toBe('<div data-rax-checksum="rax-checksum"><div>A</div></div>');
 
     let html2 = renderToString(<Parent name="B" />);
-    expect(html2).toBe('<div data-rax-checksum="426640364">B</div>');
+    expect(html2).toBe('<div data-rax-checksum="rax-checksum"><div>B</div></div>');
   });
 
   it('should pass context thru stateless component', function() {
@@ -84,11 +84,11 @@ describe('StatelessComponent', function() {
 
 
     let html = renderToString(<GrandParent test="test" />);
-    expect(html).toBe('<div data-rax-checksum="733152618">test</div>');
+    expect(html).toBe('<div data-rax-checksum="rax-checksum"><div>test</div></div>');
 
 
     let html2 = renderToString(<GrandParent test="mest" />);
-    expect(html2).toBe('<div data-rax-checksum="728565091">mest</div>');
+    expect(html2).toBe('<div data-rax-checksum="rax-checksum"><div>mest</div></div>');
   });
 
 
@@ -100,7 +100,7 @@ describe('StatelessComponent', function() {
     Child.propTypes = {test: PropTypes.string};
 
     let html = renderToString(<Child />);
-    expect(html).toBe('<div data-rax-checksum="733152618">test</div>');
+    expect(html).toBe('<div data-rax-checksum="rax-checksum"><div>test</div></div>');
   });
 
   it('should receive context', function() {
@@ -125,7 +125,7 @@ describe('StatelessComponent', function() {
     Child.contextTypes = {lang: PropTypes.string};
 
     let html = renderToString(<Parent />);
-    expect(html).toBe('<div data-rax-checksum="529007741">en</div>');
+    expect(html).toBe('<div data-rax-checksum="rax-checksum"><div>en</div></div>');
   });
 
   it('should allow simple functions to return null', function() {
@@ -133,7 +133,7 @@ describe('StatelessComponent', function() {
       return null;
     };
     let html = renderToString(<Child />);
-    expect(html).toBe('<!-- empty -- data-rax-checksum="453444543">');
+    expect(html).toBe('<div data-rax-checksum="rax-checksum"><!-- empty --></div>');
   });
 
   it('should allow simple functions to return false', function() {
@@ -141,6 +141,6 @@ describe('StatelessComponent', function() {
       return false;
     }
     let html = renderToString(<Child />);
-    expect(html).toBe('<!-- empty -- data-rax-checksum="453444543">');
+    expect(html).toBe('<div data-rax-checksum="rax-checksum"><!-- empty --></div>');
   });
 });

--- a/packages/rax/src/vdom/__tests__/stateless.js
+++ b/packages/rax/src/vdom/__tests__/stateless.js
@@ -25,7 +25,7 @@ describe('StatelessComponent', function() {
 
   it('should render functional stateless component', function() {
     let html = renderToString(<StatelessComponent name="A" />);
-    expect(html).toBe('<div>A</div>');
+    expect(html).toBe('<div data-rax-checksum="426181611">A</div>');
   });
 
   it('should render class stateless component', function() {
@@ -36,7 +36,7 @@ describe('StatelessComponent', function() {
     }
 
     let html = renderToString(<MyComponent name="A" />);
-    expect(html).toBe('<div>A</div>');
+    expect(html).toBe('<div data-rax-checksum="426181611">A</div>');
   });
 
   it('should update stateless component', function() {
@@ -47,10 +47,10 @@ describe('StatelessComponent', function() {
     }
 
     let html = renderToString(<Parent name="A" />);
-    expect(html).toBe('<div>A</div>');
+    expect(html).toBe('<div data-rax-checksum="426181611">A</div>');
 
     let html2 = renderToString(<Parent name="B" />);
-    expect(html2).toBe('<div>B</div>');
+    expect(html2).toBe('<div data-rax-checksum="426640364">B</div>');
   });
 
   it('should pass context thru stateless component', function() {
@@ -84,11 +84,11 @@ describe('StatelessComponent', function() {
 
 
     let html = renderToString(<GrandParent test="test" />);
-    expect(html).toBe('<div>test</div>');
+    expect(html).toBe('<div data-rax-checksum="733152618">test</div>');
 
 
     let html2 = renderToString(<GrandParent test="mest" />);
-    expect(html2).toBe('<div>mest</div>');
+    expect(html2).toBe('<div data-rax-checksum="728565091">mest</div>');
   });
 
 
@@ -100,7 +100,7 @@ describe('StatelessComponent', function() {
     Child.propTypes = {test: PropTypes.string};
 
     let html = renderToString(<Child />);
-    expect(html).toBe('<div>test</div>');
+    expect(html).toBe('<div data-rax-checksum="733152618">test</div>');
   });
 
   it('should receive context', function() {
@@ -125,7 +125,7 @@ describe('StatelessComponent', function() {
     Child.contextTypes = {lang: PropTypes.string};
 
     let html = renderToString(<Parent />);
-    expect(html).toBe('<div>en</div>');
+    expect(html).toBe('<div data-rax-checksum="529007741">en</div>');
   });
 
   it('should allow simple functions to return null', function() {
@@ -133,7 +133,7 @@ describe('StatelessComponent', function() {
       return null;
     };
     let html = renderToString(<Child />);
-    expect(html).toBe('<!-- empty -->');
+    expect(html).toBe('<!-- empty -- data-rax-checksum="453444543">');
   });
 
   it('should allow simple functions to return false', function() {
@@ -141,6 +141,6 @@ describe('StatelessComponent', function() {
       return false;
     }
     let html = renderToString(<Child />);
-    expect(html).toBe('<!-- empty -->');
+    expect(html).toBe('<!-- empty -- data-rax-checksum="453444543">');
   });
 });

--- a/packages/rax/src/vdom/instance.js
+++ b/packages/rax/src/vdom/instance.js
@@ -5,6 +5,21 @@ import instantiateComponent from './instantiateComponent';
 import shouldUpdateComponent from './shouldUpdateComponent';
 import Root from './root';
 import Hook from '../debug/hook';
+import {isWeb} from 'universal-env';
+import {canReuseMarkup} from '../markupChecksum';
+
+/**
+ * @param {DOMElement} container DOM element that may contain
+ * a component
+ * @return {?*} DOM element or null.
+ */
+function getRootElementInContainer(container) {
+  if (!container) {
+    return null;
+  }
+
+  return container.firstChild;
+}
 
 /**
  * Instance manager
@@ -55,6 +70,15 @@ export default {
       } else {
         Hook.Reconciler.unmountComponent(prevRootInstance);
         unmountComponentAtNode(container);
+      }
+    }
+
+    if (isWeb) {
+      let rootElement = getRootElementInContainer(container);
+      let containerHasMarkup = rootElement && canReuseMarkup(rootElement);
+      let shouldReuseMarkup = containerHasMarkup && !hasPrevRootInstance;
+      if (shouldReuseMarkup) {
+        Host.driver.removeChild(rootElement, container);
       }
     }
 


### PR DESCRIPTION
* add checksum to the output of renderToString method, check the checksum on browser to avoid duplicating render. 
* checksum algorithm use [adler32 checksum algorithom](https://en.wikipedia.org/wiki/Adler-32)
* update the test for renderToString method