### PR TITLE
More friendly stylesheet loader

### DIFF
--- a/packages/stylesheet-loader/src/BoxModelPropTypes.js
+++ b/packages/stylesheet-loader/src/BoxModelPropTypes.js
@@ -30,6 +30,7 @@ const BoxModelPropTypes = {
   borderTopRightRadius: PropTypes.length,
   overflow: PropTypes.oneOf(['hidden', 'visible']),
   position: PropTypes.oneOf(['relative', 'absolute', 'sticky', 'fixed']),
+  display: PropTypes.oneOf(['block', 'flex', 'inline-flex', 'inline-block', 'inline']),
   top: PropTypes.length,
   bottom: PropTypes.length,
   left: PropTypes.length,

--- a/packages/stylesheet-loader/src/FlexboxPropTypes.js
+++ b/packages/stylesheet-loader/src/FlexboxPropTypes.js
@@ -8,7 +8,8 @@ const FlexboxPropTypes = {
   justifyContent: PropTypes.oneOf(['flex-start', 'flex-end', 'center', 'space-between', 'space-around']),
   alignItems: PropTypes.oneOf(['flex-start', 'flex-end', 'center', 'stretch']),
   alignContent: PropTypes.oneOf(['stretch', 'flex-start', 'flex-end', 'center', 'space-between', 'space-around']),
-  alignSelf: PropTypes.oneOf(['auto', 'flex-start', 'flex-end', 'center', 'stretch'])
+  alignSelf: PropTypes.oneOf(['auto', 'flex-start', 'flex-end', 'center', 'stretch']),
+  flex: PropTypes.integer
 };
 
 export default FlexboxPropTypes;

--- a/packages/stylesheet-loader/src/PropTypes.js
+++ b/packages/stylesheet-loader/src/PropTypes.js
@@ -12,55 +12,59 @@ let PropTypes = {
   color: createColorChecker
 };
 
-function createLengthChecker(value = '', prop) {
+function createLengthChecker(value = '', prop, selectors) {
   value = value.toString();
 
   if (!value.match(LENGTH_REGEXP)) {
-    return new Error(`\`${value}\` is not a valid value for property \`${prop}\` (e.g. "16、16rem、16px")`);
+    return new Error(getMessage(prop, value, selectors, '16、16rem、16px'));
   }
   return null;
 }
 
-function createNumberChecker(value = '', prop) {
+function createNumberChecker(value = '', prop, selectors) {
   value = value.toString();
   let match = value.match(LENGTH_REGEXP);
 
   if (!match || match[1]) {
-    return new Error(`\`${value}\` is not a valid value for property \`${prop}\` (e.g. "16、24、5.2")`);
+    return new Error(getMessage(prop, value, selectors, '16、24、5.2'));
   }
   return null;
 }
 
-function createIntegerChecker(value = '', prop) {
+function createIntegerChecker(value = '', prop, selectors) {
   value = value.toString();
 
   if (!value.match(INTEGER_REGEXP)) {
-    return new Error(`\`${value}\` is not a valid value for property \`${prop}\` (e.g. "16、24、12")`);
+    return new Error(getMessage(prop, value, selectors, '16、24、12'));
   }
   return null;
 }
 
 function createEnumChecker(list) {
-  return function validate(value, prop) {
+  return function validate(value, prop, selectors) {
     let index = list.indexOf(value);
 
     if (index < 0) {
-      return new Error(`\`${value}\` is not a valid value for property \`${prop}\` (e.g. "${list.join('、')}")`);
+      return new Error(getMessage(prop, value, selectors, `${list.join('、')}`));
     }
 
     return null;
   };
 }
 
-function createColorChecker(value, prop) {
+function createColorChecker(value, prop, selectors) {
   if (typeof value === 'number') {
     return;
   }
 
   if (normalizeColor(value) === null) {
-    return new Error(`\`${value}\` is not a valid value for property \`${prop}\` (e.g. "#333、#fefefe、rgb(255, 0, 0)")`);
+    return new Error(getMessage(prop, value, selectors, '#333、#fefefe、rgb(255, 0, 0)'));
   }
   return null;
 };
+
+function getMessage(prop, value, selectors, link) {
+  return `"${prop}: ${value}" is not valid value in "${selectors}" selector (e.g. "${link}")`;
+}
 
 export default PropTypes;

--- a/packages/stylesheet-loader/src/Validation.js
+++ b/packages/stylesheet-loader/src/Validation.js
@@ -9,18 +9,19 @@ import particular from './particular';
 import chalk from 'chalk';
 
 class Validation {
-  static validate(prop, value) {
-    if (allStylePropTypes[prop]) {
-      let error = allStylePropTypes[prop](value, prop);
+  static validate(camelCaseProperty, prop, value, selectors = '', position = {}) {
+    if (allStylePropTypes[camelCaseProperty]) {
+      let error = allStylePropTypes[camelCaseProperty](value, prop, selectors);
 
       if (error) {
-        console.warn(chalk.yellow.bold(error.message));
-        pushWarnMessage(error.message);
+        const message = `line: ${position.start.line}, column: ${position.start.column} - ${error.message}`;
+        console.warn(chalk.yellow.bold(message));
+        pushWarnMessage(message);
       }
       return error;
     } else {
-      if (!particular[prop]) {
-        const message = `\`${prop}\` is not a valid property in the flexbox specification (https://facebook.github.io/yoga/)`;
+      if (!particular[camelCaseProperty]) {
+        const message = `line: ${position.start.line}, column: ${position.start.column} - "${prop}: ${value}" is not valid in "${selectors}" selector`;
         console.warn(chalk.yellow.bold(message));
         pushWarnMessage(message);
       }

--- a/packages/stylesheet-loader/src/__tests__/particular.js
+++ b/packages/stylesheet-loader/src/__tests__/particular.js
@@ -80,16 +80,6 @@ describe('particular', () => {
     expect(result).toEqual({});
   });
 
-  it('should add prefix with some property', () => {
-    testPrefix('boxShadow');
-    testPrefix('borderRadius', true);
-    testPrefix('userSelect');
-    testPrefix('flex');
-    testPrefix('justifyContent');
-    testPrefix('transition');
-    testPrefix('transform');
-  });
-
   it('should transform lineHeight to string with rem', () => {
     const result = particular.lineHeight(16);
 

--- a/packages/stylesheet-loader/src/particular.js
+++ b/packages/stylesheet-loader/src/particular.js
@@ -88,27 +88,6 @@ export default {
   margin: (value) => {
     return measure(value, 'margin');
   },
-  boxShadow: (value) => {
-    return prefix(value, 'boxShadow');
-  },
-  borderRadius: (value) => {
-    return prefix(value, 'borderRadius');
-  },
-  userSelect: (value) => {
-    return prefix(value, 'userSelect');
-  },
-  flex: (value) => {
-    return prefix(value, 'flex');
-  },
-  justifyContent: (value) => {
-    return prefix(value, 'justifyContent');
-  },
-  transition: (value) => {
-    return prefix(value, 'transition');
-  },
-  transform: (value) => {
-    return prefix(value, 'transform');
-  },
   lineHeight: (value) => {
     if (typeof value === 'number') {
       value += 'rem';

--- a/packages/stylesheet-loader/src/transformer.js
+++ b/packages/stylesheet-loader/src/transformer.js
@@ -20,10 +20,10 @@ const COLOR_PROPERTIES = {
 };
 
 export default {
-  sanitizeSelector(selector, transformDescendantCombinator) {
+  sanitizeSelector(selector, transformDescendantCombinator = false, position = { start: {line: 0, column: 0} }) {
     // filter multiple extend selectors
     if (!transformDescendantCombinator && !/^\.[a-zA-Z0-9_:]+$/.test(selector)) {
-      const message = `\`${selector}\` is not a valid selector (valid e.g. ".abc、.abcBcd、.abc_bcd")`;
+      const message = `line: ${position.start.line}, column: ${position.start.column} - "${selector}" is not a valid selector (e.g. ".abc、.abcBcd、.abc_bcd")`;
       console.error(chalk.red.bold(message));
       pushErrorMessage(message);
       return null;
@@ -75,7 +75,7 @@ export default {
       let value = this.convertValue(camelCaseProperty, declaration.value);
       style[camelCaseProperty] = value;
 
-      Validation.validate(camelCaseProperty, declaration.value);
+      Validation.validate(camelCaseProperty, declaration.property, declaration.value, rule.selectors.join(', '), declaration.position);
       if (particular[camelCaseProperty]) {
         let particularResult = particular[camelCaseProperty](value);
         if (particularResult.isDeleted) {


### PR DESCRIPTION
* add position information
* remove vendor prefix
* not output `console` when no error or warn messages
* propType list add `display` and `flex`
* more field information 

```sh
line: 12, column: 3 - "z-index: 2" is not valid in ".item" selector
```