### PR TITLE
support error boundary

### DIFF
--- a/packages/rax/src/vdom/__tests__/composite.js
+++ b/packages/rax/src/vdom/__tests__/composite.js
@@ -179,7 +179,7 @@ describe('CompositeComponent', function() {
     render(
       <ErrorBoundary>
         <BrokenRender />
-      </ErrorBoundary> , container);
+      </ErrorBoundary>, container);
 
     expect(container.childNodes[0].childNodes[0].data).toBe('Caught an error: Hello.');
   });
@@ -206,7 +206,7 @@ describe('CompositeComponent', function() {
         throw new Error('Hello');
       }
       render() {
-        retrun (
+        return (
           <span>Hello</span>
         );
       }
@@ -215,7 +215,7 @@ describe('CompositeComponent', function() {
     render(
       <ErrorBoundary>
         <BrokenRender />
-      </ErrorBoundary> , container);
+      </ErrorBoundary>, container);
 
     expect(container.childNodes[0].childNodes[0].data).toBe('Caught an error: Hello.');
   });
@@ -237,7 +237,7 @@ describe('CompositeComponent', function() {
       }
     }
 
-    render(<BrokenRender /> , container);
+    render(<BrokenRender />, container);
     expect(container.childNodes[0].childNodes[0].data).toBe('Caught an error: Hello.');
   });
 });

--- a/packages/rax/src/vdom/__tests__/composite.js
+++ b/packages/rax/src/vdom/__tests__/composite.js
@@ -154,4 +154,90 @@ describe('CompositeComponent', function() {
       'will-unmount',
     ]);
   });
+
+  it('catches render error in a boundary', () => {
+    let container = createNodeElement('div');
+    class ErrorBoundary extends Component {
+      state = {error: null};
+      componentDidCatch(error) {
+        this.setState({error});
+      }
+      render() {
+        if (this.state.error) {
+          return (
+            <span>{`Caught an error: ${this.state.error.message}.`}</span>
+          );
+        }
+        return this.props.children;
+      }
+    }
+
+    function BrokenRender(props) {
+      throw new Error('Hello');
+    }
+
+    render(
+      <ErrorBoundary>
+        <BrokenRender />
+      </ErrorBoundary> , container);
+
+    expect(container.childNodes[0].childNodes[0].data).toBe('Caught an error: Hello.');
+  });
+
+  it('catches lifeCycles errors in a boundary', () => {
+    let container = createNodeElement('div');
+    class ErrorBoundary extends Component {
+      state = {error: null};
+      componentDidCatch(error) {
+        this.setState({error});
+      }
+      render() {
+        if (this.state.error) {
+          return (
+            <span>{`Caught an error: ${this.state.error.message}.`}</span>
+          );
+        }
+        return this.props.children;
+      }
+    }
+
+    class BrokenRender extends Component {
+      componentDidMount() {
+        throw new Error('Hello');
+      }
+      render() {
+        retrun (
+          <span>Hello</span>
+        );
+      }
+    }
+
+    render(
+      <ErrorBoundary>
+        <BrokenRender />
+      </ErrorBoundary> , container);
+
+    expect(container.childNodes[0].childNodes[0].data).toBe('Caught an error: Hello.');
+  });
+
+  it('catches render errors in a component', () => {
+    let container = createNodeElement('div');
+    class BrokenRender extends Component {
+      state = {error: null};
+      componentDidCatch(error) {
+        this.setState({error});
+      }
+      render() {
+        if (this.state.error) {
+          return (
+            <span>{`Caught an error: ${this.state.error.message}.`}</span>
+          );
+        }
+        throw new Error('Hello');
+      }
+    }
+
+    render(<BrokenRender /> , container);
+    expect(container.childNodes[0].childNodes[0].data).toBe('Caught an error: Hello.');
+  });
 });

--- a/packages/rax/src/vdom/composite.js
+++ b/packages/rax/src/vdom/composite.js
@@ -161,7 +161,7 @@ class CompositeComponent {
       if (instance.componentDidCatch) {
         instance.componentDidCatch(error);
       } else {
-        console.error(e);
+        console.error(error);
         throw error;
       }
     }

--- a/packages/rax/src/vdom/empty.js
+++ b/packages/rax/src/vdom/empty.js
@@ -8,8 +8,9 @@ class EmptyComponent {
     this._currentElement = null;
   }
 
