### PR TITLE
weex-canvas 0.5.2版本中，

### DIFF
--- a/packages/rax-canvas/src/canvas.weex.js
+++ b/packages/rax-canvas/src/canvas.weex.js
@@ -6,14 +6,9 @@ export function disable() {
 
 export function init(element) {
   return new Promise(function(resolve) {
-    GCanvas.start(element.ref, function() {
-      GCanvas.setDevicePixelRatio();
-      const ctx = GCanvas.getContext('2d');
-      GCanvas.startLoop();
+    const gcanvas = GCanvas.start(element);
 
-      GCanvas.render(() => {
-        resolve(ctx);
-      });
-    });
+    const ctx = gcanvas.getContext('2d');
+    resolve(ctx);
   });
 };

--- a/packages/rax-charts/src/Chart.js
+++ b/packages/rax-charts/src/Chart.js
@@ -31,7 +31,6 @@ class Chart extends Component {
       return;
     }
 
-    context.render();
     this.chart = new GM.Chart({
       el,
       context


### PR DESCRIPTION
rax-charts不需要render即可，否则会导致先渲染的gcanvas不可用
同时rax-canvas的使用方法，从回调变成同步调用