### PR TITLE
fix: low severity

### DIFF
--- a/packages/rax-scripts/package.json
+++ b/packages/rax-scripts/package.json
@@ -78,7 +78,7 @@
     "uppercamelcase": "^3.0.0",
     "webpack": "^4.27.1",
     "webpack-bundle-analyzer": "^3.0.3",
-    "webpack-dev-server": "3.1.10",
+    "webpack-dev-server": ">=3.1.11",
     "webpack-manifest-plugin": "^2.0.4",
     "webpack-merge": "^4.1.5"
   }


### PR DESCRIPTION
An issue was discovered in lib/Server.js in webpack-dev-server before 3.1.11.
Attackers are able to steal developer's code because the origin of requests is not checked by the WebSocket server, which is used for HMR (Hot Module Replacement).
Anyone can receive the HMR message sent by the WebSocket server via a ws://127.0.0.1:8080/ connection from any origin.

See: https://github.com/alibaba/rax/network/alert/packages/rax-scripts/package.json/webpack-dev-server/open