### PR TITLE
fix: mp-loader a:for item scope can not use in a:if

### DIFF
--- a/packages/mp-loader/src/transpiler/transpileModules/index.js
+++ b/packages/mp-loader/src/transpiler/transpileModules/index.js
@@ -7,4 +7,4 @@ const tagName = require('./tagName');
 const checked = require('./checked');
 const template = require('./template');
 
-module.exports = [checked, klass, events, condition, list, bind, template, tagName];
+module.exports = [checked, klass, events, list, condition, bind, template, tagName];


### PR DESCRIPTION
`<view a:for="{{[1, 2, 3]}}" a:if="{{item == 1}}"></view>`

之前被编译成了 

```js
_l.call(this, [1, 2, 3], function (item, index) {
  return data.item == 1 ? xxx : yyy;
});
```

修复效果 

```js
_l.call(this, [1, 2, 3], function (item, index) {
  return item == 1 ? xxx : yyy;
});
```
