### PR TITLE
fix: support a:key for mp

### DIFF
--- a/packages/mp-loader/src/transpiler/transpileModules/index.js
+++ b/packages/mp-loader/src/transpiler/transpileModules/index.js
@@ -1,3 +1,4 @@
+const key = require('./key');
 const klass = require('./klass');
 const events = require('./events');
 const bind = require('./bind');
@@ -7,4 +8,4 @@ const tagName = require('./tagName');
 const checked = require('./checked');
 const template = require('./template');
 
-module.exports = [checked, klass, events, list, condition, bind, template, tagName];
+module.exports = [key, checked, klass, events, list, condition, bind, template, tagName];

--- a/packages/mp-loader/src/transpiler/transpileModules/key.js
+++ b/packages/mp-loader/src/transpiler/transpileModules/key.js
@@ -1,0 +1,17 @@
+const { getAndRemoveAttr } = require('../helpers');
+
+const type = global.TRANSPILER_TYPE || 'my';
+const ATTR_KEY_ALI = 'a:key';
+const ATTR_KEY_WX = 'wx:key';
+
+function transformNode(el, state) {
+  if (type === 'my' && el.attrsMap[ATTR_KEY_ALI] !== undefined) {
+    el.key = getAndRemoveAttr(el, ATTR_KEY_ALI);
+  } else if (type === 'wx' && el.attrsMap[ATTR_KEY_WX] !== undefined) {
+    el.key = getAndRemoveAttr(el, ATTR_KEY_WX);
+  }
+}
+
+module.exports = {
+  transformNode
+};


### PR DESCRIPTION
`<view a:for="{{xx}}" a:key="{{item.id}}">`  a:key 被转换为 { key: item.id }