### PR TITLE
Fix boundary error handle

### DIFF
--- a/packages/rax/src/vdom/__tests__/composite.js
+++ b/packages/rax/src/vdom/__tests__/composite.js
@@ -341,7 +341,39 @@ describe('CompositeComponent', function() {
     ]);
   });
 
-  it('working correct on siblings of a component that throws', () => {
+  it('rendering correct on siblings of a component that throws', () => {
+    let container = createNodeElement('div');
+    function BrokenRender() {
+      throw new Error('Hello');
+    }
+    class ErrorBoundary extends Component {
+      state = {error: null};
+      componentDidCatch(error) {
+        this.setState({error});
+      }
+      render() {
+        if (this.state.error) {
+          return (
+            <div>{`Caught an error: ${this.state.error.message}.`}</div>
+          );
+        }
+        return (
+          <div>
+            <span>siblings</span>
+            <BrokenRender />
+            <span>siblings</span>
+          </div>
+        );
+      }
+    }
+
+    render(
+      <ErrorBoundary />, container);
+    expect(container.childNodes.length).toBe(1);
+    expect(container.childNodes[0].childNodes[0].data).toBe('Caught an error: Hello.');
+  });
+
+  it('working correct with fragment when a component that throw error', () => {
     let container = createNodeElement('div');
     class ErrorBoundary extends Component {
       state = {error: null};
@@ -354,7 +386,11 @@ describe('CompositeComponent', function() {
             <span>{`Caught an error: ${this.state.error.message}.`}</span>
           );
         }
-        return this.props.children;
+        return [
+          <span>siblings</span>,
+          <BrokenRender />,
+          <span>siblings</span>
+        ];
       }
     }
 
@@ -363,11 +399,7 @@ describe('CompositeComponent', function() {
     }
 
     render(
-      <ErrorBoundary>
-        <span>siblings</span>
-        <BrokenRender />
-        <span>siblings</span>
-      </ErrorBoundary>, container);
+      <ErrorBoundary />, container);
     expect(container.childNodes.length).toBe(1);
     expect(container.childNodes[0].childNodes[0].data).toBe('Caught an error: Hello.');
   });

--- a/packages/rax/src/vdom/__tests__/composite.js
+++ b/packages/rax/src/vdom/__tests__/composite.js
@@ -301,6 +301,187 @@ describe('CompositeComponent', function() {
     expect(container.childNodes[0].childNodes[0].data).toBe('Caught an error: Hello.');
   });
 
+  it('should not attempt to recover an unmounting error boundary', () => {
+    let container = createNodeElement('div');
+    let logs = [];
+    class Parent extends Component {
+      componentWillUnmount() {
+        logs.push('Parent componentWillUnmount');
+      }
+      render() {
+        return <Boundary />;
+      }
+    }
+
+    class Boundary extends Component {
+      componentDidCatch(e) {
+        logs.push(`Caught error: ${e.message}`);
+      }
+      render() {
+        return <ThrowsOnUnmount />;
+      }
+    }
+
+    class ThrowsOnUnmount extends Component {
+      componentWillUnmount() {
+        logs.push('ThrowsOnUnmount componentWillUnmount');
+        throw new Error('unmount error');
+      }
+      render() {
+        return null;
+      }
+    }
+
+    render(<Parent />, container);
+    render(<div />, container);
+    expect(logs).toEqual([
+      // Parent unmounts before the error is thrown.
+      'Parent componentWillUnmount',
+      'ThrowsOnUnmount componentWillUnmount',
+    ]);
+  });
+
+  it('working correct on siblings of a component that throws', () => {
+    let container = createNodeElement('div');
+    class ErrorBoundary extends Component {
+      state = {error: null};
+      componentDidCatch(error) {
+        this.setState({error});
+      }
+      render() {
+        if (this.state.error) {
+          return (
+            <span>{`Caught an error: ${this.state.error.message}.`}</span>
+          );
+        }
+        return this.props.children;
+      }
+    }
+
+    function BrokenRender() {
+      throw new Error('Hello');
+    }
+
+    render(
+      <ErrorBoundary>
+        <span>siblings</span>
+        <BrokenRender />
+        <span>siblings</span>
+      </ErrorBoundary>, container);
+    expect(container.childNodes.length).toBe(1);
+    expect(container.childNodes[0].childNodes[0].data).toBe('Caught an error: Hello.');
+  });
+
+  it('Life cycle method invocation sequence should be correct', () => {
+    let logs = [];
+
+    let container = createNodeElement('div');
+    class ErrorBoundary extends Component {
+      state = {error: null};
+      componentDidCatch(error) {
+        this.setState({error});
+      }
+      render() {
+        if (this.state.error) {
+          return (
+            <span>{`Caught an error: ${this.state.error.message}.`}</span>
+          );
+        }
+        return this.props.children;
+      }
+    }
+
+    class Life1 extends Component {
+      componentWillMount() {
+        logs.push('componentWillMount1');
+      }
+      render() {
+        logs.push('render1');
+        return null;
+      }
+      componentDidMount() {
+        logs.push('componentDidMount1');
+      }
+
+      componentWillUpdate() {
+        logs.push('componentWillUpdata1');
+      }
+      componentDidUpdate() {
+        logs.push('componentDidUpdate1');
+      }
+      componentWillUnmount() {
+        logs.push('componentWillUnmount1');
+      }
+    }
+
+    class Life2 extends Component {
+      componentWillMount() {
+        logs.push('componentWillMount2');
+      }
+      render() {
+        logs.push('render2');
+        throw new Error();
+        return null;
+      }
+      componentDidMount() {
+        logs.push('componentDidMount2');
+      }
+      componentWillUpdate() {
+        logs.push('componentWillUpdate2');
+      }
+      componentDidUpdate() {
+        logs.push('componentDidUpdate2');
+      }
+      componentWillUnmount() {
+        logs.push('componentWillUnmount2');
+      }
+    }
+
+    class Life3 extends Component {
+      componentWillMount() {
+        logs.push('componentWillMount3');
+      }
+      render() {
+        logs.push('render3');
+        return null;
+      }
+      componentDidMount() {
+        logs.push('componentDidMount3');
+      }
+      componentWillUpdata() {
+        logs.push('componentWillUpdata3');
+      }
+      componentDidUpdate() {
+        logs.push('componentDidUpdate3');
+      }
+      componentWillUnmount() {
+        logs.push('componentWillUnmount3');
+      }
+    }
+
+    render(
+      <ErrorBoundary>
+        <Life1 />
+        <Life2 />
+        <Life3 />
+      </ErrorBoundary>, container);
+
+    expect(logs).toEqual([
+      'componentWillMount1',
+      'render1',
+      'componentDidMount1',
+      'componentWillMount2',
+      'render2',
+      'componentDidMount2',
+      'componentWillMount3',
+      'render3',
+      'componentDidMount3',
+      'componentWillUnmount1',
+      'componentWillUnmount2',
+      'componentWillUnmount3'
+    ]);
+  });
+
   it('should render correct when prevRenderedComponent did not generate nodes', () => {
     let container = createNodeElement('div');
     class Frag extends Component {

--- a/packages/rax/src/vdom/composite.js
+++ b/packages/rax/src/vdom/composite.js
@@ -33,7 +33,7 @@ function handleError(instance, error) {
   }
 
   if (boundary) {
-    if (boundary._internal) {
+    if (boundary  && boundary._internal) {
       let callbackQueue =
       boundary._internal._pendingCallbacks ||
       (boundary._internal._pendingCallbacks = []);

--- a/packages/rax/src/vdom/composite.js
+++ b/packages/rax/src/vdom/composite.js
@@ -34,10 +34,9 @@ function handleError(instance, error) {
 
   if (boundary) {
     // should not attempt to recover an unmounting error boundary
-    if (boundary._internal) {
-      let callbackQueue =
-      boundary._internal._pendingCallbacks ||
-      (boundary._internal._pendingCallbacks = []);
+    const boundaryInternal = boundary._internal;
+    if (boundaryInternal) {
+      let callbackQueue = boundaryInternal._pendingCallbacks || (boundaryInternal._pendingCallbacks = []);
       callbackQueue.push(() => boundary.componentDidCatch(error));
     }
   } else {

--- a/packages/rax/src/vdom/composite.js
+++ b/packages/rax/src/vdom/composite.js
@@ -33,7 +33,12 @@ function handleError(instance, error) {
   }
 
   if (boundary) {
-    boundary.componentDidCatch(error);
+    if (boundary._internal) {
+      let callbackQueue =
+      boundary._internal._pendingCallbacks ||
+      (boundary._internal._pendingCallbacks = []);
+      callbackQueue.push(() => boundary.componentDidCatch(error));
+    }
   } else {
     if (Host.sandbox) {
       setTimeout(() => {
@@ -181,7 +186,7 @@ class CompositeComponent {
       Ref.attach(this._currentElement._owner, this._currentElement.ref, this);
     }
 
-    // Trigger setState callback in componentWillMount after rendered
+    // Trigger setState callback in componentWillMount or boundary callback after rendered
     let callbacks = this._pendingCallbacks;
     if (callbacks) {
       this._pendingCallbacks = null;
@@ -412,9 +417,9 @@ class CompositeComponent {
       instance.context = nextContext;
     }
 
-    // Flush setState callbacks set in componentWillReceiveProps
-    if (hasReceived) {
-      let callbacks = this._pendingCallbacks;
+    // Flush setState callbacks set in componentWillReceiveProps or boundary callback
+    let callbacks = this._pendingCallbacks;
+    if (callbacks) {
       this._pendingCallbacks = null;
       updater.runCallbacks(callbacks, instance);
     }

--- a/packages/rax/src/vdom/composite.js
+++ b/packages/rax/src/vdom/composite.js
@@ -33,7 +33,8 @@ function handleError(instance, error) {
   }
 
   if (boundary) {
-    if (boundary  && boundary._internal) {
+    // should not attempt to recover an unmounting error boundary
+    if (boundary._internal) {
       let callbackQueue =
       boundary._internal._pendingCallbacks ||
       (boundary._internal._pendingCallbacks = []);


### PR DESCRIPTION
目前的错误处理是同步渲染错误，但是rax的渲染模型是stack更新，所以这里会有问题

两个 比较直观的例子
[demo1](https://codepen.io/anon/pen/EGxVqW?editors=0111)
[demo2](https://codepen.io/anon/pen/yGLYmN?editors=0111)

一个是由于错误更新时候，栈信息的遗留，导致底部多了个sibling，一个是fragment的childMount机制，child只是mount，还没加入到parnetNode，就被拿去diff， 所以导致报错

这里修复的话，可以比较简单的异步去执行错误处理函数，但是同步渲染的模式下面，又多个个异步，可能对用户来说不太友好，希望能做到的是用户render时候，能同步获取到最新的状态
```
render(<App />); 
code // 无论是否发生错误，这里用户能拿到稳定的状态
```
用boundary去处理错误，所以我们在延迟在boundary didMount didUpdate稳定状态去同步刷新就可以了,
目前的错误回调直接放在了之前存在的callback里面，可能自己弄个captureCallback会更好
react16中对错误处理还有强制unmout机制，不过这些都是错误处理的策略问题了。


