### PR TITLE
Refactor hook

### DIFF
--- a/packages/rax/src/__tests__/hooks.js
+++ b/packages/rax/src/__tests__/hooks.js
@@ -419,152 +419,153 @@ describe('hooks', () => {
     expect(container.childNodes[0].childNodes[0].data).toEqual('val');
   });
 
-  it('restarts the render function and applies the new updates on top', () => {
-    const container = createNodeElement('div');
-    function ScrollView({row: newRow}) {
-      let [isScrollingDown, setIsScrollingDown] = useState(false);
-      let [row, setRow] = useState(null);
+  describe('updates during the render phase', () => {
+    it('restarts the render function and applies the new updates on top', () => {
+      const container = createNodeElement('div');
+      function ScrollView({row: newRow}) {
+        let [isScrollingDown, setIsScrollingDown] = useState(false);
+        let [row, setRow] = useState(null);
 
-      if (row !== newRow) {
-        // Row changed since last render. Update isScrollingDown.
-        setIsScrollingDown(row !== null && newRow > row);
-        setRow(newRow);
+        if (row !== newRow) {
+          // Row changed since last render. Update isScrollingDown.
+          setIsScrollingDown(row !== null && newRow > row);
+          setRow(newRow);
+        }
+
+        return <div>{`Scrolling down: ${isScrollingDown}`}</div>;
       }
 
-      return <div>{`Scrolling down: ${isScrollingDown}`}</div>;
-    }
+      render(<ScrollView row={1} />, container);
+      expect(container.childNodes[0].childNodes[0].data).toEqual('Scrolling down: false');
+      render(<ScrollView row={5} />, container);
+      expect(container.childNodes[0].childNodes[0].data).toEqual('Scrolling down: true');
+      render(<ScrollView row={5} />, container);
+      expect(container.childNodes[0].childNodes[0].data).toEqual('Scrolling down: true');
+      render(<ScrollView row={10} />, container);
+      expect(container.childNodes[0].childNodes[0].data).toEqual('Scrolling down: true');
+      render(<ScrollView row={2} />, container);
+      expect(container.childNodes[0].childNodes[0].data).toEqual('Scrolling down: false');
+      render(<ScrollView row={2} />, container);
+      expect(container.childNodes[0].childNodes[0].data).toEqual('Scrolling down: false');
+    });
 
-    render(<ScrollView row={1} />, container);
-    expect(container.childNodes[0].childNodes[0].data).toEqual('Scrolling down: false');
-    render(<ScrollView row={5} />, container);
-    expect(container.childNodes[0].childNodes[0].data).toEqual('Scrolling down: true');
-    render(<ScrollView row={5} />, container);
-    expect(container.childNodes[0].childNodes[0].data).toEqual('Scrolling down: true');
-    render(<ScrollView row={10} />, container);
-    expect(container.childNodes[0].childNodes[0].data).toEqual('Scrolling down: true');
-    render(<ScrollView row={2} />, container);
-    expect(container.childNodes[0].childNodes[0].data).toEqual('Scrolling down: false');
-    render(<ScrollView row={2} />, container);
-    expect(container.childNodes[0].childNodes[0].data).toEqual('Scrolling down: false');
-  });
-
-  it('updates multiple times within same render function', () => {
-    const container = createNodeElement('div');
-    let logs = [];
-    function Counter({row: newRow}) {
-      let [count, setCount] = useState(0);
-      if (count < 12) {
-        setCount(c => c + 1);
-        setCount(c => c + 1);
-        setCount(c => c + 1);
+    it('updates multiple times within same render function', () => {
+      const container = createNodeElement('div');
+      let logs = [];
+      function Counter({row: newRow}) {
+        let [count, setCount] = useState(0);
+        if (count < 12) {
+          setCount(c => c + 1);
+          setCount(c => c + 1);
+          setCount(c => c + 1);
+        }
+        logs.push('Render: ' + count);
+        return <span>{count}</span>;
       }
-      logs.push('Render: ' + count);
-      return <span>{count}</span>;
-    }
 
-    render(<Counter />, container);
-    expect(logs).toEqual([
-      // Should increase by three each time
-      'Render: 0',
-      'Render: 3',
-      'Render: 6',
-      'Render: 9',
-      'Render: 12',
-    ]);
-    expect(container.childNodes[0].childNodes[0].data).toEqual('12');
-  });
+      render(<Counter />, container);
+      expect(logs).toEqual([
+        // Should increase by three each time
+        'Render: 0',
+        'Render: 3',
+        'Render: 6',
+        'Render: 9',
+        'Render: 12',
+      ]);
+      expect(container.childNodes[0].childNodes[0].data).toEqual('12');
+    });
 
-  it('works with useReducer', () => {
-    const container = createNodeElement('div');
-    let logs = [];
-    function reducer(state, action) {
-      return action === 'increment' ? state + 1 : state;
-    }
-    function Counter({row: newRow}) {
-      let [count, dispatch] = useReducer(reducer, 0);
-      if (count < 3) {
-        dispatch('increment');
+    it('works with useReducer', () => {
+      const container = createNodeElement('div');
+      let logs = [];
+      function reducer(state, action) {
+        return action === 'increment' ? state + 1 : state;
       }
-      logs.push('Render: ' + count);
-      return <span>{count}</span>;
-    }
-
-    render(<Counter />, container);
-    expect(logs).toEqual([
-      'Render: 0',
-      'Render: 1',
-      'Render: 2',
-      'Render: 3',
-    ]);
-    expect(container.childNodes[0].childNodes[0].data).toEqual('3');
-  });
-
-  it('uses reducer passed at time of render, not time of dispatch', () => {
-    const container = createNodeElement('div');
-    let logs = [];
-    // This test is a bit contrived but it demonstrates a subtle edge case.
-
-    // Reducer A increments by 1. Reducer B increments by 10.
-    function reducerA(state, action) {
-      switch (action) {
-        case 'increment':
-          return state + 1;
-        case 'reset':
-          return 0;
+      function Counter({row: newRow}) {
+        let [count, dispatch] = useReducer(reducer, 0);
+        if (count < 3) {
+          dispatch('increment');
+        }
+        logs.push('Render: ' + count);
+        return <span>{count}</span>;
       }
-    }
-    function reducerB(state, action) {
-      switch (action) {
-        case 'increment':
-          return state + 10;
-        case 'reset':
-          return 0;
-      }
-    }
 
-    function Counter({row: newRow}, ref) {
-      let [reducer, setReducer] = useState(() => reducerA);
-      let [count, dispatch] = useReducer(reducer, 0);
-      useImperativeMethods(ref, () => ({dispatch}));
-      if (count < 20) {
-        dispatch('increment');
-        // Swap reducers each time we increment
-        if (reducer === reducerA) {
-          setReducer(() => reducerB);
-        } else {
-          setReducer(() => reducerA);
+      render(<Counter />, container);
+      expect(logs).toEqual([
+        'Render: 0',
+        'Render: 1',
+        'Render: 2',
+        'Render: 3',
+      ]);
+      expect(container.childNodes[0].childNodes[0].data).toEqual('3');
+    });
+
+    it('uses reducer passed at time of render, not time of dispatch', () => {
+      const container = createNodeElement('div');
+      let logs = [];
+      // This test is a bit contrived but it demonstrates a subtle edge case.
+
+      // Reducer A increments by 1. Reducer B increments by 10.
+      function reducerA(state, action) {
+        switch (action) {
+          case 'increment':
+            return state + 1;
+          case 'reset':
+            return 0;
         }
       }
-      logs.push('Render: ' + count);
-      return <span>{count}</span>;
-    }
-    Counter = forwardRef(Counter);
-    const counter = createRef(null);
-    render(<Counter ref={counter} />, container);
-    expect(logs).toEqual([
-      // The count should increase by alternating amounts of 10 and 1
-      // until we reach 21.
-      'Render: 0',
-      'Render: 10',
-      'Render: 11',
-      'Render: 21',
-    ]);
-    expect(container.childNodes[0].childNodes[0].data).toEqual('21');
-    logs = [];
+      function reducerB(state, action) {
+        switch (action) {
+          case 'increment':
+            return state + 10;
+          case 'reset':
+            return 0;
+        }
+      }
+      function Counter({row: newRow}, ref) {
+        let [reducer, setReducer] = useState(() => reducerA);
+        let [count, dispatch] = useReducer(reducer, 0);
+        useImperativeMethods(ref, () => ({dispatch}));
+        if (count < 20) {
+          dispatch('increment');
+          // Swap reducers each time we increment
+          if (reducer === reducerA) {
+            setReducer(() => reducerB);
+          } else {
+            setReducer(() => reducerA);
+          }
+        }
+        logs.push('Render: ' + count);
+        return <span>{count}</span>;
+      }
+      Counter = forwardRef(Counter);
+      const counter = createRef(null);
+      render(<Counter ref={counter} />, container);
+      expect(logs).toEqual([
+        // The count should increase by alternating amounts of 10 and 1
+        // until we reach 21.
+        'Render: 0',
+        'Render: 10',
+        'Render: 11',
+        'Render: 21',
+      ]);
+      expect(container.childNodes[0].childNodes[0].data).toEqual('21');
+      logs = [];
 
-    // Test that it works on update, too. This time the log is a bit different
-    // because we started with reducerB instead of reducerA.
-    counter.current.dispatch('reset');
-    // jest.runAllTimers();
-    logs = [];
-    render(<Counter ref={counter} />, container);
-    expect(logs).toEqual([
-      'Render: 0',
-      'Render: 1',
-      'Render: 11',
-      'Render: 12',
-      'Render: 22',
-    ]);
-    expect(container.childNodes[0].childNodes[0].data).toEqual('22');
+      // Test that it works on update, too. This time the log is a bit different
+      // because we started with reducerB instead of reducerA.
+      counter.current.dispatch('reset');
+      // jest.runAllTimers();
+      logs = [];
+      render(<Counter ref={counter} />, container);
+      expect(logs).toEqual([
+        'Render: 0',
+        'Render: 1',
+        'Render: 11',
+        'Render: 12',
+        'Render: 22',
+      ]);
+      expect(container.childNodes[0].childNodes[0].data).toEqual('22');
+    });
   });
 });

--- a/packages/rax/src/__tests__/hooks.js
+++ b/packages/rax/src/__tests__/hooks.js
@@ -475,6 +475,25 @@ describe('hooks', () => {
       expect(container.childNodes[0].childNodes[0].data).toEqual('12');
     });
 
+    it('throws after too many iterations', () => {
+      const container = createNodeElement('div');
+      let logs = [];
+      function Counter({row: newRow}) {
+        let [count, setCount] = useState(0);
+        setCount(count + 1);
+        logs.push('Render: ' + count);
+        return <span>{count}</span>;
+      }
+      // render(<Counter />, container);
+      expect(() => {
+        render(<Counter />, container);
+        jest.runAllTimers();
+      }).toThrowError(
+        'Too many re-renders. React limits the number of renders to prevent ' +
+          'an infinite loop.',
+      );
+    });
+
     it('works with useReducer', () => {
       const container = createNodeElement('div');
       let logs = [];

--- a/packages/rax/src/__tests__/hooks.js
+++ b/packages/rax/src/__tests__/hooks.js
@@ -489,7 +489,7 @@ describe('hooks', () => {
         render(<Counter />, container);
         jest.runAllTimers();
       }).toThrowError(
-        'Too many re-renders. React limits the number of renders to prevent ' +
+        'Too many re-renders. rax limits the number of renders to prevent ' +
           'an infinite loop.',
       );
     });

--- a/packages/rax/src/__tests__/hooks.js
+++ b/packages/rax/src/__tests__/hooks.js
@@ -568,4 +568,96 @@ describe('hooks', () => {
       expect(container.childNodes[0].childNodes[0].data).toEqual('22');
     });
   });
+
+  describe('useReducer', () => {
+    it('simple mount and update', () => {
+      const container = createNodeElement('div');
+      const INCREMENT = 'INCREMENT';
+      const DECREMENT = 'DECREMENT';
+
+      function reducer(state, action) {
+        switch (action) {
+          case 'INCREMENT':
+            return state + 1;
+          case 'DECREMENT':
+            return state - 1;
+          default:
+            return state;
+        }
+      }
+
+      function Counter(props, ref) {
+        const [count, dispatch] = useReducer(reducer, 0);
+        useImperativeMethods(ref, () => ({dispatch}));
+        return <span>{count}</span>;
+      }
+      Counter = forwardRef(Counter);
+      const counter = createRef(null);
+      render(<Counter ref={counter} />, container);
+      expect(container.childNodes[0].childNodes[0].data).toEqual('0');
+
+      counter.current.dispatch(INCREMENT);
+      jest.runAllTimers();
+      expect(container.childNodes[0].childNodes[0].data).toEqual('1');
+
+      counter.current.dispatch(DECREMENT);
+      counter.current.dispatch(DECREMENT);
+      counter.current.dispatch(DECREMENT);
+      jest.runAllTimers();
+      expect(container.childNodes[0].childNodes[0].data).toEqual('-2');
+
+      counter.current.dispatch(DECREMENT);
+      counter.current.dispatch(INCREMENT);
+      counter.current.dispatch(INCREMENT);
+      counter.current.dispatch(INCREMENT);
+      counter.current.dispatch(DECREMENT);
+      counter.current.dispatch(DECREMENT);
+      counter.current.dispatch(DECREMENT);
+      counter.current.dispatch(INCREMENT);
+      jest.runAllTimers();
+      expect(container.childNodes[0].childNodes[0].data).toEqual('-2');
+    });
+
+    it('accepts an initial action', () => {
+      const container = createNodeElement('div');
+      const INCREMENT = 'INCREMENT';
+      const DECREMENT = 'DECREMENT';
+
+      function reducer(state, action) {
+        switch (action) {
+          case 'INITIALIZE':
+            return 10;
+          case 'INCREMENT':
+            return state + 1;
+          case 'DECREMENT':
+            return state - 1;
+          default:
+            return state;
+        }
+      }
+
+      const initialAction = 'INITIALIZE';
+
+      function Counter(props, ref) {
+        const [count, dispatch] = useReducer(reducer, 0, initialAction);
+        useImperativeMethods(ref, () => ({dispatch}));
+        return <span>{count}</span>;
+      }
+      Counter = forwardRef(Counter);
+      const counter = createRef(null);
+      render(<Counter ref={counter} />, container);
+      jest.runAllTimers();
+      expect(container.childNodes[0].childNodes[0].data).toEqual('10');
+
+      counter.current.dispatch(INCREMENT);
+      jest.runAllTimers();
+      expect(container.childNodes[0].childNodes[0].data).toEqual('11');
+
+      counter.current.dispatch(DECREMENT);
+      counter.current.dispatch(DECREMENT);
+      counter.current.dispatch(DECREMENT);
+      jest.runAllTimers();
+      expect(container.childNodes[0].childNodes[0].data).toEqual('8');
+    });
+  });
 });

--- a/packages/rax/src/hooks.js
+++ b/packages/rax/src/hooks.js
@@ -45,8 +45,9 @@ export function useState(initialState) {
 
       if (newState !== current) {
         hooks[hookId][0] = newState;
+        // This is a render phase update.  After this render pass, we'll restart
         if (Host.component && Host.component._instance === currentInstance) {
-          currentInstance.didScheduleRenderPhaseUpdate = true;
+          currentInstance.isRenderScheduled = true;
         } else {
           currentInstance.update();
         }
@@ -193,10 +194,13 @@ export function useReducer(reducer, initialState, initialAction) {
 
     const dispatch = action => {
       const hook = hooks[hookId];
+      // reducer will get in the next render, before that we add all
+      // actions to the queue
       const queue = hook[2];
       queue.push(action);
+      // This is a render phase update.  After this render pass, we'll restart
       if (Host.component && Host.component._instance === currentInstance) {
-        currentInstance.didScheduleRenderPhaseUpdate = true;
+        currentInstance.isRenderScheduled = true;
       } else {
         currentInstance.update();
       }

--- a/packages/rax/src/hooks.js
+++ b/packages/rax/src/hooks.js
@@ -193,8 +193,8 @@ export function useReducer(reducer, initialState, initialAction) {
 
     const dispatch = action => {
       const hook = hooks[hookId];
-      hook[2] = action;
-
+      const queue = hook[2];
+      queue.push(action);
       if (Host.component && Host.component._instance === currentInstance) {
         currentInstance.didScheduleRenderPhaseUpdate = true;
       } else {
@@ -205,11 +205,16 @@ export function useReducer(reducer, initialState, initialAction) {
     return hooks[hookId] = [
       initialState,
       dispatch,
-      initialAction
+      []
     ];
   }
   const hook = hooks[hookId];
-  const next = reducer(hook[0], hook[2]);
+  const queue = hook[2];
+  let next = hook[0];
+  for (let i = 0; i < queue.length; i++) {
+    next = reducer(next, queue[i]);
+  }
   hook[0] = next;
+  hook[2] = [];
   return hooks[hookId];
 }

--- a/packages/rax/src/vdom/reactive.js
+++ b/packages/rax/src/vdom/reactive.js
@@ -105,19 +105,20 @@ class ReactiveComponent extends Component {
       Host.measurer && Host.measurer.beforeRender();
     }
     this.hooksIndex = 0;
+    this.numberOfReRenders = 0;
+    this.didScheduleRenderPhaseUpdate = false;
     let children = this.pureRender(this.props, this.forwardRef ? this.forwardRef : this.context);
     while (this.didScheduleRenderPhaseUpdate) {
-      this.hooksIndex = 0;
-      this.didScheduleRenderPhaseUpdate = false;
       this.numberOfReRenders++;
       if (this.numberOfReRenders > RE_RENDER_LIMIT) {
-        this.numberOfReRenders = 0;
         throw new Error('Too many re-renders. React limits the number of renders to prevent ' +
         'an infinite loop.');
       }
+
+      this.hooksIndex = 0;
+      this.didScheduleRenderPhaseUpdate = false;
       children = this.pureRender(this.props, this.forwardRef ? this.forwardRef : this.context);
     }
-    this.numberOfReRenders = 0;
     return children;
   }
 }

--- a/packages/rax/src/vdom/reactive.js
+++ b/packages/rax/src/vdom/reactive.js
@@ -15,6 +15,7 @@ class ReactiveComponent extends Component {
     this.didMountHandlers = [];
     this.didUpdateHandlers = [];
     this.willUnmountHandlers = [];
+    this.didScheduleRenderPhaseUpdate = false;
 
     if (pureRender.forwardRef) {
       this.prevForwardRef = this.forwardRef = ref;
@@ -102,7 +103,13 @@ class ReactiveComponent extends Component {
       Host.measurer && Host.measurer.beforeRender();
     }
     this.hooksIndex = 0;
-    return this.pureRender(this.props, this.forwardRef ? this.forwardRef : this.context);
+    let children = this.pureRender(this.props, this.forwardRef ? this.forwardRef : this.context);
+    while (this.didScheduleRenderPhaseUpdate) {
+      this.hooksIndex = 0;
+      this.didScheduleRenderPhaseUpdate = false;
+      children = this.pureRender(this.props, this.forwardRef ? this.forwardRef : this.context);
+    }
+    return children;
   }
 }
 

--- a/packages/rax/src/vdom/reactive.js
+++ b/packages/rax/src/vdom/reactive.js
@@ -2,6 +2,7 @@ import Host from './host';
 import Component from '../component';
 import { scheduleImmediateCallback } from '../scheduler';
 
+const RE_RENDER_LIMIT = 25;
 /**
  * Functional Reactive Component Class Wrapper
  */
@@ -16,6 +17,7 @@ class ReactiveComponent extends Component {
     this.didUpdateHandlers = [];
     this.willUnmountHandlers = [];
     this.didScheduleRenderPhaseUpdate = false;
+    this.numberOfReRenders = 0;
 
     if (pureRender.forwardRef) {
       this.prevForwardRef = this.forwardRef = ref;
@@ -107,6 +109,12 @@ class ReactiveComponent extends Component {
     while (this.didScheduleRenderPhaseUpdate) {
       this.hooksIndex = 0;
       this.didScheduleRenderPhaseUpdate = false;
+      this.numberOfReRenders++;
+      if (this.numberOfReRenders > RE_RENDER_LIMIT) {
+        this.numberOfReRenders = 0;
+        throw new Error('Too many re-renders. React limits the number of renders to prevent ' +
+        'an infinite loop.');
+      }
       children = this.pureRender(this.props, this.forwardRef ? this.forwardRef : this.context);
     }
     return children;

--- a/packages/rax/src/vdom/reactive.js
+++ b/packages/rax/src/vdom/reactive.js
@@ -16,7 +16,7 @@ class ReactiveComponent extends Component {
     this.didMountHandlers = [];
     this.didUpdateHandlers = [];
     this.willUnmountHandlers = [];
-    this.didScheduleRenderPhaseUpdate = false;
+    this.isRenderScheduled = false;
     this.numberOfReRenders = 0;
 
     if (pureRender.forwardRef) {
@@ -79,10 +79,6 @@ class ReactiveComponent extends Component {
     return Provider.defaultValue;
   }
 
-  isComponentRendered() {
-    return Boolean(this._internal._renderedComponent);
-  }
-
   componentDidMount() {
     this.didMountHandlers.forEach(handler => handler());
   }
@@ -106,17 +102,17 @@ class ReactiveComponent extends Component {
     }
     this.hooksIndex = 0;
     this.numberOfReRenders = 0;
-    this.didScheduleRenderPhaseUpdate = false;
+    this.isRenderScheduled = false;
     let children = this.pureRender(this.props, this.forwardRef ? this.forwardRef : this.context);
-    while (this.didScheduleRenderPhaseUpdate) {
+    while (this.isRenderScheduled) {
       this.numberOfReRenders++;
       if (this.numberOfReRenders > RE_RENDER_LIMIT) {
-        throw new Error('Too many re-renders. React limits the number of renders to prevent ' +
+        throw new Error('Too many re-renders. rax limits the number of renders to prevent ' +
         'an infinite loop.');
       }
 
       this.hooksIndex = 0;
-      this.didScheduleRenderPhaseUpdate = false;
+      this.isRenderScheduled = false;
       children = this.pureRender(this.props, this.forwardRef ? this.forwardRef : this.context);
     }
     return children;

--- a/packages/rax/src/vdom/reactive.js
+++ b/packages/rax/src/vdom/reactive.js
@@ -117,6 +117,7 @@ class ReactiveComponent extends Component {
       }
       children = this.pureRender(this.props, this.forwardRef ? this.forwardRef : this.context);
     }
+    this.numberOfReRenders = 0;
     return children;
   }
 }

--- a/packages/rax/src/vdom/reactive.js
+++ b/packages/rax/src/vdom/reactive.js
@@ -2,7 +2,7 @@ import Host from './host';
 import Component from '../component';
 import { scheduleImmediateCallback } from '../scheduler';
 
-const RE_RENDER_LIMIT = 25;
+const RE_RENDER_LIMIT = 24;
 /**
  * Functional Reactive Component Class Wrapper
  */


### PR DESCRIPTION
主要解决两个问题：
1. fix: useReducer
在rax之前的实现中，function每次渲染中，无论useReducer中的reducer参数是否改变，dispatcher始终引用了初始闭包里面的reducer。但是仔细观察官方的实现中，reducer实时引用的是function执行时候传入的reducer，真正缓存的应该是state，而不是reducer。也就是说useReducer计算nextState是在渲染时，拿到最新的reducer才去计算，而不是在dispatcher阶段去计算。由于这里存在异步渲染的关系，把action放入队列中
2. 另外一个问题是在function执行的过程中，调度更新如何处理的问题，这里已经完全覆盖了官方的相关test