### PR TITLE
fix: solve the 'Uncaught ReferenceError: callback_*** is not defined' error on web for universal-jsonp

### DIFF
--- a/packages/universal-jsonp/src/index.js
+++ b/packages/universal-jsonp/src/index.js
@@ -10,7 +10,6 @@ function generateCallbackFunction() {
   return `jsonp_${Date.now()}_${Math.ceil(Math.random() * 100000)}`;
 }
 
-// Known issue: Will throw 'Uncaught ReferenceError: callback_*** is not defined' error if request timeout
 function clearFunction(functionName) {
   // IE8 throws an exception when you try to delete a property on window
   // http://stackoverflow.com/a/1824228/751089
@@ -100,8 +99,12 @@ const JSONP = function(url, options = {}) {
 
       timeoutId = setTimeout(() => {
         reject(new Error(`JSONP request to ${url} timed out`));
-        clearFunction(callbackFunction);
         removeScript(jsonpScript);
+
+        // remove script will not abort the request, so rewrite callback function and clear itself after response
+        window[callbackFunction] = function() {
+          clearFunction(callbackFunction);
+        };
       }, timeout);
     });
   }


### PR DESCRIPTION
*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).
5. Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

Removing script tag will not abort the request, so remove callback function directly will cause this issue.
