### PR TITLE
fix: source-map should in comment block

### DIFF
--- a/packages/rax-cli/src/generator/templates/webpack.config.js
+++ b/packages/rax-cli/src/generator/templates/webpack.config.js
@@ -65,7 +65,7 @@ module.exports = {
   // Compile target should "web" when use hot reload
   target: isProducation ? 'node' : 'web',
 
-  devtool: 'cheap-module-source-map',
+  devtool: '@cheap-module-source-map',
   // These are the "entry points" to our application.
   // This means they will be the "root" imports that are included in JS bundle.
   // The first two entry points enable "hot" CSS and auto-refreshes for JS.


### PR DESCRIPTION
Fixed https://github.com/alibaba/rax/issues/114

Prefixing `@` style

```js
/*
//@ sourceMappingURL=[url]
*/
```