### PR TITLE
fix: input value can not be clean

### DIFF
--- a/packages/atag/src/components/input/index.js
+++ b/packages/atag/src/components/input/index.js
@@ -1,5 +1,4 @@
 import { PolymerElement, html } from '@polymer/polymer';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status';
 
 let uid = 0;
 
@@ -180,7 +179,7 @@ export default class Input extends PolymerElement {
       <input 
         id="input" 
         placeholder="[[placeholder]]" 
-        value$="[[value]]" 
+        value="[[value]]" 
         type$="[[type]]" 
         disabled$="[[disabled]]"
         autofocus$="[[focus]]" 


### PR DESCRIPTION
fix: should pass property 'value' to native input
----
另: 思考一种常见的场景

```
data: {foo: ''}
<input :value="foo" />
<button @click="foo=''">clean</button>
```

当用户输入字符后清空无效, 因为 foo 未发生变化.  
1. 这种表现是否为符合期望?
2. 这种需求用户要如何实现?
  - 一种可能的实现:
    ```js
      this.setData({ foo: ' ' }, () => { this.setData({ foo: '' }); })
    ```
  - 另一种: 让 input 组件重新渲染
3. 更直接的方式?
