### PR TITLE
chore: add config name to identify container type in compilation process

### DIFF
--- a/packages/rax-webpack-plugin/src/MultiplePlatform.js
+++ b/packages/rax-webpack-plugin/src/MultiplePlatform.js
@@ -69,6 +69,7 @@ module.exports = function MultiplePlatform(config, options = {}) {
       });
 
       platformConfig.entry = platformEntry;
+      platformConfig.name = platformType;
 
       // support chunkFilename config according to platformType
       if (typeof options.chunkFilename === 'function') {

--- a/packages/rax-webpack-plugin/src/__tests__/MultiplePlatform.js
+++ b/packages/rax-webpack-plugin/src/__tests__/MultiplePlatform.js
@@ -45,7 +45,7 @@ describe('MultiplePlatform', function() {
       'entry': {
         'hello.bundle.weex': './index.js'
       },
-      "name": "weex",      
+      'name': 'weex',
       'module': {
         'loaders': [{
           'test': /\.jsx?$/,
@@ -102,7 +102,7 @@ describe('MultiplePlatform', function() {
       'entry': {
         'hello.bundle.weex': './index.js'
       },
-      "name": "weex",      
+      'name': 'weex',
       'module': {
         'loaders': [{
           'test': /\.jsx?$/,
@@ -156,7 +156,7 @@ describe('MultiplePlatform', function() {
       'entry': {
         'hello.bundle.weex': './index.js'
       },
-      "name": "weex",
+      'name': 'weex',
       'module': {
         'loaders': [{
           'test': /\.jsx?$/,
@@ -263,7 +263,7 @@ describe('MultiplePlatform', function() {
         'hello.bundle.weex': ['./index.js', './weex.js'],
         'world.bundle.weex': './world.js'
       },
-      "name": "weex",
+      'name': 'weex',
       'module': {
         'loaders': [{
           test: /\.jsx?$/,
@@ -337,7 +337,7 @@ describe('MultiplePlatform', function() {
 
         }]
       },
-      "name": "weex",
+      'name': 'weex',
       'platforms': [
         'weex'
       ]

--- a/packages/rax-webpack-plugin/src/__tests__/MultiplePlatform.js
+++ b/packages/rax-webpack-plugin/src/__tests__/MultiplePlatform.js
@@ -45,6 +45,7 @@ describe('MultiplePlatform', function() {
       'entry': {
         'hello.bundle.weex': './index.js'
       },
+      "name": "weex",      
       'module': {
         'loaders': [{
           'test': /\.jsx?$/,
@@ -101,6 +102,7 @@ describe('MultiplePlatform', function() {
       'entry': {
         'hello.bundle.weex': './index.js'
       },
+      "name": "weex",      
       'module': {
         'loaders': [{
           'test': /\.jsx?$/,
@@ -154,6 +156,7 @@ describe('MultiplePlatform', function() {
       'entry': {
         'hello.bundle.weex': './index.js'
       },
+      "name": "weex",
       'module': {
         'loaders': [{
           'test': /\.jsx?$/,
@@ -260,6 +263,7 @@ describe('MultiplePlatform', function() {
         'hello.bundle.weex': ['./index.js', './weex.js'],
         'world.bundle.weex': './world.js'
       },
+      "name": "weex",
       'module': {
         'loaders': [{
           test: /\.jsx?$/,
@@ -333,6 +337,7 @@ describe('MultiplePlatform', function() {
 
         }]
       },
+      "name": "weex",
       'platforms': [
         'weex'
       ]


### PR DESCRIPTION
It should config like [this](https://github.com/webpack/webpack/blob/master/examples/multi-compiler/webpack.config.js#L5)

eg:
when webpack returns stats object , it need this property [ref](https://github.com/webpack/webpack/blob/master/lib/MultiStats.js#L46-Lundefined)
