### PR TITLE
fix: style object split work with background image url

### DIFF
--- a/packages/render-helpers/src/renderStyle.js
+++ b/packages/render-helpers/src/renderStyle.js
@@ -1,33 +1,7 @@
-// classnames or cx
-
-var hasOwn = {}.hasOwnProperty;
-function flatClassNames() {
-  var classes = [];
-  for (var i = 0; i < arguments.length; i++) {
-    var arg = arguments[i];
-    if (!arg) continue;
-    var argType = typeof arg;
-    if (argType === 'string') {
-      classes = classes.concat(arg.split(' '));
-    } else if (argType === 'number') {
-      classes.push(arg);
-    } else if (Array.isArray(arg)) {
-      classes.push(flatClassNames.apply(null, arg));
-    } else if (argType === 'object') {
-      for (var key in arg) {
-        if (hasOwn.call(arg, key) && arg[key]) {
-          classes.push(key);
-        }
-      }
-    }
-  }
-  return [].concat.apply([], classes);
-}
-
 function transformCSSStyleObject(str) {
   const styleObj = {};
   str.split(';').forEach(rule => {
-    const [key, val] = rule.split(/:/);
+    const [key, val] = rule.split(/:(.+)/);
     if (key && val) {
       styleObj[key.trim()] = val.trim();
     }


### PR DESCRIPTION
### 问题

```
<view style="background-image: url({{url}})" />

url = 'https://g.alicdn.com/foo.png';
```
--->

```
background-image: url(https;
```

### 原因 

```
_cx(style, null);
```

_cx 会把 cssText 转换成 cssObject (kv), 用正则切分 `:` 的时候没有考虑 background-image

### 解决: 参考代码 diff

### 验证: 
![image](https://user-images.githubusercontent.com/3922719/48486765-6808b500-e857-11e8-91d2-0bafc34a1551.png)
