### PR TITLE
Feat: Support css transition

### DIFF
--- a/packages/stylesheet-loader/src/CSSTransitionPropTypes.js
+++ b/packages/stylesheet-loader/src/CSSTransitionPropTypes.js
@@ -1,0 +1,13 @@
+'use strict';
+
+import PropTypes from './PropTypes';
+
+const CSSTransitionPropTypes = {
+  transition: PropTypes.string,
+  transitionTimingFunction: PropTypes.string,
+  transitionProperty: PropTypes.string,
+  transitionDuration: PropTypes.string,
+  transitionDelay: PropTypes.string
+};
+
+export default CSSTransitionPropTypes;

--- a/packages/stylesheet-loader/src/Validation.js
+++ b/packages/stylesheet-loader/src/Validation.js
@@ -4,6 +4,7 @@ import BoxModelPropTypes from './BoxModelPropTypes';
 import FlexboxPropTypes from './FlexboxPropTypes';
 import TextStylePropTypes from './TextStylePropTypes';
 import ColorPropTypes from './ColorPropTypes';
+import CSSTransitionPropTypes from './CSSTransitionPropTypes';
 import {pushWarnMessage} from './promptMessage';
 import particular from './particular';
 import chalk from 'chalk';
@@ -41,5 +42,6 @@ Validation.addValidStylePropTypes(BoxModelPropTypes);
 Validation.addValidStylePropTypes(FlexboxPropTypes);
 Validation.addValidStylePropTypes(TextStylePropTypes);
 Validation.addValidStylePropTypes(ColorPropTypes);
+Validation.addValidStylePropTypes(CSSTransitionPropTypes);
 
 export default Validation;

--- a/packages/stylesheet-loader/src/__tests__/particular.js
+++ b/packages/stylesheet-loader/src/__tests__/particular.js
@@ -125,15 +125,15 @@ describe('particular', () => {
     expect(result.transitionProperty).toEqual('backgroundColor');
   });
 
