### PR TITLE
fix: gesture cannot handle touch event from props

### DIFF
--- a/components/rax-gesture-view/src/gesture.web.js
+++ b/components/rax-gesture-view/src/gesture.web.js
@@ -25,8 +25,10 @@ class GestureViewOnWeb extends Component {
   panType;
 
   onTouchStart = (e) => {
+    const {onTouchStart} = this.props;
     this.startX = e.changedTouches[0].clientX;
     this.startY = e.changedTouches[0].clientY;
+    onTouchStart && onTouchStart(e);
   }
 
   reset() {
@@ -42,7 +44,7 @@ class GestureViewOnWeb extends Component {
   }
 
   onTouchMove = (e) => {
-    let {onHorizontalPan, onVerticalPan} = this.props;
+    let {onHorizontalPan, onVerticalPan, onTouchMove} = this.props;
     let deltaX = e.changedTouches[0].clientX - this.startX;
     let deltaY = e.changedTouches[0].clientY - this.startY;
 
@@ -81,10 +83,12 @@ class GestureViewOnWeb extends Component {
       }
       onVerticalPan && onVerticalPan(e);
     }
+
+    onTouchMove && onTouchMove(e);
   }
 
   onTouchEnd = (e) => {
-    let {onHorizontalPan, onVerticalPan} = this.props;
+    let {onHorizontalPan, onVerticalPan, onTouchEnd} = this.props;
     e.state = 'end';
     e.changedTouches[0].deltaX = e.changedTouches[0].clientX - this.startX;
     e.changedTouches[0].deltaY = e.changedTouches[0].clientY - this.startY;
@@ -94,10 +98,11 @@ class GestureViewOnWeb extends Component {
       onVerticalPan && onVerticalPan(e);
     }
     this.reset();
+    onTouchEnd && onTouchEnd(e);
   }
 
   onTouchCancel = (e) => {
-    let {onHorizontalPan, onVerticalPan} = this.props;
+    let {onHorizontalPan, onVerticalPan, onTouchCancel} = this.props;
     e.state = 'cancel';
     e.changedTouches[0].deltaX = e.changedTouches[0].clientX - this.startX;
     e.changedTouches[0].deltaY = e.changedTouches[0].clientY - this.startY;
@@ -107,6 +112,7 @@ class GestureViewOnWeb extends Component {
       onVerticalPan && onVerticalPan(e);
     }
     this.reset();
+    onTouchCancel && onTouchCancel(e);
   }
 
   render() {

--- a/components/rax-gesture-view/src/gesture.weex.js
+++ b/components/rax-gesture-view/src/gesture.weex.js
@@ -7,7 +7,9 @@ import View from 'rax-view';
 
 class GestureViewOnWeex extends Component {
   onTouchStart = (e) => {
+    const {onTouchStart} = this.props;
     this.startX = e.changedTouches[0].clientX;
+    onTouchStart && onTouchStart(e);
   }
 
   onHorizontalPan = (e) => {


### PR DESCRIPTION
问题描述：使用xslider时，发现autoPlay始终无法停止，发现gesture组件里面没能正常接收外界传入的touch事件，修复这个bug。
