### PR TITLE
fix: composite diff error

### DIFF
--- a/packages/rax/src/vdom/__tests__/composite.js
+++ b/packages/rax/src/vdom/__tests__/composite.js
@@ -240,4 +240,27 @@ describe('CompositeComponent', function() {
     render(<BrokenRender />, container);
     expect(container.childNodes[0].childNodes[0].data).toBe('Caught an error: Hello.');
   });
+
+  it('should render correct when prevRenderedComponent did not generate nodes', () => {
+    let container = createNodeElement('div');
+    class Frag extends Component {
+      render() {
+        return [];
+      }
+    }
+    class App extends Component {
+      state = {count: 0};
+      render() {
+        if (this.state.count === 0) {
+          return <Frag />;
+        }
+        return <div />;
+      }
+    }
+
+    const instance = render(<App />, container);
+    expect(container.childNodes.length).toBe(0);
+    instance.setState({count: 1});
+    expect(container.childNodes[0].tagName).toBe('DIV');
+  });
 });

--- a/packages/rax/src/vdom/composite.js
+++ b/packages/rax/src/vdom/composite.js
@@ -474,8 +474,10 @@ class CompositeComponent {
             let child = newChild[i];
             if (oldChild[i]) {
               Host.driver.replaceChild(child, oldChild[i]);
-            } else {
+            } else if (lastNewChild) {
               Host.driver.insertAfter(child, lastNewChild);
+            } else {
+              Host.driver.appendChild(child, parent);
             }
             lastNewChild = child;
           }


### PR DESCRIPTION
一般情况下 null 等 都要注释节点兜底，所以composite renderComponent diff的时候不会报错，但是frag情况下，如果空数组实际不会生存node节点 所以会出错

[复现demo](https://codepen.io/anon/pen/jvQjyg?editors=0111)