### PR TITLE
chore: rename useImperativeMethods -> useImperativeHandle

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,11 +249,11 @@ render(<Hello name="world" />, document.body, { driver: DomDriver });
     );
   }
   ```
-* useImperativeMethods()
+* useImperativeHandle()
   ```jsx
   function FancyInput(props, ref) {
     const inputRef = useRef();
-    useImperativeMethods(ref, () => ({
+    useImperativeHandle(ref, () => ({
       focus: () => {
         inputRef.current.focus();
       }

--- a/packages/rax/src/__tests__/hooks.js
+++ b/packages/rax/src/__tests__/hooks.js
@@ -5,7 +5,7 @@ import Host from '../vdom/host';
 import render from '../render';
 import ServerDriver from 'driver-server';
 import createContext from '../createContext';
-import {useState, useContext, useEffect, useLayoutEffect, useRef, useReducer, useImperativeMethods} from '../hooks';
+import {useState, useContext, useEffect, useLayoutEffect, useRef, useReducer, useImperativeHandle} from '../hooks';
 import { flushPassiveEffects } from '../vdom/updater';
 import forwardRef from '../forwardRef';
 import createRef from '../createRef';
@@ -526,7 +526,7 @@ describe('hooks', () => {
       function Counter({row: newRow}, ref) {
         let [reducer, setReducer] = useState(() => reducerA);
         let [count, dispatch] = useReducer(reducer, 0);
-        useImperativeMethods(ref, () => ({dispatch}));
+        useImperativeHandle(ref, () => ({dispatch}));
         if (count < 20) {
           dispatch('increment');
           // Swap reducers each time we increment
@@ -586,7 +586,7 @@ describe('hooks', () => {
 
       function Counter(props, ref) {
         const [count, dispatch] = useReducer(reducer, 0);
-        useImperativeMethods(ref, () => ({dispatch}));
+        useImperativeHandle(ref, () => ({dispatch}));
         return <span>{count}</span>;
       }
       Counter = forwardRef(Counter);
@@ -635,7 +635,7 @@ describe('hooks', () => {
 
       function Counter(props, ref) {
         const [count, dispatch] = useReducer(reducer, 0, initialAction);
-        useImperativeMethods(ref, () => ({dispatch}));
+        useImperativeHandle(ref, () => ({dispatch}));
         return <span>{count}</span>;
       }
       Counter = forwardRef(Counter);

--- a/packages/rax/src/hooks.js
+++ b/packages/rax/src/hooks.js
@@ -139,7 +139,7 @@ function useEffectImpl(effect, inputs, defered) {
   }
 }
 
-export function useImperativeMethods(ref, create, inputs) {
+export function useImperativeHandle(ref, create, inputs) {
   const nextInputs = inputs != null ? inputs.concat([ref]) : [ref, create];
 
   useLayoutEffect(() => {

--- a/packages/rax/src/index.d.ts
+++ b/packages/rax/src/index.d.ts
@@ -719,14 +719,14 @@ declare namespace Rax {
   function useEffect(effect: EffectCallback, inputs?: InputIdentityList): void;
   // NOTE: this does not accept strings, but this will have to be fixed by removing strings from type Ref<T>
   /**
-   * `useImperativeMethods` customizes the instance value that is exposed to parent components when using
+   * `useImperativeHandle` customizes the instance value that is exposed to parent components when using
    * `ref`. As always, imperative code using refs should be avoided in most cases.
    *
-   * `useImperativeMethods` should be used with `Rax.forwardRef`.
+   * `useImperativeHandle` should be used with `Rax.forwardRef`.
    *
    * @version experimental
    */
-  function useImperativeMethods<T, R extends T>(ref: Ref<T>|undefined, init: () => R, inputs?: InputIdentityList): void;
+  function useImperativeHandle<T, R extends T>(ref: Ref<T>|undefined, init: () => R, inputs?: InputIdentityList): void;
   // I made 'inputs' required here and in useMemo as there's no point to memoizing without the memoization key
   // useCallback(X) is identical to just using X, useMemo(() => Y) is identical to just using Y.
   /**

--- a/packages/rax/src/index.js
+++ b/packages/rax/src/index.js
@@ -2,7 +2,7 @@ import './debug/devtools';
 import createElement from './createElement';
 import createContext from './createContext';
 import createRef from './createRef';
-import {useState, useContext, useEffect, useLayoutEffect, useRef, useCallback, useMemo, useReducer, useImperativeMethods} from './hooks';
+import {useState, useContext, useEffect, useLayoutEffect, useRef, useCallback, useMemo, useReducer, useImperativeHandle} from './hooks';
 import memo from './memo';
 import Fragment from './fragment';
 import render from './render';
@@ -10,7 +10,7 @@ import version from './version';
 
 export {
   createElement, createRef, createContext,
-  useState, useContext, useEffect, useLayoutEffect, useRef, useCallback, useMemo, useReducer, useImperativeMethods,
+  useState, useContext, useEffect, useLayoutEffect, useRef, useCallback, useMemo, useReducer, useImperativeHandle,
   Fragment, memo,
   render,
   version
@@ -18,7 +18,7 @@ export {
 
 export default {
   createElement, createRef, createContext,
-  useState, useContext, useEffect, useLayoutEffect, useRef, useCallback, useMemo, useReducer, useImperativeMethods,
+  useState, useContext, useEffect, useLayoutEffect, useRef, useCallback, useMemo, useReducer, useImperativeHandle,
   Fragment, memo,
   render,
   version


### PR DESCRIPTION
官方已经把useImperativeMethods改成useImperativeHandle了，这里同步一下

[相关pr](https://github.com/facebook/react/pull/14565/files)
