### PR TITLE
fix: atag scroll-view scrollX/Y as property

### DIFF
--- a/packages/atag/src/components/scroll-view/__tests__/scroll-view.html
+++ b/packages/atag/src/components/scroll-view/__tests__/scroll-view.html
@@ -1,0 +1,1 @@
+<a-scroll-view id="scrollView"></a-scroll-view>

--- a/packages/atag/src/components/scroll-view/__tests__/scroll-view.js
+++ b/packages/atag/src/components/scroll-view/__tests__/scroll-view.js
@@ -1,0 +1,43 @@
+const timeout = 10000;
+
+describe('scroll-view', () => {
+  const pages = [];
+  async function createPage() {
+    const page = await global.__BROWSER__.newPage();
+    await page.setViewport(global.__VIEWPORT__);
+    await page.goto('http://localhost:9002/components/scroll-view/__tests__/scroll-view.html');
+    pages.push(page);
+    return page;
+  }
+
+  afterAll(async() => {
+    for (let i = 0, l = pages.length; i < l; i ++) {
+      await pages[i].close();
+    }
+  });
+
+  it('prevent property', async() => {
+    const page = await createPage();
+    await page.addScriptTag({
+      content: `
+          const scrollView = document.getElementById('scrollView');
+          scrollView.scrollX = true;
+          scrollView.scrollY = false;
+          scrollView._prevent = true;
+        `,
+    });
+    const scrollViewHandle = await page.$('#scrollView');
+    const overflowX = await page.evaluate(el => el.style.overflowX, scrollViewHandle);
+    const overflowY = await page.evaluate(el => el.style.overflowY, scrollViewHandle);
+    const scrollX = await page.evaluate(el => el.scrollX, scrollViewHandle);
+    const scrollY = await page.evaluate(el => el.scrollY, scrollViewHandle);
+    // overflowX/Y are overrided.
+    expect(overflowX).toEqual('hidden');
+    expect(overflowY).toEqual('hidden');
+    // scrollX and scrollY property dones't changed.
+    expect(scrollX).toEqual(true);
+    expect(scrollY).toEqual(false);
+  });
+},
+timeout
+);

--- a/packages/atag/src/components/scroll-view/__tests__/scroll-view.js
+++ b/packages/atag/src/components/scroll-view/__tests__/scroll-view.js
@@ -27,12 +27,27 @@ describe('scroll-view', () => {
         `,
     });
     const scrollViewHandle = await page.$('#scrollView');
-    const overflowX = await page.evaluate(el => el.style.overflowX, scrollViewHandle);
-    const overflowY = await page.evaluate(el => el.style.overflowY, scrollViewHandle);
-    const scrollX = await page.evaluate(el => el.scrollX, scrollViewHandle);
-    const scrollY = await page.evaluate(el => el.scrollY, scrollViewHandle);
+    let overflowX = await page.evaluate(el => el.style.overflowX, scrollViewHandle);
+    let overflowY = await page.evaluate(el => el.style.overflowY, scrollViewHandle);
+    let scrollX = await page.evaluate(el => el.scrollX, scrollViewHandle);
+    let scrollY = await page.evaluate(el => el.scrollY, scrollViewHandle);
     // overflowX/Y are overrided.
     expect(overflowX).toEqual('hidden');
+    expect(overflowY).toEqual('hidden');
+    // scrollX and scrollY property dones't changed.
+    expect(scrollX).toEqual(true);
+    expect(scrollY).toEqual(false);
+
+    // Restore prevent
+    await page.addScriptTag({
+      content: `scrollView._prevent = false;`,
+    });
+    overflowX = await page.evaluate(el => el.style.overflowX, scrollViewHandle);
+    overflowY = await page.evaluate(el => el.style.overflowY, scrollViewHandle);
+    scrollX = await page.evaluate(el => el.scrollX, scrollViewHandle);
+    scrollY = await page.evaluate(el => el.scrollY, scrollViewHandle);
+    // overflowX/Y are restored.
+    expect(overflowX).toEqual('auto');
     expect(overflowY).toEqual('hidden');
     // scrollX and scrollY property dones't changed.
     expect(scrollX).toEqual(true);

--- a/packages/atag/src/components/scroll-view/index.js
+++ b/packages/atag/src/components/scroll-view/index.js
@@ -98,9 +98,13 @@ export default class ScrollViewElement extends PolymerElement {
       get: () => _prevent,
       set: (val) => {
         _prevent = val;
-        // Recalc computed properties.
-        this.scrollX = this._getBoolPropFromAttr('scroll-x', this.scrollX);
-        this.scrollY = this._getBoolPropFromAttr('scroll-y', this.scrollY);
+        // If prevented, stop scroll by overrides CSS overflow.
+        if (val) {
+          this.style.overflowX = this.style.overflowY = 'hidden';
+        } else {
+          this.style.overflowX = this.scrollX ? 'auto' : 'hidden';
+          this.style.overflowY = this.scrollY ? 'auto' : 'hidden';
+        }
       }
     });
   }


### PR DESCRIPTION
prevent setter 不应该覆盖 this.scrollX 和 this.scrollY, 这样就没办法恢复了