-  it('should transform transitionProperty \'all\' to string \'width,height,backgroundColor,opacity,transformOrigin,transform\'', () => {
+  it('should transform transitionProperty \'all\' to string \'width,height,top,bottom,left,right,backgroundColor,opacity,transform\'', () => {
     const result = particular.transitionProperty('all');
 
-    expect(result.transitionProperty).toEqual('width,height,backgroundColor,opacity,transformOrigin,transform');
+    expect(result.transitionProperty).toEqual('width,height,top,bottom,left,right,backgroundColor,opacity,transform');
   });
 
   it('should separate transition value', () => {
     testTransition('all 0.5s linear', {
-      transitionProperty: 'width,height,backgroundColor,opacity,transformOrigin,transform',
+      transitionProperty: 'width,height,top,bottom,left,right,backgroundColor,opacity,transform',
       transitionDuration: '500ms',
       transitionTimingFunction: 'linear',
       transitionDelay: '0ms'

--- a/packages/stylesheet-loader/src/__tests__/particular.js
+++ b/packages/stylesheet-loader/src/__tests__/particular.js
@@ -30,6 +30,15 @@ describe('particular', () => {
     expect(result[methodName]).toEqual(value);
   }
 
+  function testTransition(value, separatedValue) {
+    const result = particular.transition(value);
+
+    expect(result.transitionProperty).toEqual(separatedValue.transitionProperty);
+    expect(result.transitionDuration).toEqual(separatedValue.transitionDuration);
+    expect(result.transitionDelay).toEqual(separatedValue.transitionDelay);
+    expect(result.transitionTimingFunction).toEqual(separatedValue.transitionTimingFunction);
+  }
+
   it('should separate border value', () => {
     testBorder('border');
     testBorder('borderTop');
@@ -90,5 +99,55 @@ describe('particular', () => {
     const result = particular.fontWeight(200);
 
     expect(result.fontWeight).toEqual('200');
+  });
+
+  it('should transform transitionDuration to string with ms', () => {
+    const result = particular.transitionDuration('0.5s');
+
+    expect(result.transitionDuration).toEqual('500ms');
+  });
+
+  it('should transform transitionDelay to string with ms', () => {
+    const result = particular.transitionDuration('.5s');
+
+    expect(result.transitionDuration).toEqual('500ms');
+  });
+
+  it('should delete empty spaces in transitionTimingFunction', () => {
+    const result = particular.transitionTimingFunction('cubic-bezier( 0.42, 0, 0.58, 1 )');
+
+    expect(result.transitionTimingFunction).toEqual('cubic-bezier(0.42,0,0.58,1)');
+  });
+
+  it('should transform transitionProperty \'background-color\' to string \'backgroundColor\'', () => {
+    const result = particular.transitionProperty('background-color');
+
+    expect(result.transitionProperty).toEqual('backgroundColor');
+  });
+
+  it('should transform transitionProperty \'all\' to string \'width,height,backgroundColor,opacity,transformOrigin,transform\'', () => {
+    const result = particular.transitionProperty('all');
+
+    expect(result.transitionProperty).toEqual('width,height,backgroundColor,opacity,transformOrigin,transform');
+  });
+
+  it('should separate transition value', () => {
+    testTransition('all 0.5s linear', {
+      transitionProperty: 'width,height,backgroundColor,opacity,transformOrigin,transform',
+      transitionDuration: '500ms',
+      transitionTimingFunction: 'linear',
+      transitionDelay: '0ms'
+    });
+    testTransition('background-color 300ms cubic-bezier( 0.42, 0, 0.58, 1 ) .01s', {
+      transitionProperty: 'backgroundColor',
+      transitionDuration: '300ms',
+      transitionTimingFunction: 'cubic-bezier(0.42,0,0.58,1)',
+      transitionDelay: '10ms'
+    });
+    testTransition('none', {
+      transitionDuration: '0ms',
+      transitionTimingFunction: 'ease',
+      transitionDelay: '0ms'
+    });
   });
 });

--- a/packages/stylesheet-loader/src/particular.js
+++ b/packages/stylesheet-loader/src/particular.js
@@ -90,7 +90,7 @@ let toMs = function(value) {
 
 let transitionProperty = function(value) {
   if (value === 'all') {
-    value = 'width,height,backgroundColor,opacity,transformOrigin,transform';
+    value = 'width,height,top,bottom,left,right,backgroundColor,opacity,transform';
   } else if (value === 'none' || !value) {
     return { isDeleted: true };
   }

--- a/packages/stylesheet-loader/src/particular.js
+++ b/packages/stylesheet-loader/src/particular.js
@@ -76,6 +76,46 @@ let border = function(key, value) {
   return result;
 };
 
+let toMs = function(value) {
+  if (typeof value === 'string') {
+    if (/^\./.test(value)) value = '0' + value; // .5s
+    if (/s$/.test(value) && !/ms$/.test(value)) { // 1.5s
+      value = parseFloat(value) * 1000;
+    } else { // 150 or 150ms
+      value = parseFloat(value);
+    }
+  }
+  return (value || 0) + 'ms';
+};
+
+let transitionProperty = function(value) {
+  if (value === 'all') {
+    value = 'width,height,backgroundColor,opacity,transformOrigin,transform';
+  } else if (value === 'none' || !value) {
+    return { isDeleted: true };
+  }
+  return {
+    transitionProperty: value.replace('background-color', 'backgroundColor')
+  };
+};
+
+let transition = function(value) {
+  let result = {
+    isDeleted: true
+  };
+  const options = (value || '')
+    .trim()
+    .replace(/cubic-bezier\(.*\)/g, ($0) => $0.replace(/\s+/g, '')) // transition: all 0.2s cubic-bezier( 0.42, 0, 0.58, 1 ) 0s
+    .split(/\s+/);
+  const property = transitionProperty(options[0] || 'all');
+
+  if (!property.isDeleted) result.transitionProperty = property.transitionProperty;
+  result.transitionTimingFunction = (options[2] || 'ease').replace(/\s+/g, '');
+  result.transitionDuration = toMs(options[1]);
+  result.transitionDelay = toMs(options[3]);
+  return result;
+};
+
 export default {
   border: (value) => {
     return border('border', value);
@@ -109,6 +149,27 @@ export default {
   fontWeight: (value) => {
     return {
       fontWeight: value.toString()
+    };
+  },
+  transition: (value) => {
+    return transition(value);
+  },
+  transitionProperty: (value) => {
+    return transitionProperty(value);
+  },
+  transitionDuration: (value) => {
+    return {
+      transitionDuration: toMs(value)
+    };
+  },
+  transitionDelay: (value) => {
+    return {
+      transitionDelay: toMs(value)
+    };
+  },
+  transitionTimingFunction: (value) => {
+    return {
+      transitionTimingFunction: value.replace(/\s+/g, '')
     };
   }
 };


### PR DESCRIPTION
`Weex v0.1.16+` 已经支持CSS动画的书写方式，具体见 [transition](http://weex-project.io/cn/wiki/common-styles.html#can-shu)，`Rax` 需要调整代码才可以支持

### 本次修改包括：

#### 1. 增加样式属性校验

* `transition`
* `transition-property`
* `transition-duration`
* `transition-delay`
* `transition-timing-function`

#### 2. 自动将时间单位转换成毫秒

**客户端不支持秒的单位，设置 `0.5s` 不会被运行**

```
transition-duration: 0.3s => 300ms
transition-delay: .2s => 200ms
```

#### 3. 动画属性支持 `all`

```
transition-property: all => width,height,top,bottom,left,right,backgroundColor,opacity,transform
```

#### 4. 自动转换动画属性 `background-color`

`Weex` 中背景的写法是**驼峰**的 `backgroundColor`，不符合样式的书写习惯，这里修改兼容**中划线**的写法 `background-color`

```
transition-property: background-color => backgroundColor
```

#### 5. 自动将 `transition` 拆分成子属性

```
transition: width 0.5s linear .2s
=>
transition-property: width;
transition-duration: 500ms;
transition-delay: 200ms;
transition-timing-function: linear;
```