### PR TITLE
fix: nested scroll-view

### DIFF
--- a/packages/atag/src/components/scroll-view/__tests__/nested.html
+++ b/packages/atag/src/components/scroll-view/__tests__/nested.html
@@ -1,0 +1,30 @@
+<a-scroll-view id="scrollView" scroll-y="true" class="outer">
+  <a-scroll-view id="scrollViewNested" scroll-y="true" class="inner">
+    <a-view class="content"></a-view>
+  </a-scroll-view>
+</a-scroll-view>
+
+<script>
+  const content = document.querySelector('.content');
+  content.innerHTML = '<a-view>Hello World</a-view>'.repeat(50) + 'END';
+</script>
+
+<style>
+  .outer {
+    background-color: red;
+    height: 400px;
+    width: 100vw;
+  }
+
+  .inner {
+    background-color: green;
+    height: 950px;
+    width: 80vw;
+    margin-top: 25px;
+    margin-left: 10vw;
+  }
+
+  .content {
+    height: 2000px;
+  }
+</style>

--- a/packages/atag/src/components/scroll-view/index.js
+++ b/packages/atag/src/components/scroll-view/index.js
@@ -167,9 +167,15 @@ export default class ScrollViewElement extends PolymerElement {
   }
 
   _handleTouchStart = (evt) => {
+    /**
+     * @Note: Same direction scroll-view handled by webview automaticlly.
+     * Otherwise, parent scroll-view overflow hidden, child scroll-view also stop scrolls.
+     */
     this._parentSameDirectionScrollElement = this._getNearestParentElement(
       this,
-      (el) => el._scrollable === true && el._scrollDirection === this._scrollDirection
+      (el) => el._scrollable === true
+        && el._scrollDirection === this._scrollDirection
+        && !el instanceof ScrollViewElement
     );
     if (this._parentSameDirectionScrollElement) {
       evt.stopPropagation();


### PR DESCRIPTION
scroll-view 嵌套情况下, 浏览器会自动处理嵌套的滚动情况, 如果额外把父层节点 overflow hidden, 会导致滑动起来是卡顿的