### PR TITLE
fix: workder driver handle text node

### DIFF
--- a/packages/driver-worker/src/index.js
+++ b/packages/driver-worker/src/index.js
@@ -18,7 +18,6 @@ const TO_SANITIZE = [
   'previousSibling'
 ];
 
-
 export default ({ postMessage, addEventListener }) => {
   let document = createDocument();
   let MutationObserver = document.defaultView.MutationObserver;
@@ -63,7 +62,7 @@ export default ({ postMessage, addEventListener }) => {
     if (obj.nodeName === BODY) {
       out.nodeName = BODY;
     } else if (prop === 'addedNodes') {
-      if (obj.data) {
+      if (typeof obj.data === 'string') {
         out.data = obj.data;
       } else {
         out = {
@@ -71,7 +70,7 @@ export default ({ postMessage, addEventListener }) => {
           events: Object.keys(obj.eventListeners || {}),
           attributes: obj.attributes,
           nodeName: obj.nodeName,
-          style: obj.style,
+          style: obj.style
         };
       }
       out.nodeType = obj.nodeType;


### PR DESCRIPTION
经常会有空字符串节点出现, 关于HTML里的标签间空隙, vue 的处理是与 html 保持一致, 即产生一个空 text 节点

```
<view>a</view>
<view>b</view>
```
这样有三个节点: `[view, #text, view]`

这里判断条件不严谨