### PR TITLE
fix: rax ref update exec condition

### DIFF
--- a/packages/rax/src/vdom/ref.js
+++ b/packages/rax/src/vdom/ref.js
@@ -10,9 +10,9 @@ export default {
     // Update refs in owner component
     if (prevRef !== nextRef) {
       // Detach prev RenderedElement's ref
-      prevRef != null && this.detach(prevElement._owner, prevRef, component);
+      prevRef !== false && this.detach(prevElement._owner, prevRef, component);
       // Attach next RenderedElement's ref
-      nextRef != null && this.attach(nextElement._owner, nextRef, component);
+      nextRef !== false && this.attach(nextElement._owner, nextRef, component);
     }
   },
   attach(ownerComponent, ref, component) {


### PR DESCRIPTION

```js
let prevRef = prevElement != null && prevElement.ref;
prevRef != null && this.detach(prevElement._owner, prevRef, component);
```
prevRef 如果一开始为空的话，后面变成 false，也会执行后面的 detach， 这里修改了判断逻辑

