### PR TITLE
fix: mp get array binding

### DIFF
--- a/packages/mp-loader/package.json
+++ b/packages/mp-loader/package.json
@@ -43,6 +43,7 @@
     "@babel/preset-env": "^7.0.0",
     "autoprefixer": "^9.3.1",
     "babel-loader": "^8.0.2",
+    "babylon": "^6.18.0",
     "css-loader": "^1.0.1",
     "miniapp-builder": "^0.1.11",
     "postcss": "^7.0.5",

--- a/packages/mp-loader/src/transpiler/__tests__/__snapshots__/template-transpiler.js.snap
+++ b/packages/mp-loader/src/transpiler/__tests__/__snapshots__/template-transpiler.js.snap
@@ -306,6 +306,41 @@ Object {
 }
 `;
 
+exports[`Transpiler parse should parse instant nested object expression 1`] = `
+Object {
+  "ast": Object {
+    "attrs": Array [
+      Object {
+        "name": "foo",
+        "scope": "",
+        "value": "(({
+  x: {
+    y: 2
+  }
+}))",
+      },
+    ],
+    "attrsList": Array [],
+    "attrsMap": Object {
+      "foo": "{{x:{y:2}}}",
+    },
+    "children": Array [],
+    "parent": undefined,
+    "plain": false,
+    "tag": "view",
+    "tagHelperMap": Object {
+      "view": "view",
+    },
+    "type": 1,
+  },
+  "render": "_c(__components_ref__['view']||'view',{foo:(({
+  x: {
+    y: 2
+  }
+}))})",
+}
+`;
+
 exports[`Transpiler parse should use a:for with other rules 1`] = `
 Object {
   "alias": "item",

--- a/packages/mp-loader/src/transpiler/__tests__/__snapshots__/template-transpiler.js.snap
+++ b/packages/mp-loader/src/transpiler/__tests__/__snapshots__/template-transpiler.js.snap
@@ -249,6 +249,63 @@ Object {
 
 exports[`Transpiler parse nested 2`] = `"_c(__components_ref__['view']||'view',{foo:\\"bar\\"},[_c(__components_ref__['text']||'text',[_v(\\"hello\\")]),_c(__components_ref__['text']||'text',[_v(\\"world\\")])])"`;
 
+exports[`Transpiler parse should parse instant array expression 1`] = `
+Object {
+  "alias": "item",
+  "attrs": Array [
+    Object {
+      "name": "empty",
+      "scope": "",
+      "value": "(1)",
+    },
+  ],
+  "attrsList": Array [],
+  "attrsMap": Object {
+    "a:for": "{{[{},{},{},{}]}}",
+    "empty": "{{1}}",
+  },
+  "children": Array [],
+  "for": "([{}, {}, {}, {}])",
+  "iterator1": "index",
+  "parent": undefined,
+  "plain": false,
+  "tag": "single-item",
+  "type": 1,
+}
+`;
+
+exports[`Transpiler parse should parse instant array expression 2`] = `
+Object {
+  "ast": Object {
+    "alias": "item",
+    "attrs": Array [
+      Object {
+        "name": "empty",
+        "scope": "",
+        "value": "(1)",
+      },
+    ],
+    "attrsList": Array [],
+    "attrsMap": Object {
+      "a:for": "{{[{},{},{},{}]}}",
+      "empty": "{{1}}",
+    },
+    "children": Array [],
+    "for": "([{}, {}, {}, {}])",
+    "forProcessed": true,
+    "iterator1": "index",
+    "parent": undefined,
+    "plain": false,
+    "tag": "single-item",
+    "tagHelperMap": Object {
+      "single-item": "single-item",
+    },
+    "type": 1,
+  },
+  "render": "_l.call(this,(([{}, {}, {}, {}])),function(item,index){return _c(__components_ref__['single-item']||'single-item',{empty:(1)})})",
+}
+`;
+
 exports[`Transpiler parse should use a:for with other rules 1`] = `
 Object {
   "alias": "item",

--- a/packages/mp-loader/src/transpiler/__tests__/template-transpiler.js
+++ b/packages/mp-loader/src/transpiler/__tests__/template-transpiler.js
@@ -1,8 +1,24 @@
 const { parse } = require('../parser');
 const generate = require('../generate');
 const modules = require('../transpileModules');
+const babylon = require('babylon');
 
 const transpilerOptions = { modules };
+
+/**
+ * Check whether a js string is valid.
+ */
+function checkValidJavaScriptStr(str) {
+  try {
+    babylon.parseExpression(str, {
+      allowImportExportEverywhere: true,
+      plugins: ['objectRestSpread'],
+    });
+  } catch (err) {
+    return false;
+  }
+  return true;
+}
 
 describe('Transpiler parse', () => {
   it('nested', () => {
@@ -105,5 +121,18 @@ describe('Transpiler parse', () => {
 
     const generated = generate(ast, transpilerOptions);
     expect(generated.render).toMatchSnapshot();
+  });
+
+  it('should parse instant array expression', () => {
+    const content = `
+      <single-item
+        a:for="{{[{},{},{},{}]}}"
+        empty="{{1}}"></single-item>
+    `;
+    const ast = parse(content, transpilerOptions);
+    // expect(ast).toMatchSnapshot();
+
+    const generated = generate(ast, transpilerOptions);
+    expect(checkValidJavaScriptStr(generated.render)).toBe(true);
   });
 });

--- a/packages/mp-loader/src/transpiler/__tests__/template-transpiler.js
+++ b/packages/mp-loader/src/transpiler/__tests__/template-transpiler.js
@@ -145,5 +145,5 @@ describe('Transpiler parse', () => {
     const generated = generate(ast, transpilerOptions);
     expect(checkValidJavaScriptStr(generated.render)).toBe(true);
     expect(generated).toMatchSnapshot();
-  })
+  });
 });

--- a/packages/mp-loader/src/transpiler/__tests__/template-transpiler.js
+++ b/packages/mp-loader/src/transpiler/__tests__/template-transpiler.js
@@ -130,9 +130,10 @@ describe('Transpiler parse', () => {
         empty="{{1}}"></single-item>
     `;
     const ast = parse(content, transpilerOptions);
-    // expect(ast).toMatchSnapshot();
+    expect(ast).toMatchSnapshot();
 
     const generated = generate(ast, transpilerOptions);
     expect(checkValidJavaScriptStr(generated.render)).toBe(true);
+    expect(generated).toMatchSnapshot();
   });
 });

