### PR TITLE
fix: input & textarea's value duplex bind to property not attribute

### DIFF
--- a/packages/atag/src/components/input/index.js
+++ b/packages/atag/src/components/input/index.js
@@ -194,7 +194,7 @@ export default class Input extends PolymerElement {
       <input 
         id="input" 
         placeholder="[[placeholder]]" 
-        value$="[[value]]"
+        value="{{value}}"
         type$="[[type]]" 
         disabled$="[[disabled]]"
         autofocus$="[[focus]]" 

--- a/packages/atag/src/components/textarea/index.js
+++ b/packages/atag/src/components/textarea/index.js
@@ -305,7 +305,7 @@ export default class Textarea extends PolymerElement {
       <textarea 
         id="textarea"
         placeholder="[[placeholder]]"
-        value$="[[value]]"
+        value="{{value}}"
         disabled$="[[disabled]]"
         readonly$="[[readonly]]"
         autofocus$="[[focus]]"


### PR DESCRIPTION
原来是 attribute 单向, 应该是 property 双向.

- 如果是 attribute, 设置为空值的时候, input 组件不会响应内容的变化
- 如果是单向, input 变化的时候不会触发外层自定义组件变化

![image](https://user-images.githubusercontent.com/3922719/51114322-ebd32380-183f-11e9-8273-9d730f6dcfa1.png)
