### PR TITLE
fix: fix sourcemap logic of multi config

### DIFF
--- a/packages/rax-webpack-plugin/package.json
+++ b/packages/rax-webpack-plugin/package.json
@@ -22,6 +22,7 @@
     "babylon": "^6.14.1",
     "loader-utils": "^0.2.16",
     "lodash.clonedeep": "^4.5.0",
+    "source-map": "^0.5.6",
     "webpack-sources": "^0.1.4"
   }
 }

--- a/packages/rax-webpack-plugin/src/PlatformLoader.js
+++ b/packages/rax-webpack-plugin/src/PlatformLoader.js
@@ -1,5 +1,7 @@
+import path from 'path';
 import loaderUtils from 'loader-utils';
 import traverseImport from './TraverseImport';
+import sourceMap from 'source-map';
 
 /**
  * remove universal-env module dependencies
@@ -19,15 +21,67 @@ import traverseImport from './TraverseImport';
  * const isWeb = false
  * ```
  */
+
+function mergeSourceMap(map, inputMap) {
+
+  if (inputMap) {
+    const inputMapConsumer   = new sourceMap.SourceMapConsumer(inputMap);
+    const outputMapConsumer  = new sourceMap.SourceMapConsumer(map);
+
+    const mergedGenerator = new sourceMap.SourceMapGenerator({
+      file: inputMapConsumer.file,
+      sourceRoot: inputMapConsumer.sourceRoot
+    });
+
+    // This assumes the output map always has a single source, since Babel always compiles a
+    // single source file to a single output file.
+    const source = outputMapConsumer.sources[0];
+
+    inputMapConsumer.eachMapping(function (mapping) {
+      const generatedPosition = outputMapConsumer.generatedPositionFor({
+        line: mapping.generatedLine,
+        column: mapping.generatedColumn,
+        source: source
+      });
+      if (generatedPosition.column != null) {
+        mergedGenerator.addMapping({
+          source: mapping.source,
+
+          original: mapping.source == null ? null : {
+            line: mapping.originalLine,
+            column: mapping.originalColumn
+          },
+
+          generated: generatedPosition
+        });
+      }
+    });
+
+    const mergedMap = mergedGenerator.toJSON();
+    inputMap.mappings = mergedMap.mappings;
+    return inputMap;
+  } else {
+    return map;
+  }
+}
+
 module.exports = function(inputSource, inputSourceMap) {
   this.cacheable();
   const callback = this.async();
-
   const loaderOptions = loaderUtils.parseQuery(this.query);
+  const resourcePath = this.resourcePath;
+  const projectDir = process.cwd();
+
+  let sourceMapOption = {
+    sourceMapTarget: path.basename(resourcePath),
+    soueceFileName: path.relative(projectDir, resourcePath);
+    sourceMap: true,
+    sourceRoot: projectDir
+  }
 
   const options = Object.assign({ name: 'universal-env' }, loaderOptions);
 
-  const { code } = traverseImport(options, inputSource);
+  const { code, map } = traverseImport(options, inputSource, sourceMapOption);
 
-  callback(null, code, inputSourceMap);
+  callback(null, code, mergeSourceMap(map, inputSourceMap));
 };