--- a/packages/mp-loader/src/transpiler/__tests__/template-transpiler.js
+++ b/packages/mp-loader/src/transpiler/__tests__/template-transpiler.js
@@ -136,4 +136,14 @@ describe('Transpiler parse', () => {
     expect(checkValidJavaScriptStr(generated.render)).toBe(true);
     expect(generated).toMatchSnapshot();
   });
+
+  it('should parse instant nested object expression', () => {
+    const content = `
+      <view foo="{{x:{y:2}}}"></view>
+    `;
+    const ast = parse(content, transpilerOptions);
+    const generated = generate(ast, transpilerOptions);
+    expect(checkValidJavaScriptStr(generated.render)).toBe(true);
+    expect(generated).toMatchSnapshot();
+  })
 });

--- a/packages/mp-loader/src/transpiler/expression.js
+++ b/packages/mp-loader/src/transpiler/expression.js
@@ -9,7 +9,7 @@ function toLiteralString(str) {
 
 // not allow {{x:{y:1}}}
 // or use complex parser
-const expressionTagReg = /\{\{([^}]+)\}\}/g;
+const expressionTagReg = /{{(.*?)}}/g;
 const fullExpressionTagReg = /^\{\{([^}]+)\}\}$/;
 const spreadReg = /^\.\.\.[\w$_]/;
 const objReg = /^[\w$_](?:[\w$_\d\s]+)?:/;
@@ -122,6 +122,7 @@ function transformCode(code_, rmlScope, config) {
       }
     }
   };
+
   var expression = parseExpression(codeStr, babylonConfig);
   var start = expression.start,
     end = expression.end;

--- a/packages/mp-loader/src/transpiler/expression.js
+++ b/packages/mp-loader/src/transpiler/expression.js
@@ -165,7 +165,6 @@ function transformExpressionByPart(str_, scope, config) {
   if (!str.match(expressionTagReg)) {
     return [toLiteralString(str_)];
   }
-  console.log(str);
   var match = str.match(fullExpressionTagReg);
   if (match) {
     return [transformCode(match[1], scope, config)];

--- a/packages/mp-loader/src/transpiler/helpers.js
+++ b/packages/mp-loader/src/transpiler/helpers.js
@@ -90,8 +90,6 @@ function addHandler(el, name, value, modifiers, important, warn) {
 
 exports.getBindingAttr = getBindingAttr;
 function getBindingAttr(el, name, getStatic) {
-  const dynamicValue =
-    getAndRemoveAttr(el, ':' + name) || getAndRemoveAttr(el, 'v-bind:' + name);
   if (getStatic !== false) {
     const staticValue = getAndRemoveAttr(el, name);
     if (staticValue != null) {


### PR DESCRIPTION
原先对  `xx={{[{}]}}` 的提取正则有问题, 用 `.*` + 贪婪模式 实现兼容 `xx="{{a}} {{b}}` 和 `xx="{{[ {} ]}}"`