### PR TITLE
Hook update opt

### DIFF
--- a/packages/rax/src/vdom/reactive.js
+++ b/packages/rax/src/vdom/reactive.js
@@ -20,6 +20,8 @@ class ReactiveComponent extends Component {
     this.willUnmount = [];
     // Is render scheduled
     this.isScheduled = false;
+    this.didReceiveUpdate = false;
+    this.preChildren = null;
 
 
     if (pureRender.forwardRef) {
@@ -86,8 +88,16 @@ class ReactiveComponent extends Component {
     return Provider.defaultValue;
   }
 
+  componentWillMount() {
+    this.didReceiveUpdate = true;
+  }
+
   componentDidMount() {
     this.didMount.forEach(handler => handler());
+  }
+
+  componentWillReceiveProps() {
+    this.didReceiveUpdate = true;
   }
 
   componentDidUpdate() {
@@ -122,7 +132,12 @@ class ReactiveComponent extends Component {
       this.isScheduled = false;
       children = this._render(this.props, this.forwardRef ? this.forwardRef : this.context);
     }
-    return children;
+
+    if (this.didReceiveUpdate) {
+      this.preChildren = children;
+      this.didReceiveUpdate = false;
+    }
+    return this.preChildren;
   }
 }
 


### PR DESCRIPTION
react16官方对hook这块的优化思路看着挺有意思的，能在函数进行render的时候，对children进行bail out

react16 render时候，进行bail out比较容易，不往下这些逻辑就行，目前在rax上面实现思路为

1. 通过 componentWillMount 和  componentWillReceiveProps 判断是否是通过父更新带来的更新
2. setState的时候，把所有的状态都存储在eagerState里面（因为都是同步优先级）
3. 导出状态的时候，和之前的判断是否发生改变

通过element缓存，来到达不更新children的效果

这块可能在bath update的时候，比较有用，如果后面有考虑提供这种api，或者在effect中使用的话

