### PR TITLE
fix: allow app.js content not ended with `;`

### DIFF
--- a/packages/mp-loader/src/index.js
+++ b/packages/mp-loader/src/index.js
@@ -46,7 +46,7 @@ module.exports = function(content) {
      */
     source = `import App from ${createAppRequest};
       ${content}
-      ${requireAppPages}`;
+      ;${requireAppPages}`;
   }
 
   return source;


### PR DESCRIPTION
如果缺少分号, 

```
App({})
```

末尾的括号会与下面的IIFE构成 CallExpression. 导致运行时报错.

```
App({})
(function(){ 
  // ...
})();
```

所以必须单独加一个`;` 隔开