### PR TITLE
fix: checkbox and text

### DIFF
--- a/packages/atag/src/components/checkbox-group/index.js
+++ b/packages/atag/src/components/checkbox-group/index.js
@@ -1,6 +1,4 @@
 import { PolymerElement, html } from '@polymer/polymer';
-import afterNextRender from '../../shared/afterNextRender';
-import throttle from '../../shared/throttle';
 
 export default class CheckboxGroupElement extends PolymerElement {
   static get is() {
@@ -20,9 +18,14 @@ export default class CheckboxGroupElement extends PolymerElement {
     };
   }
 
-  ready() {
-    super.ready();
+  connectedCallback() {
+    super.connectedCallback();
     this.addEventListener('_checkboxChange', this.changeHandler);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener('_checkboxChange', this.changeHandler);
   }
 
   changeHandler = e => {
@@ -30,7 +33,7 @@ export default class CheckboxGroupElement extends PolymerElement {
     const checkboxList = this.querySelectorAll('a-checkbox');
     for (let i = 0; i < checkboxList.length; i++) {
       const node = checkboxList[i];
-      node.isChecked && value.push(node.value);
+      node.checked && value.push(node.value);
     }
     const event = new CustomEvent('change', {
       detail: {
@@ -40,10 +43,6 @@ export default class CheckboxGroupElement extends PolymerElement {
     this.dispatchEvent(event);
     e.stopPropagation();
   };
-
-  disconnectedCallback() {
-    this.removeEventListener('_checkboxChange', this.changeHandler);
-  }
 
   static get template() {
     return html`

--- a/packages/atag/src/components/text/index.js
+++ b/packages/atag/src/components/text/index.js
@@ -2,6 +2,21 @@ import { PolymerElement, html } from '@polymer/polymer';
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer';
 import debounce from '../../shared/debounce';
 
+const style = document.createElement('style');
+style.innerText = `
+  a-text {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  a-text[selectable=''],
+  a-text[selectable='true'] {
+    -webkit-user-select: all;
+    user-select: all;
+  }
+`;
+document.head.appendChild(style);
+
 export default class TextElement extends PolymerElement {
   static get is() {
     return 'a-text';
@@ -42,21 +57,6 @@ export default class TextElement extends PolymerElement {
         }
       }
     }
-  }
-
-  static get template() {
-    return html`<style>
-      :host {
-        -webkit-user-select: none;
-        user-select: none;
-      }
-
-      :host([selectable='']),
-      :host([selectable='true']) {
-        -webkit-user-select: all;
-        user-select: all;
-      }
-    </style><slot></slot>`;
   }
 }
 

--- a/packages/atag/src/components/view/index.js
+++ b/packages/atag/src/components/view/index.js
@@ -3,7 +3,7 @@ import { afterNextRender } from '@polymer/polymer/lib/utils/render-status';
 import * as Gestures from '@polymer/polymer/lib/utils/gestures';
 
 const style = document.createElement('style');
-style.innerHTML = `
+style.innerText = `
   a-view {
     display: block;
     -webkit-user-select: none;

--- a/packages/atag/src/components/view/index.js
+++ b/packages/atag/src/components/view/index.js
@@ -2,6 +2,17 @@ import { PolymerElement, html } from '@polymer/polymer';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status';
 import * as Gestures from '@polymer/polymer/lib/utils/gestures';
 
+const style = document.createElement('style');
+style.innerHTML = `
+  a-view {
+    display: block;
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-overflow-scrolling: touch;
+  }
+`;
+document.head.appendChild(style);
+
 export default class ViewElement extends PolymerElement {
   static get is() {
     return 'a-view';
@@ -147,20 +158,6 @@ export default class ViewElement extends PolymerElement {
       this._hoverActiveState = false;
       this._removeHoverAttrs();
     }, delay);
-  }
-
-  static get template() {
-    return html`
-      <style>
-        :host {
-          display: block;
-          -webkit-user-select: none;
-          user-select: none;
-          -webkit-overflow-scrolling: touch;
-        }
-      </style>
-      <slot></slot>
-    `;
   }
 }
 


### PR DESCRIPTION
把 text 组件的 shadow-dom 去掉了, 因为 slot 节点在浏览器下也算成一个节点, 处理样式继承需要走白名单, 从组件角度来看, text 组件本身没有什么依赖shadow dom 的逻辑