### PR TITLE
chore: Fix link in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,4 +12,4 @@
 * [Differences with React](./difference-with-react.md)
 
 ## Advanced Guides
-* [Rax Driver Specification](./driver-spec)
+* [Rax Driver Specification](./driver-spec.md)


### PR DESCRIPTION
Add `.md` to the link.