### PR TITLE
fix: transport child layout props to contentContainerStyle for RecyclerView in Web

### DIFF
--- a/packages/rax-recyclerview/src/index.js
+++ b/packages/rax-recyclerview/src/index.js
@@ -129,8 +129,18 @@ class RecyclerView extends Component {
         </list>
       );
     } else {
+      const { style = {}, contentContainerStyle = {}, ...others } = props;
+
+      // transport child layout props to contentContainerStyle for ScrollView
+      const childLayoutProps = [ 'alignItems', 'justifyContent' ]
+        .filter((prop) => style[prop] !== undefined);
+      childLayoutProps.forEach(propName => {
+        contentContainerStyle[propName] = style[propName];
+        delete style[propName];
+      });
+
       return (
-        <ScrollView {...props} ref="scrollview" />
+        <ScrollView {...others} style={style} contentContainerStyle={contentContainerStyle} ref="scrollview" />
       );
     }
   }


### PR DESCRIPTION
![temp](https://cloud.githubusercontent.com/assets/8381024/26480096/783759da-420a-11e7-9778-23a7f177ecf2.png)

Prevent dozens of warning while using RecylerView in web.
