### PR TITLE
fix: transition universal all bug

### DIFF
--- a/universal/universal-transition/src/index.js
+++ b/universal/universal-transition/src/index.js
@@ -27,11 +27,11 @@ export default function transition(node, styles, options, callback) {
       needLayout: options.needLayout || false
     }, callback || function() {});
   } else if (isWeb) {
+    const property = Object.keys(styles).join(',');
     const duration = options.duration || 0; // ms
     const timingFunction = options.timingFunction || 'linear';
     const delay = options.delay || 0; // ms
-    const transitionValue = 'all ' + duration + 'ms '
-        + timingFunction + ' ' + delay + 'ms';
+    const transitionValue = `${property} ${duration}ms ${timingFunction} ${delay}ms`;
 
     node.style.transition = transitionValue;
     node.style.webkitTransition = transitionValue;


### PR DESCRIPTION
由于Web上设置transition-property为All，导致transition系统会控制不需要控制的style，造成多余的动画效果

