### PR TITLE
fix: rax-canvas context must has type, default 2d

### DIFF
--- a/packages/rax-canvas/src/index.js
+++ b/packages/rax-canvas/src/index.js
@@ -3,7 +3,7 @@ import {isWeex} from 'universal-env';
 import * as Gcanvas from 'gcanvas.js';
 
 class Canvas extends Component {
-  getContext = (type) => {
+  getContext = (type = '2d') => {
     const canvas = findDOMNode(this.refs.canvas);
     if (isWeex) {
       this._canvasHolder = Gcanvas.enable(this.refs.canvas, {bridge: Gcanvas.WeexBridge});


### PR DESCRIPTION
没有默认值，造成 https://github.com/alibaba/rax/blob/master/packages/rax-qrcode/src/index.js#L44 渲染失败。