### PR TITLE
fix: findDOMNode 与 ReactDOM 的API 一致性统一

### DIFF
--- a/packages/rax/src/findDOMNode.js
+++ b/packages/rax/src/findDOMNode.js
@@ -16,7 +16,12 @@ function findDOMNode(instance) {
   }
 
   if (typeof instance == 'string') {
-    return Host.driver.getElementById(instance);
+    const domNode = Host.driver.getElementById(instance);
+    if (domNode === null) {
+      throw new Error('Appears to be an invalid DOM id');
+    } else {
+      return domNode;
+    }
   }
 
   if (typeof instance.render !== 'function') {


### PR DESCRIPTION
fix #341