### PR TITLE
fix: get compute changed data

### DIFF
--- a/packages/mp-runtime/src/computeChangedData.js
+++ b/packages/mp-runtime/src/computeChangedData.js
@@ -67,6 +67,9 @@ export default function computeChangedData(originalData, changedData) {
   let ret = {};
   Object.keys(changedData).forEach((pathString) => {
     const path = stringToPath(pathString);
+    if (path && path[0] !== undefined) {
+      ret[path[0]] = originalData[path[0]];
+    }
     set(ret, ret, path, (clonedObj, finalPath) => {
       clonedObj[finalPath] = changedData[pathString];
       return clonedObj;

--- a/packages/mp-runtime/src/computeChangedData.js
+++ b/packages/mp-runtime/src/computeChangedData.js
@@ -53,8 +53,18 @@ function set(dest, src, path, changeCallback, deep) {
   return dest;
 }
 
+/**
+ * Get changed data, just changed keys will included.
+ * eg:
+ *   originalData: { foo: 'some val', bar: '' }
+ *   changedData: { foo: 'new val' }
+ *   returns: { foo: 'new val' }
+ * @param originalData
+ * @param changedData
+ * @returns {Object}
+ */
 export default function computeChangedData(originalData, changedData) {
-  let ret = { ...originalData };
+  let ret = {};
   Object.keys(changedData).forEach((pathString) => {
     const path = stringToPath(pathString);
     set(ret, ret, path, (clonedObj, finalPath) => {


### PR DESCRIPTION
case

```js
rawData: { title1: '', title2: '' };
this.setData({ title1: '1111' })
this.setData({ title2: '2222' })
```

原逻辑会变成 
```js
this.setState({ title1: '1111', title2: '' })
this.setState({ title1: '', title2: '2222' })
```

导致后面的覆盖了前面, 期望

```js
this.setState({ title1: '1111' })
this.setState({ title2: '2222' })
```