### PR TITLE
fix: Consumer render twice and render order incorrect

### DIFF
--- a/packages/rax/src/__tests__/createContext.js
+++ b/packages/rax/src/__tests__/createContext.js
@@ -123,4 +123,129 @@ describe('createContext', () => {
     expect(container.childNodes[0].childNodes[0].data).toEqual('4');
     expect(container.childNodes[1].childNodes[0].data).toEqual('8');
   });
+
+  it('Consumer should render correct when its owner props update', () => {
+    const container = createNodeElement('div');
+    const Context = createContext(1);
+    class Indirection extends Component {
+      shouldComponentUpdate() {
+        return false;
+      }
+      render() {
+        return this.props.children;
+      }
+    }
+    class Owner extends Component {
+      render() {
+        return (
+          <Indirection>
+            <Context.Consumer>
+              {
+                (value) => {
+                  return (
+                    <div>
+                      <span>{value}</span>
+                      <span>{this.props.value}</span>
+                    </div>
+                  );
+                }
+              }
+            </Context.Consumer>
+          </Indirection>
+        );
+      }
+    }
+
+    function App(props) {
+      return (
+        <Context.Provider value={props.value}>
+          <Owner value={props.value} />
+        </Context.Provider>
+      );
+    }
+
+    render(<App value={2} />, container);
+    expect(container.childNodes[0].childNodes[0].childNodes[0].data).toEqual('2');
+    expect(container.childNodes[0].childNodes[1].childNodes[0].data).toEqual('2');
+
+    // Update
+    render(<App value={3} />, container);
+    expect(container.childNodes[0].childNodes[0].childNodes[0].data).toEqual('3');
+    expect(container.childNodes[0].childNodes[1].childNodes[0].data).toEqual('3');
+  });
+
+  it('Consumer should render only once when Context value change', () => {
+    const container = createNodeElement('div');
+    const Context = createContext(1);
+    class Indirection extends Component {
+      shouldComponentUpdate() {
+        return false;
+      }
+      render() {
+        return this.props.children;
+      }
+    }
+    class App extends Component {
+      render() {
+        return (
+          <Context.Provider value={this.props.value}>
+            <Context.Consumer ref="consumer">
+              {() => <div />}
+            </Context.Consumer>
+            <Indirection>
+              <Context.Consumer ref="consumerWithIndirection">
+                {() => <div />}
+              </Context.Consumer>
+            </Indirection>
+          </Context.Provider>
+        );
+      }
+    }
+    const instance = render(<App value={2} />, container);
+    const spyConsumerRender = jest.spyOn(instance.refs.consumer, 'render');
+    const spyConsumerWithIndirection = jest.spyOn(instance.refs.consumerWithIndirection, 'render');
+    render(<App value={3} />, container);
+    expect(spyConsumerRender).toHaveBeenCalledTimes(1);
+    expect(spyConsumerWithIndirection).toHaveBeenCalledTimes(1);
+  });
+
+  it('Consumer child should be rendered in the right order', () => {
+    const container = createNodeElement('div');
+    const Context = createContext(1);
+    let Yield = [];
+    class Parent extends Component {
+      render() {
+        Yield.push('Parent');
+        return this.props.children;
+      }
+    }
+    class App extends Component {
+      render() {
+        Yield.push('App');
+        return (
+          <Context.Provider value={this.props.value}>
+            <Parent>
+              <Context.Consumer>
+                {
+                  (value) => {
+                    Yield.push('Consumer render');
+                    return <span>{value}</span>;
+                  }
+                }
+              </Context.Consumer>
+            </Parent>
+          </Context.Provider>
+        );
+      }
+    }
+    render(<App />, container);
+    Yield = [];
+    render(<App value={2} />, container);
+    expect(Yield).toEqual([
+      'App',
+      'Parent',
+      'Consumer render',
+    ]);
+    expect(container.childNodes[0].childNodes[0].data).toEqual('2');
+  });
 });


### PR DESCRIPTION
兼容React new Context的API设计的非常巧妙，但是这里会两重问题
1. 在Provider value 改变的时候，实际会触发两次Consumer的更新。
2. Consumer更新的顺序无法保证

React16不会出现这两个问题，new Context的难点在于，如何保证在Parent不更新情况下，他的子代的Consumer能触发更新，React16可以非常容易的实现这一点，再Provider的value更新的时候，propagateContextChange去修改依赖的Consumer的expirationTime，再往上更新其return fiber的childExpirationTime的值即可。propagateContextChange不会立即触发Consumer的更新，只是修改了它的expirationTime。 这样就能确保，当前的渲染流程中，无论Consumer的parent是否会更新，借助react16的fiber的reconciler机制，Consumer都会更新，而且只更新一次

rax是stack reconciler, Parent的不更新，就会造成child的不更新，所以使用了event机制作为解决方案。如何在当前方案下面去解决这两个问题？基本的出发点是，同步往下传递最新的context value,  往后推迟event emit, 当event监听的事件触发的时候，判断当前Consumer是否已经取得最新的context value，如果不是的话，说明其ancestor有不更新情况，需要setState, 如果不是的话，Consumer就无需setState了

### 为何保证Consumer更新的顺序很重要，
因为Consumer的一般来说, 其child function是定义在Owner组件里面的，可能使用了Owner组件里render函数的变量，所以必须保证Owner render函数先执行。具体可以看添加的测试，有个例子



