### PR TITLE
fix: hook useEffect schedule bug

### DIFF
--- a/packages/rax/src/__tests__/hooks.js
+++ b/packages/rax/src/__tests__/hooks.js
@@ -171,14 +171,14 @@ describe('hooks', () => {
     jest.runAllTimers();
     expect(logs).toEqual([
       'render', 'create2', 'create1',
-      'render', 'destory1', 'destory2', 'create2', 'create1']);
+      'render', 'destory2', 'create2', 'destory1', 'create1']);
 
     render(<Counter count={2} />, container);
     jest.runAllTimers();
     expect(logs).toEqual([
       'render', 'create2', 'create1',
-      'render', 'destory1', 'destory2', 'create2', 'create1',
-      'render', 'destory1', 'destory2', 'create2', 'create1']);
+      'render', 'destory2', 'create2', 'destory1', 'create1',
+      'render', 'destory2', 'create2', 'destory1', 'create1']);
   });
 
   it('mount and update a function component with useEffect', () => {
@@ -678,5 +678,28 @@ describe('hooks', () => {
       jest.runAllTimers();
       expect(container.childNodes[0].childNodes[0].data).toEqual('8');
     });
+  });
+
+
+  it('simple mount and update', () => {
+    const container = createNodeElement('div');
+    let logs = [];
+    function Counter(props) {
+      useEffect(() => {
+        logs.push(`Did commit [${props.count}]`);
+      });
+      return <span>{props.count}</span>;
+    }
+    render(<Counter count={0} />, container);
+    expect(container.childNodes[0].childNodes[0].data).toEqual('0');
+    jest.runAllTimers();
+    expect(logs).toEqual(['Did commit [0]']);
+
+    logs = [];
+    render(<Counter count={1} />, container);
+    expect(container.childNodes[0].childNodes[0].data).toEqual('1');
+    // Effects are deferred until after the commit
+    jest.runAllTimers();
+    expect(logs).toEqual(['Did commit [1]']);
   });
 });

--- a/packages/rax/src/hooks.js
+++ b/packages/rax/src/hooks.js
@@ -97,9 +97,6 @@ function useEffectImpl(effect, inputs, defered) {
       if (current) {
         current();
         destory.current = null;
-      } else if (defered) {
-        create(true);
-        destory(true);
       }
     };
 
@@ -117,7 +114,7 @@ function useEffectImpl(effect, inputs, defered) {
     currentInstance.didUpdateHandlers.push(() => {
       const { prevInputs, inputs, create } = hooks[hookId];
       if (prevInputs == null || !areInputsEqual(inputs, prevInputs)) {
-        destory(true);
+        destory();
         create();
       }
     });


### PR DESCRIPTION

fix: useEffect bug
useEffect 如果在 effect 没有返回的情况下，会爆栈

具体理由如下： [相关代码](https://github.com/alibaba/rax/blob/master/packages/rax/src/hooks.js#L100)

```js
} else if (defered) {
   create(true);
   destory(true);
}
```

useEffect情况下， defered为true,  一旦执行 destory(true) 发现陷入无限调用destory(true)了

为何之前会这么写？我猜应该是和   [这段代码](https://github.com/alibaba/rax/blob/master/packages/rax/src/hooks.js#L120) 有关
因为 mount 的时候 create 异步的，但是update的时候，我们先要destory之前mount的，但是之前mount的很明显还没创建，所以需要先ceate再destory

修改方案：useEffect整体走异步队列，这样的话，create 一定在destory之前

把 [test](https://github.com/alibaba/rax/blob/master/packages/rax/src/__tests__/hooks.js#L137) 修改了一下和官方的输出一致 [demo](https://codepen.io/anon/pen/XoYGPw?editors=0010)