### PR TITLE
Fix driver worker

### DIFF
--- a/packages/driver-worker/src/worker/Event.js
+++ b/packages/driver-worker/src/worker/Event.js
@@ -13,6 +13,11 @@ export default class Event {
     this._end = true;
   }
   preventDefault() {
-    this.defaultPrevented = true;
+    if (this.cancelable) {
+      this.defaultPrevented = true;
+    } else {
+      // Calling preventDefault in uncancelable event should produce errors,
+      // but in chrome and safari, which not throw or console errors, follow behaviors here.
+    }
   }
 }

--- a/packages/driver-worker/src/worker/EventTarget.js
+++ b/packages/driver-worker/src/worker/EventTarget.js
@@ -51,12 +51,13 @@ export default class EventTarget {
     let i;
     do {
       listeners = target._eventListeners && target._eventListeners[type];
-      if (listeners)
+      if (listeners) {
         for (i = listeners.length; i--;) {
           if ((listeners[i].call(target, event) === false || event._end) && cancelable) break;
         }
+      }
     } while (
-      event.bubbles && !cancelable &&
+      event.bubbles && !event.defaultPrevented &&
       (event.currentTarget = target = target.parentNode)
     );
     return !event.defaultPrevented;

--- a/packages/driver-worker/src/worker/__tests__/event.js
+++ b/packages/driver-worker/src/worker/__tests__/event.js
@@ -25,8 +25,12 @@ describe('Event', () => {
   });
 
   it('preventDefault', () => {
-    const event = new Event('input');
-    event.preventDefault();
-    expect(event.defaultPrevented).toEqual(true);
+    const cancelableEvent = new Event('input', { cancelable: true });
+    cancelableEvent.preventDefault();
+    expect(cancelableEvent.defaultPrevented).toEqual(true);
+
+    const uncancelableEvent = new Event('input', { cancelable: false });
+    uncancelableEvent.preventDefault();
+    expect(uncancelableEvent.defaultPrevented).toEqual(false);
   });
 });

--- a/packages/driver-worker/src/worker/__tests__/eventTarget.js
+++ b/packages/driver-worker/src/worker/__tests__/eventTarget.js
@@ -43,7 +43,7 @@ describe('EventTarget', () => {
     eventTarget1.addEventListener('foo', (evt) => {
       done();
     });
-    eventTarget2.dispatchEvent(new Event('foo', { bubbles: true }));
+    eventTarget2.dispatchEvent(new Event('foo', { bubbles: true, cancelable: true }));
   });
 
   it('stopPropagation', (done) => {


### PR DESCRIPTION
1. 事件冒泡的判断逻辑问题, cancelable 是是否允许 cancel 的状态, 不应该作为事件是否继续冒泡的判断条件
2. 样式处理的问题, style 节点添加到父级节点可以被阻止, style 的子节点(textNode) 没有考虑, 目前导致text节点可能从父节点 remove