### PR TITLE
feat: add custom mainTemplate prefix & suffix; add multiplatform chun…

### DIFF
--- a/packages/rax-webpack-plugin/src/MultiplePlatform.js
+++ b/packages/rax-webpack-plugin/src/MultiplePlatform.js
@@ -71,8 +71,8 @@ module.exports = function MultiplePlatform(config, options = {}) {
       platformConfig.entry = platformEntry;
 
       // support chunkFilename config according to platformType
-      if (typeof options.chunkFilenameFn === 'function') {
-        platformConfig.output.chunkFilename = options.chunkFilenameFn(platformType);
+      if (typeof options.chunkFilename === 'function') {
+        platformConfig.output.chunkFilename = options.chunkFilename(platformType);
       }
 
       if (Array.isArray(options.name)) {

--- a/packages/rax-webpack-plugin/src/MultiplePlatform.js
+++ b/packages/rax-webpack-plugin/src/MultiplePlatform.js
@@ -71,9 +71,8 @@ module.exports = function MultiplePlatform(config, options = {}) {
       platformConfig.entry = platformEntry;
 
       // support chunkFilename config according to platformType
-      if(typeof options.chunkFilenameFn === 'function') {
-          platformConfig.output.chunkFilename = options.chunkFilenameFn(platformType);
-        }
+      if (typeof options.chunkFilenameFn === 'function') {
+        platformConfig.output.chunkFilename = options.chunkFilenameFn(platformType);
       }
 
       if (Array.isArray(options.name)) {

--- a/packages/rax-webpack-plugin/src/MultiplePlatform.js
+++ b/packages/rax-webpack-plugin/src/MultiplePlatform.js
@@ -70,6 +70,12 @@ module.exports = function MultiplePlatform(config, options = {}) {
 
       platformConfig.entry = platformEntry;
 
+      // support chunkFilename config according to platformType
+      if(typeof options.chunkFilenameFn === 'function') {
+          platformConfig.output.chunkFilename = options.chunkFilenameFn(platformType);
+        }
+      }
+
       if (Array.isArray(options.name)) {
         options.name.map(name => {
           nameQuery += '&name[]=' + name;

--- a/packages/rax-webpack-plugin/src/RaxMainTemplatePlugin.js
+++ b/packages/rax-webpack-plugin/src/RaxMainTemplatePlugin.js
@@ -35,8 +35,8 @@ export default class CustomUmdMainTemplatePlugin {
 
       if (typeof this.options.sourcePrefixFn === 'function' &&
          typeof this.options.sourceSuffixFn === 'function') {
-        sourcePrefix = this.options.sourcePrefixFn(source, chunk, hash);
-        sourceSuffix = this.options.sourceSuffixFn(source, chunk, hash);
+        sourcePrefix = this.options.sourcePrefix(source, chunk, hash);
+        sourceSuffix = this.options.sourceSuffix(source, chunk, hash);
       } else {
         // module, function is private, only use in rax internal
         if (chunk.name.endsWith('.module') || target === 'module') {

--- a/packages/rax-webpack-plugin/src/RaxMainTemplatePlugin.js
+++ b/packages/rax-webpack-plugin/src/RaxMainTemplatePlugin.js
@@ -33,8 +33,8 @@ export default class CustomUmdMainTemplatePlugin {
       let sourcePrefix = '';
       let sourceSuffix = '';
 
-      if (typeof this.options.sourcePrefixFn === 'function' &&
-         typeof this.options.sourceSuffixFn === 'function') {
+      if (typeof this.options.sourcePrefix === 'function' &&
+         typeof this.options.sourceSuffix === 'function') {
         sourcePrefix = this.options.sourcePrefix(source, chunk, hash);
         sourceSuffix = this.options.sourceSuffix(source, chunk, hash);
       } else {

--- a/packages/rax-webpack-plugin/src/RaxMainTemplatePlugin.js
+++ b/packages/rax-webpack-plugin/src/RaxMainTemplatePlugin.js
@@ -33,11 +33,11 @@ export default class CustomUmdMainTemplatePlugin {
       let sourcePrefix = '';
       let sourceSuffix = '';
 
-      if(typeof options.sourcePrefixFn === 'function' && 
-         typeof options.sourceSuffixFn === 'function') {
-        sourcePrefix = options.sourcePrefixFn(source, chunk, hash);
-        sourceSuffix = options.sourceSuffixFn(source, chunk, hash);
-      }else {
+      if (typeof this.options.sourcePrefixFn === 'function' &&
+         typeof this.options.sourceSuffixFn === 'function') {
+        sourcePrefix = this.options.sourcePrefixFn(source, chunk, hash);
+        sourceSuffix = this.options.sourceSuffixFn(source, chunk, hash);
+      } else {
         // module, function is private, only use in rax internal
         if (chunk.name.endsWith('.module') || target === 'module') {
           sourcePrefix = 'module.exports = ';
@@ -102,7 +102,6 @@ export default class CustomUmdMainTemplatePlugin {
           sourceSuffix = '});';
         }
       }
-
 
 
       return new ConcatSource(

--- a/packages/rax-webpack-plugin/src/RaxMainTemplatePlugin.js
+++ b/packages/rax-webpack-plugin/src/RaxMainTemplatePlugin.js
@@ -33,69 +33,77 @@ export default class CustomUmdMainTemplatePlugin {
       let sourcePrefix = '';
       let sourceSuffix = '';
 
-      // module, function is private, only use in rax internal
-      if (chunk.name.endsWith('.module') || target === 'module') {
-        sourcePrefix = 'module.exports = ';
-        sourceSuffix = '';
-      } else if (chunk.name.endsWith('.function') || target === 'function') {
-        sourcePrefix = `
-module.exports = function() {
-  return `;
-        sourceSuffix = '};';
-      } else if (chunk.name.endsWith('.bundle') || target === 'bundle') {
-        // Build page bundle use this mode.
-        if (this.options.bundle === 'compatible') {
-          sourcePrefix = `define("${chunk.name}", function(require) {`;
-          sourceSuffix = `}); require("${chunk.name}");`;
-        } else {
-          sourcePrefix = '';
+      if(typeof options.sourcePrefixFn === 'function' && 
+         typeof options.sourceSuffixFn === 'function') {
+        sourcePrefix = options.sourcePrefixFn(source, chunk, hash);
+        sourceSuffix = options.sourceSuffixFn(source, chunk, hash);
+      }else {
+        // module, function is private, only use in rax internal
+        if (chunk.name.endsWith('.module') || target === 'module') {
+          sourcePrefix = 'module.exports = ';
           sourceSuffix = '';
-        }
-      } else if (chunk.name.endsWith('.factory') || target === 'factory') {
-        // Build weex builtin modules use this mode.
-        // NOTE: globals should sync logic in weex-rax-framework
-        if (this.options.factoryGlobals) {
-          var globalsCodes = this.options.factoryGlobals.map(function(name) {
-            return `var ${name} = this["${name}"];`;
-          });
-          sourcePrefix = `module.exports = function(require, exports, module) {
-  ${globalsCodes.join('\n')}
-  module.exports = `;
+        } else if (chunk.name.endsWith('.function') || target === 'function') {
+          sourcePrefix = `
+  module.exports = function() {
+    return `;
           sourceSuffix = '};';
-        } else {
-          sourcePrefix = `module.exports = function(require, exports, module) {
-  with(this) { module.exports = `;
-          sourceSuffix = '}};';
-        }
-      } else if (chunk.name.endsWith('.umd') || target === 'umd') {
-        // CommonJS first that could rename module name by wrap another define in air
-        sourcePrefix = `
-;(function(fn) {
-  if (typeof exports === "object" && typeof module !== "undefined") {
-    module.exports = fn();
-  } else if (typeof define === "function") {
-    define(${JSON.stringify(moduleName)}, function(require, exports, module){
+        } else if (chunk.name.endsWith('.bundle') || target === 'bundle') {
+          // Build page bundle use this mode.
+          if (this.options.bundle === 'compatible') {
+            sourcePrefix = `define("${chunk.name}", function(require) {`;
+            sourceSuffix = `}); require("${chunk.name}");`;
+          } else {
+            sourcePrefix = '';
+            sourceSuffix = '';
+          }
+        } else if (chunk.name.endsWith('.factory') || target === 'factory') {
+          // Build weex builtin modules use this mode.
+          // NOTE: globals should sync logic in weex-rax-framework
+          if (this.options.factoryGlobals) {
+            var globalsCodes = this.options.factoryGlobals.map(function(name) {
+              return `var ${name} = this["${name}"];`;
+            });
+            sourcePrefix = `module.exports = function(require, exports, module) {
+    ${globalsCodes.join('\n')}
+    module.exports = `;
+            sourceSuffix = '};';
+          } else {
+            sourcePrefix = `module.exports = function(require, exports, module) {
+    with(this) { module.exports = `;
+            sourceSuffix = '}};';
+          }
+        } else if (chunk.name.endsWith('.umd') || target === 'umd') {
+          // CommonJS first that could rename module name by wrap another define in air
+          sourcePrefix = `
+  ;(function(fn) {
+    if (typeof exports === "object" && typeof module !== "undefined") {
       module.exports = fn();
-    });
-  } else {
-    var root;
-    if (typeof window !== "undefined") {
-      root = window;
-    } else if (typeof self !== "undefined") {
-      root = self;
-    } else if (typeof global !== "undefined") {
-      root = global;
+    } else if (typeof define === "function") {
+      define(${JSON.stringify(moduleName)}, function(require, exports, module){
+        module.exports = fn();
+      });
     } else {
-      // NOTICE: In JavaScript strict mode, this is null
-      root = this;
-    }
-    root["${globalName}"] = fn();
-  }
-})(function(){
-  return `;
-
-        sourceSuffix = '});';
+      var root;
+      if (typeof window !== "undefined") {
+        root = window;
+      } else if (typeof self !== "undefined") {
+        root = self;
+      } else if (typeof global !== "undefined") {
+        root = global;
+      } else {
+        // NOTICE: In JavaScript strict mode, this is null
+        root = this;
       }
+      root["${globalName}"] = fn();
+    }
+  })(function(){
+    return `;
+
+          sourceSuffix = '});';
+        }
+      }
+
+
 
       return new ConcatSource(
         polyfills.join('\n'),

--- a/packages/rax-webpack-plugin/src/__tests__/MultiplePlatform.js
+++ b/packages/rax-webpack-plugin/src/__tests__/MultiplePlatform.js
@@ -64,7 +64,7 @@ describe('MultiplePlatform', function() {
     expect(MultiplePlatform(config)).toEqual(expected);
   });
 
-  it('config `chunkFilenameFn` field', function() {
+  it('config `chunkFilename` field', function() {
     const config = {
       platforms: ['weex'],
       entry: {
@@ -121,7 +121,7 @@ describe('MultiplePlatform', function() {
       }
     }];
     expect(MultiplePlatform(config, {
-      chunkFilenameFn: function(platformType) {
+      chunkFilename: function(platformType) {
         return '[name].' + platformType + '.js';
       }
     })).toEqual(expected);

--- a/packages/rax-webpack-plugin/src/__tests__/MultiplePlatform.js
+++ b/packages/rax-webpack-plugin/src/__tests__/MultiplePlatform.js
@@ -64,6 +64,69 @@ describe('MultiplePlatform', function() {
     expect(MultiplePlatform(config)).toEqual(expected);
   });
 
+  it('config `chunkFilenameFn` field', function() {
+    const config = {
+      platforms: ['weex'],
+      entry: {
+        'hello.bundle': './index.js'
+      },
+      module: {
+        loaders: [{
+          test: /\.jsx?$/,
+          loader: 'babel'
+        }]
+      },
+      output: {
+        chunkFilename: '[name].js',
+      }
+    };
+
+    const expected = [{
+      'entry': {
+        'hello.bundle': './index.js'
+      },
+      'module': {
+        'loaders': [{
+          'test': /\.jsx?$/,
+          'loader': 'babel'
+        }]
+      },
+      'platforms': [
+        'weex'
+      ],
+      output: {
+        chunkFilename: '[name].js',
+      }
+    }, {
+      'entry': {
+        'hello.bundle.weex': './index.js'
+      },
+      'module': {
+        'loaders': [{
+          'test': /\.jsx?$/,
+          'loader': 'babel'
+        }],
+        'preLoaders': [{
+          'test': /\.jsx?$/,
+          'exclude': /(node_modules|bower_components)/,
+          'loader': `${path.resolve(__dirname, '../PlatformLoader.js')}?platform=weex`
+
+        }]
+      },
+      'platforms': [
+        'weex'
+      ],
+      output: {
+        chunkFilename: '[name].weex.js',
+      }
+    }];
+    expect(MultiplePlatform(config, {
+      chunkFilenameFn: function(platformType) {
+        return '[name].' + platformType + '.js';
+      }
+    })).toEqual(expected);
+  });
+
   it('specified platform is `weex` pass options', function() {
     const config = {
       entry: {

--- a/packages/rax-webpack-plugin/src/__tests__/fixtures/custom/expected/index.bundle.js
+++ b/packages/rax-webpack-plugin/src/__tests__/fixtures/custom/expected/index.bundle.js
@@ -1,6 +1,5 @@
-module.exports = function(require, exports, module) {
-    var weex = this["weex"];
-    module.exports = /******/ (function(modules) { // webpackBootstrap
+// {"framework" : "Rax"}
+define("index.bundle", function(require) {/******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
 /******/
@@ -75,4 +74,4 @@ module.exports = function(require, exports, module) {
 console.log('it work!');
 
 /***/ })
-/******/ ])};;
+/******/ ])});

--- a/packages/rax-webpack-plugin/src/__tests__/fixtures/custom/index.js
+++ b/packages/rax-webpack-plugin/src/__tests__/fixtures/custom/index.js
@@ -1,0 +1,1 @@
+console.log('it work!');

--- a/packages/rax-webpack-plugin/src/__tests__/fixtures/custom/webpack.config.js
+++ b/packages/rax-webpack-plugin/src/__tests__/fixtures/custom/webpack.config.js
@@ -7,11 +7,11 @@ module.exports = {
   plugins: [
     new RaxWebpackPlugin({
       target: 'bundle',
-      sourcePrefixFn: function(source, chunk, hash){
+      sourcePrefixFn: function(source, chunk, hash) {
         return 'define("' + chunk.name + '", function(require) {';
       },
-      sourceSuffixFn: function(source, chunk, hash){
-        return '})'
+      sourceSuffixFn: function(source, chunk, hash) {
+        return '})';
       }
     })
   ]

--- a/packages/rax-webpack-plugin/src/__tests__/fixtures/custom/webpack.config.js
+++ b/packages/rax-webpack-plugin/src/__tests__/fixtures/custom/webpack.config.js
@@ -7,10 +7,10 @@ module.exports = {
   plugins: [
     new RaxWebpackPlugin({
       target: 'bundle',
-      sourcePrefixFn: function(source, chunk, hash) {
+      sourcePrefix: function(source, chunk, hash) {
         return 'define("' + chunk.name + '", function(require) {';
       },
-      sourceSuffixFn: function(source, chunk, hash) {
+      sourceSuffix: function(source, chunk, hash) {
         return '})';
       }
     })

--- a/packages/rax-webpack-plugin/src/__tests__/fixtures/custom/webpack.config.js
+++ b/packages/rax-webpack-plugin/src/__tests__/fixtures/custom/webpack.config.js
@@ -1,0 +1,18 @@
+import RaxWebpackPlugin from '../../../index';
+
+module.exports = {
+  entry: {
+    'index.bundle': './index',
+  },
+  plugins: [
+    new RaxWebpackPlugin({
+      target: 'bundle',
+      sourcePrefixFn: function(source, chunk, hash){
+        return 'define("' + chunk.name + '", function(require) {';
+      },
+      sourceSuffixFn: function(source, chunk, hash){
+        return '})'
+      }
+    })
+  ]
+};

--- a/packages/rax-webpack-plugin/src/__tests__/fixtures/factory/expected/index.factory.js
+++ b/packages/rax-webpack-plugin/src/__tests__/fixtures/factory/expected/index.factory.js
@@ -1,5 +1,5 @@
 module.exports = function(require, exports, module) {
-  with(this) { module.exports = /******/ (function(modules) { // webpackBootstrap
+    with(this) { module.exports = /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
 /******/

--- a/packages/rax-webpack-plugin/src/__tests__/fixtures/function/expected/index.function.js
+++ b/packages/rax-webpack-plugin/src/__tests__/fixtures/function/expected/index.function.js
@@ -1,6 +1,6 @@
 
-module.exports = function() {
-  return /******/ (function(modules) { // webpackBootstrap
+  module.exports = function() {
+    return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
 /******/

--- a/packages/rax-webpack-plugin/src/__tests__/fixtures/umd/expected/index.umd.js
+++ b/packages/rax-webpack-plugin/src/__tests__/fixtures/umd/expected/index.umd.js
@@ -1,27 +1,27 @@
 
-;(function(fn) {
-  if (typeof exports === "object" && typeof module !== "undefined") {
-    module.exports = fn();
-  } else if (typeof define === "function") {
-    define("index.umd", function(require, exports, module){
+  ;(function(fn) {
+    if (typeof exports === "object" && typeof module !== "undefined") {
       module.exports = fn();
-    });
-  } else {
-    var root;
-    if (typeof window !== "undefined") {
-      root = window;
-    } else if (typeof self !== "undefined") {
-      root = self;
-    } else if (typeof global !== "undefined") {
-      root = global;
+    } else if (typeof define === "function") {
+      define("index.umd", function(require, exports, module){
+        module.exports = fn();
+      });
     } else {
-      // NOTICE: In JavaScript strict mode, this is null
-      root = this;
+      var root;
+      if (typeof window !== "undefined") {
+        root = window;
+      } else if (typeof self !== "undefined") {
+        root = self;
+      } else if (typeof global !== "undefined") {
+        root = global;
+      } else {
+        // NOTICE: In JavaScript strict mode, this is null
+        root = this;
+      }
+      root["index.umd"] = fn();
     }
-    root["index.umd"] = fn();
-  }
-})(function(){
-  return /******/ (function(modules) { // webpackBootstrap
+  })(function(){
+    return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
 /******/

--- a/packages/rax-webpack-plugin/src/__tests__/index.js
+++ b/packages/rax-webpack-plugin/src/__tests__/index.js
@@ -84,7 +84,7 @@ describe('rax-webpack-plugin', function() {
     });
   });
 
-  it('bundle', function(done) {
+  it('custom', function(done) {
     runWebpack(done, 'custom', function(actualPath, filePath) {
       const actual = readFile(actualPath);
       const expected = readFile(filePath);

--- a/packages/rax-webpack-plugin/src/__tests__/index.js
+++ b/packages/rax-webpack-plugin/src/__tests__/index.js
@@ -28,6 +28,8 @@ describe('rax-webpack-plugin', function() {
     let outputPath = path.join(outputDirectory, fixture);
     const configFile = path.join(testDirectory, 'webpack.config.js');
 
+
+
     if (argv.indexOf('--updateFixture') !== -1) {
       outputPath = path.join(__dirname, 'fixtures', fixture, 'expected');
     }
@@ -78,7 +80,15 @@ describe('rax-webpack-plugin', function() {
     runWebpack(done, 'bundle', function(actualPath, filePath) {
       const actual = readFile(actualPath);
       const expected = readFile(filePath);
+      expect(actual).toBe(expected);
+      expect(actual).toMatch('// {"framework" : "Rax"}');
+    });
+  });
 
+  it('bundle', function(done) {
+    runWebpack(done, 'custom', function(actualPath, filePath) {
+      const actual = readFile(actualPath);
+      const expected = readFile(filePath);
       expect(actual).toBe(expected);
       expect(actual).toMatch('// {"framework" : "Rax"}');
     });

--- a/packages/rax-webpack-plugin/src/__tests__/index.js
+++ b/packages/rax-webpack-plugin/src/__tests__/index.js
@@ -29,7 +29,6 @@ describe('rax-webpack-plugin', function() {
     const configFile = path.join(testDirectory, 'webpack.config.js');
 
 
-
     if (argv.indexOf('--updateFixture') !== -1) {
       outputPath = path.join(__dirname, 'fixtures', fixture, 'expected');
     }


### PR DESCRIPTION
1. add custom mainTemplate in case of more business situation such as not require automatically .
2. add multiplatform `chunkFilename` config to enable code splitting's custom chunk name 