--- a/packages/rax-webpack-plugin/src/PlatformLoader.js
+++ b/packages/rax-webpack-plugin/src/PlatformLoader.js
@@ -23,10 +23,9 @@ import sourceMap from 'source-map';
  */
 
 function mergeSourceMap(map, inputMap) {
-
   if (inputMap) {
-    const inputMapConsumer   = new sourceMap.SourceMapConsumer(inputMap);
-    const outputMapConsumer  = new sourceMap.SourceMapConsumer(map);
+    const inputMapConsumer = new sourceMap.SourceMapConsumer(inputMap);
+    const outputMapConsumer = new sourceMap.SourceMapConsumer(map);
 
     const mergedGenerator = new sourceMap.SourceMapGenerator({
       file: inputMapConsumer.file,
@@ -37,7 +36,7 @@ function mergeSourceMap(map, inputMap) {
     // single source file to a single output file.
     const source = outputMapConsumer.sources[0];
 
-    inputMapConsumer.eachMapping(function (mapping) {
+    inputMapConsumer.eachMapping(function(mapping) {
       const generatedPosition = outputMapConsumer.generatedPositionFor({
         line: mapping.generatedLine,
         column: mapping.generatedColumn,
@@ -74,10 +73,10 @@ module.exports = function(inputSource, inputSourceMap) {
 
   let sourceMapOption = {
     sourceMapTarget: path.basename(resourcePath),
-    soueceFileName: path.relative(projectDir, resourcePath);
+    soueceFileName: path.relative(projectDir, resourcePath),
     sourceMap: true,
     sourceRoot: projectDir
-  }
+  };
 
   const options = Object.assign({ name: 'universal-env' }, loaderOptions);
 

--- a/packages/rax-webpack-plugin/src/TraverseImport.js
+++ b/packages/rax-webpack-plugin/src/TraverseImport.js
@@ -5,7 +5,7 @@ import generate from 'babel-generator';
 
 /* eslint-disable new-cap */
 
-export default function traverseImport(options, inputSource) {
+export default function traverseImport(options, inputSource, sourceMapOption) {
   let specified; // Collector import specifiers
   let hasPlatformSpecified = false;
 
@@ -111,5 +111,5 @@ export default function traverseImport(options, inputSource) {
     }
   });
 
-  return generate(ast, null, inputSource);
+  return generate(ast, sourceMapOption, inputSource);
 };

--- a/packages/rax-webpack-plugin/src/__tests__/TraverseImport.import.js
+++ b/packages/rax-webpack-plugin/src/__tests__/TraverseImport.import.js
@@ -25,23 +25,23 @@ describe('PlatformLoader.traverseImport', function() {
     expect(code).toBe('const isWeex = true;');
   });
 
-  it('sourcemap', function(){
+  it('sourcemap', function() {
     const { map, code } = traverseImport(
       { name: 'universal-env', platform: 'weex' },
       'import { isWeex } from "universal-env";\n let a = 1;',
       { sourceMaps: true,
-        filename: "inline",
-      sourceFileName: "inline"}
+        filename: 'inline',
+        sourceFileName: 'inline'}
     );
     let sourceMapObj = {
-      "version":3, 
-      "sources":["inline"],
-      "names":["a"],
-      "mappings":";;AACC,IAAIA,IAAI,CAAR",
-      "sourcesContent":["import { isWeex } from \"universal-env\";\n let a = 1;"]
+      'version': 3,
+      'sources': ['inline'],
+      'names': ['a'],
+      'mappings': ';;AACC,IAAIA,IAAI,CAAR',
+      'sourcesContent': ['import { isWeex } from "universal-env";\n let a = 1;']
     };
     expect(map).toMatchObject(sourceMapObj);
-  })
+  });
 
   it('isWeex as iw', function() {
     const { code } = traverseImport(

--- a/packages/rax-webpack-plugin/src/__tests__/TraverseImport.import.js
+++ b/packages/rax-webpack-plugin/src/__tests__/TraverseImport.import.js
@@ -25,6 +25,24 @@ describe('PlatformLoader.traverseImport', function() {
     expect(code).toBe('const isWeex = true;');
   });
 
+  it('sourcemap', function(){
+    const { map, code } = traverseImport(
+      { name: 'universal-env', platform: 'weex' },
+      'import { isWeex } from "universal-env";\n let a = 1;',
+      { sourceMaps: true,
+        filename: "inline",
+      sourceFileName: "inline"}
+    );
+    let sourceMapObj = {
+      "version":3, 
+      "sources":["inline"],
+      "names":["a"],
+      "mappings":";;AACC,IAAIA,IAAI,CAAR",
+      "sourcesContent":["import { isWeex } from \"universal-env\";\n let a = 1;"]
+    };
+    expect(map).toMatchObject(sourceMapObj);
+  })
+
   it('isWeex as iw', function() {
     const { code } = traverseImport(
       { name: 'universal-env', platform: 'weex' },


### PR DESCRIPTION
1. The `PlatformLoader` ought to return code and sourcemap that the  `TraverseImport` produce.
2. The sourcemap should merge the `inputSourceMap` that previous loader produce