### PR TITLE
Change camelcase version

### DIFF
--- a/packages/babel-plugin-transform-jsx-stylesheet/package.json
+++ b/packages/babel-plugin-transform-jsx-stylesheet/package.json
@@ -20,6 +20,6 @@
     "babel-plugin-syntax-jsx": "^6.18.0"
   },
   "dependencies": {
-    "camelcase": "^4.0.0"
+    "camelcase": "^3.0.0"
   }
 }


### PR DESCRIPTION
camelcase 4.0.0 没有编译，在 playground 中不能使用