### PR TITLE
fix: wrong transition format

### DIFF
--- a/universal/universal-transition/src/index.js
+++ b/universal/universal-transition/src/index.js
@@ -27,11 +27,13 @@ export default function transition(node, styles, options, callback) {
       needLayout: options.needLayout || false
     }, callback || function() {});
   } else if (isWeb) {
-    const property = Object.keys(styles).join(',');
+    const properties = Object.keys(styles);
     const duration = options.duration || 0; // ms
     const timingFunction = options.timingFunction || 'linear';
     const delay = options.delay || 0; // ms
-    const transitionValue = `${property} ${duration}ms ${timingFunction} ${delay}ms`;
+    const transitionValue = properties.length ?
+      properties.map((property) => `${property} ${duration}ms ${timingFunction} ${delay}ms`).join(',') :
+      `all ${duration}ms ${timingFunction} ${delay}ms`;
 
     node.style.transition = transitionValue;
     node.style.webkitTransition = transitionValue;


### PR DESCRIPTION
transition style格式错误
About: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions#Multiple_animated_properties_example