### PR TITLE
fix: atag textarea

### DIFF
--- a/packages/atag/src/components/textarea/index.js
+++ b/packages/atag/src/components/textarea/index.js
@@ -280,6 +280,20 @@ export default class Textarea extends PolymerElement {
           -webkit-user-select: auto;
           user-select: auto;
           
+          /**
+           * Reset webkit appearance in iOS.
+           */
+          -webkit-appearance: none;
+          appearance: none;
+          
+          /**
+           * Some special properties in textarea is not default,
+           * reset these props to fix unset all.
+           */
+          -webkit-nbsp-mode: space;
+          line-break: after-white-space;
+          white-space: pre-wrap;
+          
           display: block;
           outline: none;
           border: none;


### PR DESCRIPTION
一些 textarea 默认的属性被 unset: all 覆盖了. 重新重置回来.

white-space 重置引起以下问题: 

![image](https://user-images.githubusercontent.com/3922719/51813027-1b2d6a00-22ef-11e9-9f0a-80b70c77e3b8.png)
