### PR TITLE
Feat update opt

### DIFF
--- a/packages/rax/src/__tests__/createPortal.js
+++ b/packages/rax/src/__tests__/createPortal.js
@@ -164,6 +164,7 @@ describe('createPortal', () => {
     expect(portalContainer.childNodes[0].childNodes[0].data).toBe('initial');
     expect(updatedCount).toBe(1);
 
+    // nothing can be changed
     render(<Parent />, container);
     expect(container.childNodes[0].nodeType).toBe(8);
     expect(portalContainer.childNodes[0].childNodes[0].data).toBe('initial');
@@ -175,7 +176,13 @@ describe('createPortal', () => {
     expect(portalContainer.childNodes[0].childNodes[0].data).toBe('changed');
     expect(updatedCount).toBe(2);
 
-    // change context -> none
+    // change context -> null
+    render(<Parent />, container);
+    expect(container.childNodes[0].nodeType).toBe(8);
+    expect(portalContainer.childNodes[0].childNodes[0].data).toBe('initial');
+    expect(updatedCount).toBe(3);
+
+    // nothing can be changed
     render(<Parent />, container);
     expect(container.childNodes[0].nodeType).toBe(8);
     expect(portalContainer.childNodes[0].childNodes[0].data).toBe('initial');

--- a/packages/rax/src/__tests__/createPortal.js
+++ b/packages/rax/src/__tests__/createPortal.js
@@ -125,7 +125,7 @@ describe('createPortal', () => {
     expect(portalContainer.childNodes[0].childNodes[0].data).toBe('changed-changed');
   });
 
-  it('should update portal if context or react element change', () => {
+  it('should update portal if context or element change', () => {
     const container = createNodeElement('div');
     const portalContainer = createNodeElement('div');
     let updatedCount = 0;

--- a/packages/rax/src/__tests__/render.js
+++ b/packages/rax/src/__tests__/render.js
@@ -78,4 +78,21 @@ describe('render', () => {
       done();
     });
   });
+
+  it('should not re-render when react element is same in same root', function() {
+    let container = createNodeElement('container');
+    let updatedCount = 0;
+    let App = function() {
+      updatedCount++;
+      return <div />;
+    };
+    let CacheApp = <App />;
+
+    render(CacheApp, container);
+    expect(container.childNodes[0].tagName).toBe('DIV');
+    expect(updatedCount).toBe(1);
+    render(CacheApp, container);
+    expect(container.childNodes[0].tagName).toBe('DIV');
+    expect(updatedCount).toBe(1);
+  });
 });

--- a/packages/rax/src/__tests__/render.js
+++ b/packages/rax/src/__tests__/render.js
@@ -79,7 +79,7 @@ describe('render', () => {
     });
   });
 
-  it('should not re-render when react element is same in same root', function() {
+  it('should not re-render when element is same in same root', function() {
     let container = createNodeElement('container');
     let updatedCount = 0;
     let App = function() {

--- a/packages/rax/src/vdom/__tests__/native.js
+++ b/packages/rax/src/vdom/__tests__/native.js
@@ -128,4 +128,38 @@ describe('NativeComponent', function() {
     expect(childNodes[1].data).toBe('hello1');
     expect(childNodes[2].data).toBe('hello2');
   });
+
+  it('should rendering correct even if child did not update when element is same', function() {
+    let container = createNodeElement('div');
+    const child1 = <div key="a">a</div>;
+    const child2 = <div>b</div>;
+    const child3 = <div key="c">c</div>;
+
+    class App extends Component {
+      state = {count: 0};
+      render() {
+        return (
+          <div>
+            {
+              this.state.count === 0
+                ? [<div>d</div>, child1, <div>e</div>, child2, child3]
+                : [child3, <div>e</div>, child2, child1, <div>d</div>]
+            }
+          </div>
+        );
+      }
+    }
+    const instance = render(<App />, container);
+    expect(container.childNodes[0].childNodes[0].childNodes[0].data).toBe('d');
+    expect(container.childNodes[0].childNodes[1].childNodes[0].data).toBe('a');
+    expect(container.childNodes[0].childNodes[2].childNodes[0].data).toBe('e');
+    expect(container.childNodes[0].childNodes[3].childNodes[0].data).toBe('b');
+    expect(container.childNodes[0].childNodes[4].childNodes[0].data).toBe('c');
+    instance.setState({count: 1});
+    expect(container.childNodes[0].childNodes[0].childNodes[0].data).toBe('c');
+    expect(container.childNodes[0].childNodes[1].childNodes[0].data).toBe('e');
+    expect(container.childNodes[0].childNodes[2].childNodes[0].data).toBe('b');
+    expect(container.childNodes[0].childNodes[3].childNodes[0].data).toBe('a');
+    expect(container.childNodes[0].childNodes[4].childNodes[0].data).toBe('d');
+  });
 });

--- a/packages/rax/src/vdom/composite.js
+++ b/packages/rax/src/vdom/composite.js
@@ -456,12 +456,17 @@ class CompositeComponent {
     Host.component = null;
 
     if (shouldUpdateComponent(prevRenderedElement, nextRenderedElement)) {
-      prevRenderedComponent.updateComponent(
-        prevRenderedElement,
-        nextRenderedElement,
-        prevRenderedComponent._context,
-        this._processChildContext(context)
-      );
+      const prevRenderedUnmaskedContext = prevRenderedComponent._context;
+      const nextRenderedUnmaskedContext = this._processChildContext(context);
+      if (prevRenderedElement !== nextRenderedElement || prevRenderedUnmaskedContext !== nextRenderedUnmaskedContext) {
+        prevRenderedComponent.updateComponent(
+          prevRenderedElement,
+          nextRenderedElement,
+          prevRenderedUnmaskedContext,
+          nextRenderedUnmaskedContext
+        );
+      }
+
       if (process.env.NODE_ENV !== 'production') {
         Host.measurer && Host.measurer.recordOperation({
           instanceID: this._mountID,

--- a/packages/rax/src/vdom/instance.js
+++ b/packages/rax/src/vdom/instance.js
@@ -62,12 +62,15 @@ export default {
       let prevElement = prevRenderedComponent._currentElement;
       if (shouldUpdateComponent(prevElement, element)) {
         let prevUnmaskedContext = prevRenderedComponent._context;
-        prevRenderedComponent.updateComponent(
-          prevElement,
-          element,
-          prevUnmaskedContext,
-          parentContext || prevUnmaskedContext
-        );
+        let nextUnmaskedContext = parentContext || prevUnmaskedContext;
+        if (prevElement !== element || prevUnmaskedContext !== nextUnmaskedContext) {
+          prevRenderedComponent.updateComponent(
+            prevElement,
+            element,
+            prevUnmaskedContext,
+            nextUnmaskedContext
+          );
+        }
 
         return prevRootInstance;
       } else {

--- a/packages/rax/src/vdom/native.js
+++ b/packages/rax/src/vdom/native.js
@@ -285,12 +285,16 @@ class NativeComponent {
         let name = getElementKeyName(nextChildren, nextElement, index);
         let prevChild = prevChildren && prevChildren[name];
         let prevElement = prevChild && prevChild._currentElement;
+        let prevContext = prevChild && prevChild._context;
 
         if (prevChild != null && shouldUpdateComponent(prevElement,
           nextElement)) {
-          // Pass the same context when updating chidren
-          prevChild.updateComponent(prevElement, nextElement, context,
-            context);
+          if (prevElement !== nextElement || prevContext !== context) {
+            // Pass the same context when updating chidren
+            prevChild.updateComponent(prevElement, nextElement, context,
+              context);
+          }
+
           nextChildren[name] = prevChild;
         } else {
           // Unmount the prevChild when nextChild is different element type.


### PR DESCRIPTION
增加rax更新时的一些优化

在jsx的作用下，每次render的时候，新生成一个新的react element对象，这样的话，每次都会去执行更新diff,  在不可变的数据结构上面讲，这层逻辑面上面没错，两个不一样的element确实需要去更新，所以有pureComponet或者 Memo解决方案

但是，很多静态的东西我们想直接做一层，elemnt缓存，去解决性能问题的方案，但是相信很少人会这么写
```
const A = <div />
render(A) 
render(A)  // 期望不在执行任何diff操作 
```

虽然很少可能这么去写，但是无感于用户，element缓存可以在框架层面做，
比如react-redux最新版本中，用了这个策略 [相关代码](https://github.com/reduxjs/react-redux/blob/master/src/components/connectAdvanced.js#L171),  基于这个启发，感觉这个特性还是非常有用的