### PR TITLE
fix: rax-textinput index.d.ts 中 BaseProps 引用错误

### DIFF
--- a/components/rax-textinput/src/index.d.ts
+++ b/components/rax-textinput/src/index.d.ts
@@ -1,5 +1,5 @@
 import * as Rax from "rax";
-import {BaseProps} from "../rax";
+import {BaseProps} from "rax";
 
 /**
  * component:(文本输入)


### PR DESCRIPTION
rax-textinput 的 index.d.ts 引用 BaseProps 有误，导致在 ts 中 rax-textinput 使用 style 属性会报错
