### PR TITLE
feat: miniapp-manifest-loader

### DIFF
--- a/packages/miniapp-manifest-loader/README.md
+++ b/packages/miniapp-manifest-loader/README.md
@@ -1,0 +1,3 @@
+# miniapp-manifest-loader
+
+> Miniapp Manifest Loader for Webpack"

--- a/packages/miniapp-manifest-loader/package.json
+++ b/packages/miniapp-manifest-loader/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "miniapp-manifest-loader",
+  "version": "0.1.1-beta.0",
+  "description": "Mini App Manifest Loader for Webpack",
+  "main": "src/index.js",
+  "dependencies": {
+    "miniapp-web-renderer": "^0.1.1-beta.2"
+  }
+}

--- a/packages/miniapp-manifest-loader/package.json
+++ b/packages/miniapp-manifest-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miniapp-manifest-loader",
-  "version": "0.1.1-beta.0",
+  "version": "0.1.1-beta.1",
   "description": "Mini App Manifest Loader for Webpack",
   "main": "src/index.js",
   "dependencies": {

--- a/packages/miniapp-manifest-loader/src/index.js
+++ b/packages/miniapp-manifest-loader/src/index.js
@@ -1,30 +1,29 @@
 module.exports = function(source) {
-  let manifestJson = typeof source === 'string' ? JSON.parse(source) : source;
-
+  const manifestJson = typeof source === 'string' ? JSON.parse(source) : source;
   const pages = manifestJson.pages;
-
-  const pagesMap = `{
-${Object.keys(pages)
-    .map((page) => {
-      return `"${page}": _requireReturnDefault(require('./${pages[page]}'))`;
-    })
-    .join(',\n')}
-}`;
-
-  // Ensure the miniapp-web-renderer absolute path
-  const miniappWebRendererPath = require.resolve('miniapp-web-renderer');
-
-  const manifestCode = JSON.stringify(manifestJson, null, 2)
-    .replace(/\u2028/g, '\\u2028')
-    .replace(/\u2029/g, '\\u2029');
+  // Resolve to miniapp-web-renderer local absolute path
+  const webRendererPathname = require.resolve('miniapp-web-renderer');
+  
   return `
-import { render } from '${miniappWebRendererPath}';
+import { render } from '${webRendererPathname}';
 
 function _requireReturnDefault(obj) { return obj && obj.__esModule ? obj.default : obj; }
 
-const pagesMap = ${pagesMap};
-
-const manifestData = ${manifestCode};
-
-render(manifestData, pagesMap)`;
+const pagesMap = {
+  ${
+    Object.keys(pages).map((page) => {
+      return `  "${page}" : _requireReturnDefault(require('./${pages[page]}'))`;
+    }).join(',\n')
+  }
 };
+
+const manifestData = ${
+  JSON.stringify(manifestJson, null, 2)
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029')
+};
+
+render(manifestData, pagesMap);
+`;
+
+}

--- a/packages/miniapp-manifest-loader/src/index.js
+++ b/packages/miniapp-manifest-loader/src/index.js
@@ -2,28 +2,29 @@ module.exports = function(source) {
   let manifestJson = typeof source === 'string' ? JSON.parse(source) : source;
 
   const pages = manifestJson.pages;
-  const pagesImport = Object.keys(pages).map((page) => {
-    return `import Page${page} from './${pages[page]}';`;
-  });
 
-  const pagesMap = `{${Object.keys(pages)
+  const pagesMap = `{
+${Object.keys(pages)
     .map((page) => {
-      return `${page}: Page${page}`;
+      return `"${page}": _requireReturnDefault(require('./${pages[page]}'))`;
     })
-    .join(',')}
-  }`;
+    .join(',\n')}
+}`;
 
   // Ensure the miniapp-web-renderer absolute path
   const miniappWebRendererPath = require.resolve('miniapp-web-renderer');
 
-  const manifestCode = JSON.stringify(manifestJson)
+  const manifestCode = JSON.stringify(manifestJson, null, 2)
     .replace(/\u2028/g, '\\u2028')
     .replace(/\u2029/g, '\\u2029');
   return `
 import { render } from '${miniappWebRendererPath}';
-${pagesImport.join('\n')}
+
+function _requireReturnDefault(obj) { return obj && obj.__esModule ? obj.default : obj; }
 
 const pagesMap = ${pagesMap};
+
 const manifestData = ${manifestCode};
+
 render(manifestData, pagesMap)`;
 };

--- a/packages/miniapp-manifest-loader/src/index.js
+++ b/packages/miniapp-manifest-loader/src/index.js
@@ -1,0 +1,29 @@
+module.exports = function(source) {
+  let manifestJson = typeof source === 'string' ? JSON.parse(source) : source;
+
+  const pages = manifestJson.pages;
+  const pagesImport = Object.keys(pages).map((page) => {
+    return `import Page${page} from './${pages[page]}';`;
+  });
+
+  const pagesMap = `{${Object.keys(pages)
+    .map((page) => {
+      return `${page}: Page${page}`;
+    })
+    .join(',')}
+  }`;
+
+  // Ensure the miniapp-web-renderer absolute path
+  const miniappWebRendererPath = require.resolve('miniapp-web-renderer');
+
+  const manifestCode = JSON.stringify(manifestJson)
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+  return `
+import { render } from '${miniappWebRendererPath}';
+${pagesImport.join('\n')}
+
+const pagesMap = ${pagesMap};
+const manifestData = ${manifestCode};
+render(manifestData, pagesMap)`;
+};


### PR DESCRIPTION
将 manifest 作为 entry 转换成 js 代码

- 支持实时编辑
- 加载 pages/page/index.html

后调用 miniapp-web-renderer 渲染