-  mountComponent(parent, context, childMounter) {
+  mountComponent(parent, parentInstance, context, childMounter) {
     this._parent = parent;
+    this._parentInstance = parentInstance;
     this._context = context;
 
     let instance = {
@@ -33,6 +34,7 @@ class EmptyComponent {
 
     this._nativeNode = null;
     this._parent = null;
+    this._parentInstance = null;
     this._context = null;
   }
 

--- a/packages/rax/src/vdom/fragment.js
+++ b/packages/rax/src/vdom/fragment.js
@@ -12,9 +12,10 @@ class FragmentComponent extends NativeComponent {
     super(element);
   }
 
-  mountComponent(parent, context, childMounter) {
+  mountComponent(parent, parentInstance, context, childMounter) {
     // Parent native element
     this._parent = parent;
+    this._parentInstance = parentInstance;
     this._context = context;
     this._mountID = Host.mountID++;
 
@@ -60,6 +61,7 @@ class FragmentComponent extends NativeComponent {
       // Mount
       let mountImage = renderedChild.mountComponent(
         this._parent,
+        this._instance,
         context, (nativeNode) => {
           if (Array.isArray(nativeNode)) {
             for (let i = 0; i < nativeNode.length; i++) {
@@ -92,6 +94,7 @@ class FragmentComponent extends NativeComponent {
     this._currentElement = null;
     this._nativeNode = null;
     this._parent = null;
+    this._parentInstance = null;
     this._context = null;
     this._instance = null;
   }

--- a/packages/rax/src/vdom/instance.js
+++ b/packages/rax/src/vdom/instance.js
@@ -86,7 +86,7 @@ export default {
     let wrappedElement = createElement(Root, null, element);
     let renderedComponent = instantiateComponent(wrappedElement);
     let defaultContext = {};
-    let rootInstance = renderedComponent.mountComponent(container, defaultContext);
+    let rootInstance = renderedComponent.mountComponent(container, null, defaultContext);
     this.set(container, rootInstance);
 
     // After render callback

--- a/packages/rax/src/vdom/native.js
+++ b/packages/rax/src/vdom/native.js
@@ -18,9 +18,10 @@ class NativeComponent {
     this._currentElement = element;
   }
 
-  mountComponent(parent, context, childMounter) {
+  mountComponent(parent, parentInstance, context, childMounter) {
     // Parent native element
     this._parent = parent;
+    this._parentInstance = parentInstance;
     this._context = context;
     this._mountID = Host.mountID++;
 
@@ -85,7 +86,7 @@ class NativeComponent {
       renderedChild._mountIndex = index;
       // Mount
       let mountImage = renderedChild.mountComponent(this.getNativeNode(),
-        context);
+        this._instance, context, null);
       return mountImage;
     });
 
@@ -125,6 +126,7 @@ class NativeComponent {
     this._currentElement = null;
     this._nativeNode = null;
     this._parent = null;
+    this._parentInstance = null;
     this._context = null;
     this._instance = null;
     this._prevStyleCopy = null;
@@ -382,6 +384,7 @@ class NativeComponent {
 
           nextChild.mountComponent(
             parent,
+            this._instance,
             context, (newChild, parent) => {
               // TODO: Rework the duplicate code
               let oldChild = oldNodes[name];

--- a/packages/rax/src/vdom/text.js
+++ b/packages/rax/src/vdom/text.js
@@ -9,8 +9,9 @@ class TextComponent {
     this._stringText = String(element);
   }
 
-  mountComponent(parent, context, childMounter) {
+  mountComponent(parent, parentInstance, context, childMounter) {
     this._parent = parent;
+    this._parentInstance = parentInstance;
     this._context = context;
     this._mountID = Host.mountID++;
 
@@ -42,6 +43,7 @@ class TextComponent {
     this._currentElement = null;
     this._nativeNode = null;
     this._parent = null;
+    this._parentInstance = null;
     this._context = null;
     this._stringText = null;
   }


### PR DESCRIPTION
Components can use `componentDidCatch` method to catch errors.

```
class App extends Component {
  render() {
    return (
      <div className="App">
        <ErrorBoundary>
          <BrokenRender />
        </ErrorBoundary>
      </div>
    );
  }
}

class ErrorBoundary extends Component {
  state = {error: null};
  componentDidCatch(error) {
    this.setState({error});
  }
  render() {
    if (this.state.error) {
      return (
        <Text>{`Caught an error: ${this.state.error.message}.`}</Text>
      );
    }
    return this.props.children;
  }
}

function BrokenRender(props) {
  throw new Error('BrokenRender');
}

```