### PR TITLE
rax-image load参数默认可以不传

### DIFF
--- a/components/rax-image/src/index.d.ts
+++ b/components/rax-image/src/index.d.ts
@@ -39,7 +39,7 @@ export interface ImageProps extends BaseProps {
      * (当加载完成 src 指定的图片时，load事件将被触发)
      * @param {ImageLoadEvent} event
      */
-    load: (event: ImageLoadEvent) => void;
+    load?: (event: ImageLoadEvent) => void;
 
 
 }


### PR DESCRIPTION
load: (event: ImageLoadEvent) => void; -> load?: (event: ImageLoadEvent) => void;
否则会在ts下提示load必传的报错