### PR TITLE
refactor: remove redundant  code

### DIFF
--- a/packages/rax/src/vdom/__tests__/fragment.js
+++ b/packages/rax/src/vdom/__tests__/fragment.js
@@ -436,4 +436,20 @@ describe('FragmentComponent', function() {
     expect(el.childNodes[0].childNodes[1].data).toBe('2');
     expect(el.childNodes[0].childNodes[2].data).toBe('3');
   });
+
+  it('Fragment and its child Fragment should have the same parent node', function() {
+    let el = createNodeElement('div');
+
+    class Frag extends Component {
+      render() {
+        return [1, 2, [4, 5, [7, 8]], 6];
+      }
+    }
+
+    const instance = render(<Frag />, el);
+    const frgmentInstance = instance._internal._renderedComponent;
+    expect(frgmentInstance._parent).toBe(el);
+    expect(frgmentInstance._renderedChildren['.2']._parent).toBe(el);
+    expect(frgmentInstance._renderedChildren['.2']._renderedChildren['.2']._parent).toBe(el);
+  });
 });

--- a/packages/rax/src/vdom/fragment.js
+++ b/packages/rax/src/vdom/fragment.js
@@ -33,15 +33,9 @@ class FragmentComponent extends NativeComponent {
     if (childMounter) {
       childMounter(fragment, parent);
     } else {
-      let isFragmentParent = Array.isArray(parent);
       for (let i = 0; i < fragment.length; i++) {
         let child = fragment[i];
-        // When the parent is also a fragment
-        if (isFragmentParent) {
-          parent.push(child);
-        } else {
-          Host.driver.appendChild(child, parent);
-        }
+        Host.driver.appendChild(child, parent);
       }
     }
 


### PR DESCRIPTION
对fragment中的冗余逻辑进行删除，实际上 fragment的 _parent是不可能为 array类型的，因为fragment每次创建孩子节点的时候把自己的_parent传递下去， 而且fragment的_parent为array的话，也会和native中的逻辑造成bug  [相关代码](https://github.com/alibaba/rax/blob/master/packages/rax/src/vdom/native.js#L382)
