### PR TITLE
为weex下增加w3c标准的onerror API

### DIFF
--- a/packages/weex-rax-framework/src/__tests__/index.js
+++ b/packages/weex-rax-framework/src/__tests__/index.js
@@ -52,6 +52,7 @@ describe('framework', () => {
       geolocation: ['addEventListener', 'removeAllEventListeners', 'getCurrentPosition', 'watchPosition', 'clearWatch'],
       audio: ['addEventListener', 'removeAllEventListeners', 'canPlayType', 'stop', 'pause', 'load', 'play', 'setVolume'],
       picker: ['addEventListener', 'removeAllEventListeners', 'pickTime', 'pickDate', 'pick'],
+      globalEvent: ['addEventListener', 'removeEventListener'],
     });
 
     framework.registerComponents(['div', 'video']);
@@ -903,5 +904,23 @@ describe('framework', () => {
     instance.$create(code, __weex_callbacks__, __weex_options__, __weex_data__);
 
     expect(mockFn).toHaveBeenCalled();
+  });
+
+  it('window onerror', () => {
+    const code = `
+      window.onerror = function(e){alert('occur error')}
+      var e = err + 1;
+    `;
+    const mockFn = jest.fn((args) => {
+      expect(args).toEqual({
+        message: 'occur error'
+      });
+    });
+
+    expect(function() {
+      instance.oncall('modal', 'alert', mockFn);
+      instance.$create(code, __weex_callbacks__, __weex_options__, __weex_data__);
+      expect(mockFn).toHaveBeenCalled();
+    }).toThrowError(/err is not defined/);
   });
 });

--- a/packages/weex-rax-framework/src/index.js
+++ b/packages/weex-rax-framework/src/index.js
@@ -249,6 +249,13 @@ export function createInstance(instanceId, __weex_code__, __weex_options__, __we
 
     const windowEmitter = new EventEmitter();
 
+    const globalEvent = __weex_require__('@weex-module/globalEvent');
+    globalEvent.addEventListener("exception", (e) => {
+      if (window.onerror && typeof window.onerror == 'function') {
+        window.onerror(e.exception, e.bundleUrl, 0, 0, new Error(e.exception, e.bundleUrl, 0));
+      }
+    });
+    
     const window = {
       // ES
       Promise,
@@ -341,6 +348,7 @@ export function createInstance(instanceId, __weex_code__, __weex_options__, __we
       dispatchEvent: (e) => {
         windowEmitter.emit(e.type, e);
       },
+      onerror: null,
       // ModuleJS
       define: __weex_define__,
       require: __weex_require__,

--- a/packages/weex-rax-framework/src/index.js
+++ b/packages/weex-rax-framework/src/index.js
@@ -250,12 +250,12 @@ export function createInstance(instanceId, __weex_code__, __weex_options__, __we
     const windowEmitter = new EventEmitter();
 
     const globalEvent = __weex_require__('@weex-module/globalEvent');
-    globalEvent.addEventListener("exception", (e) => {
+    globalEvent.addEventListener('exception', (e) => {
       if (window.onerror && typeof window.onerror == 'function') {
         window.onerror(e.exception, e.bundleUrl, 0, 0, new Error(e.exception, e.bundleUrl, 0));
       }
     });
-    
+
     const window = {
       // ES
       Promise,

--- a/packages/weex-rax-framework/src/index.js
+++ b/packages/weex-rax-framework/src/index.js
@@ -248,21 +248,21 @@ export function createInstance(instanceId, __weex_code__, __weex_options__, __we
     const {Event, CustomEvent} = require('./event.weex')();
 
     const windowEmitter = new EventEmitter();
-    
+
     let errorHandler = null;
-    function registerErrorHandler(){
+    function registerErrorHandler() {
       if (registerErrorHandler.once) return;
-      
+
       const globalEvent = __weex_require__(GLOBAL_EVENT_MODULE);
       globalEvent.addEventListener('exception', (e) => {
         // TODO: miss lineno and colno
         // window.onerror = function(messageOrEvent, source, lineno, colno, error) { ... }
         errorHandler(e.exception, e.bundleUrl, 0, 0, new Error(e.exception, e.bundleUrl, 0));
       });
-      
+
       registerErrorHandler.once = true;
     }
-    
+
     const window = {
       // ES
       Promise,


### PR DESCRIPTION
通过globalEvent的exception类型事件来触发。
会按照w3c的onerror回调来提供 message，source，行列号（暂定为0），err对象。

提供和w3c类似的api，业务代码里可以通过

```
window.onerror = (e) => {
  if ( typeof WXEnvironment !== 'undefined' ) {
	let instanceWrap = require('@weex-module/instanceWrap');
    instanceWrap && instanceWrap.error && instanceWrap.error(1, 1004, 'Downgrade[occur error] :: error info ' + e); 
  }
}
```

在业务稳定之后，对weex页面发生不在预料之中的错误时进行单点被动降级。