### PR TITLE
fix: native map android drop route after update

### DIFF
--- a/packages/atag/src/components/image/index.js
+++ b/packages/atag/src/components/image/index.js
@@ -6,6 +6,7 @@ const UNSENT = 0;
 const LOADING = 1;
 const DONE = 2;
 const IS_HTTP_REG = /^(https?:)?\/{2}/;
+const IS_BASE64_DATA_REG = /^data:/;
 /**
  * Local files:
  *   eg: /foo/bar.png
@@ -103,7 +104,7 @@ export default class ImageElement extends PolymerElement {
     const fileSchemaPrefix = getFileSchemaPrefix() || '';
     if (IS_ABS_REG.test(this.src)) {
       return fileSchemaPrefix + this.src;
-    } else if (IS_HTTP_REG.test(this.src)) {
+    } else if (IS_HTTP_REG.test(this.src) || IS_BASE64_DATA_REG.test(this.src)) {
       return this.src;
     } else {
       return fileSchemaPrefix + '/' + this.src;

--- a/packages/atag/src/components/map/map.native.js
+++ b/packages/atag/src/components/map/map.native.js
@@ -237,6 +237,10 @@ export default class NativeMap extends PolymerElement {
         this._callNativeControl('zoomTo', { zoomLevel: value });
         break;
 
+      case 'includePoints':
+        this._callNativeControl('animateBounds', value);
+        break;
+
       case 'route-config':
         this._callNativeControl('drawRoute', {
           routeStart: this.routeStart,
@@ -267,6 +271,13 @@ export default class NativeMap extends PolymerElement {
       'show-location': this.showLocation,
       'show-map-text': this.showMapText,
     });
+    /**
+     * Update will clean all items on map, route-config as same.
+     * Call drawing route after updated.
+     */
+    if (this.routeStart && this.routeEnd) {
+      this._updateParamWithAndroid('route-config');
+    }
   }
 
 

--- a/packages/atag/src/components/map/map.native.js
+++ b/packages/atag/src/components/map/map.native.js
@@ -211,7 +211,7 @@ export default class NativeMap extends PolymerElement {
   }
 
   _observeRouteConfig() {
-    this._createOrUpdateParam('route-config', {
+    this._createOrUpdateParam('routeConfig', {
       'route-start': this.routeStart,
       'route-end': this.routeEnd,
       'route-width': this.routeWidth,
@@ -241,7 +241,7 @@ export default class NativeMap extends PolymerElement {
         this._callNativeControl('animateBounds', value);
         break;
 
-      case 'route-config':
+      case 'routeConfig':
         this._callNativeControl('drawRoute', {
           routeStart: this.routeStart,
           routeEnd: this.routeEnd,


### PR DESCRIPTION
统一用 camelcase 调用 api, 对 attribute 在创建节点的时候转换为 kebabCase
...
修复 安卓 调用 update 后会清除所有导航路径的问题: 在update 之后再调用一次 drawRoute