### PR TITLE
自动轮播的时候 调用slideTo 有bug

### DIFF
--- a/components/rax-slider/src/index.js
+++ b/components/rax-slider/src/index.js
@@ -20,6 +20,7 @@ class Slider extends Component {
   }
 
   onChange = (e) => {
+    this.setState({index:e.currentTarget.attr.index});
     this.props.onChange(e);
   }
 


### PR DESCRIPTION
设置自动轮播的时候, 组件内部的state值并没有和当前轮播的索引值同步进行改变, 导致调用slideTo方法的时候传入了一个和当前state.index 一样的值的时候，轮播并不会发生切换

*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).
5. Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.
