### PR TITLE
fix: export default rax and rax.Children

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,9 @@
     "es2015",
     "rax"
   ],
+  "plugins": [
+    "export-default-module-exports"
+  ],
   "ignore": [
     "src/generator/templates",
     "__mockc__"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "babel-eslint": "^7.2.3",
     "babel-jest": "^20.0.3 ",
     "babel-loader": "^7.1.0",
+    "babel-plugin-export-default-module-exports": "^0.0.4",
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-rax": "^0.4.12",
     "chalk": "^1.1.3",

--- a/packages/rax/src/index.js
+++ b/packages/rax/src/index.js
@@ -11,3 +11,4 @@ export unmountComponentAtNode from './unmountComponentAtNode';
 export findComponentInstance from './findComponentInstance';
 export setNativeProps from './setNativeProps';
 export version from './version';
+export Children from './children';


### PR DESCRIPTION
`rax` 目前没有 export default，当用户在 webpack 中配置 `alias` 使用 rax 替代 react 时，原有的

```js
import React from 'react';
```

往往不能运行。

```js
import React from 'react';
import Rax from 'rax';

import { createElement } from 'rax';

console.log(React); // React
console.log(Rax);  // undefined
console.log(React.Children); // React.Children

console.log(createElement); // rax.createElement
```

https://www.webpackbin.com/bins/-KtjqtZKIyTSU6Lp7QKb

同时直接使用 `React.Children.only` 等函数的代码也无法使用