### PR TITLE
fix: style render should be called in render, not in constructor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 
 node_js:
   - "8"
-  - "11"
+  - "11.10.1"
 
 before_script:
   - npm run setup

--- a/packages/mp-runtime/src/createComponent.js
+++ b/packages/mp-runtime/src/createComponent.js
@@ -42,6 +42,23 @@ export default function createComponent(renderFactory, render, config, component
 
     constructor(props, context) {
       super(props, context);
+
+      /**
+       * One component's style can only be append once in each docuemnt(page).
+       * Use a flag in document object to mark.
+       */
+      if (context.$page && context.$page.vnode) {
+        const document = context.$page.vnode._document;
+        const styleFlag = document[STYLE_FLAG_KEY] = document[STYLE_FLAG_KEY] || {};
+        if (!styleFlag[componentPath] && cssText) {
+          styleFlag[componentPath] = true;
+          const cssTextNode = document.createTextNode(String(cssText));
+          const styleNode = document.createElement('style');
+          styleNode.appendChild(cssTextNode);
+          document.body.appendChild(styleNode);
+        }
+      }
+
       /**
        * If not defined `data` field in config,
        * then default val will be an empty plain object,
@@ -136,34 +153,7 @@ export default function createComponent(renderFactory, render, config, component
       }
     }
 
-    /**
-     * Render style node at first time render is called.
-     */
-    styleNodesRendered = false;
-    renderStyleOnce() {
-      /**
-       * Side effect operation only run once.
-       * One component's style can only be append once in each docuemnt(page).
-       * Use a flag in document object to mark.
-       */
-      if (this.styleNodesRendered === false && this.context.$page && this.context.$page.vnode) {
-        const document = this.context.$page.vnode._document;
-        const styleFlag = document[STYLE_FLAG_KEY] = document[STYLE_FLAG_KEY] || {};
-        if (!styleFlag[componentPath] && cssText) {
-          styleFlag[componentPath] = true;
-          const cssTextNode = document.createTextNode(String(cssText));
-          const styleNode = document.createElement('style');
-          styleNode.appendChild(cssTextNode);
-          document.body.appendChild(styleNode);
-        }
-      }
-      // Mark the rendered flag.
-      this.styleNodesRendered = true;
-    }
-
     render() {
-      this.renderStyleOnce();
-
       const { $slots, $id, props, data } = this.publicInstance;
       return templateRender.call(this.publicInstance, {
         $id, $slots, ...props, ...data

--- a/packages/mp-runtime/src/createPage.js
+++ b/packages/mp-runtime/src/createPage.js
@@ -256,12 +256,17 @@ export default function createPage(renderFactory, requireCoreModule, config = {}
      * Render style node at first time render is called.
      */
     styleNodesRendered = false;
-    render() {
+
+    renderStyleOnce() {
+      const styleLength = styleNodes.length;
       if (this.styleNodesRendered === false) {
-        let i = 0, l = styleNodes.length;
-        for (; i < l; i++) document.body.appendChild(styleNodes[i]);
-        styleNodes.styleNodesRendered = true;
+        for (let i = 0; i < styleLength; i++) document.body.appendChild(styleNodes[i]);
+        this.styleNodesRendered = true;
       }
+    }
+
+    render() {
+      this.renderStyleOnce();
       return render.call(this.pageInstance, this.state);
     }
   };

--- a/packages/mp-runtime/src/createPage.js
+++ b/packages/mp-runtime/src/createPage.js
@@ -73,13 +73,14 @@ export default function createPage(renderFactory, requireCoreModule, config = {}
   const { document, location, evaluator, pageQuery, pageName, clientId } = pageContext;
   const { getWebViewSource, getWebViewOnMessage } = renderFactory;
 
+  const styleNodes = [];
   if (Array.isArray(cssTexts)) {
     for (let i = 0, l = cssTexts.length; i < l; i++) {
       if (typeof cssTexts[i] === 'object') {
         const cssTextNode = document.createTextNode(cssTexts[i].toString());
         const styleNode = document.createElement('style');
         styleNode.appendChild(cssTextNode);
-        document.body.appendChild(styleNode);
+        styleNodes.push(styleNode);
       }
     }
   }
@@ -251,7 +252,16 @@ export default function createPage(renderFactory, requireCoreModule, config = {}
       }
     }
 
+    /**
+     * Render style node at first time render is called.
+     */
+    styleNodesRendered = false;
     render() {
+      if (this.styleNodesRendered === false) {
+        let i = 0, l = styleNodes.length;
+        for (; i < l; i++) document.body.appendChild(styleNodes[i]);
+        styleNodes.styleNodesRendered = true;
+      }
       return render.call(this.pageInstance, this.state);
     }
   };

--- a/packages/mp-runtime/src/createPage.js
+++ b/packages/mp-runtime/src/createPage.js
@@ -246,20 +246,17 @@ export default function createPage(renderFactory, requireCoreModule, config = {}
     styleNodesRendered = false;
     renderStyleOnce() {
       // Side effect operation only run once.
-      if (this.styleNodesRendered === false) {
-        if (Array.isArray(cssTexts)) {
-          for (let i = 0, l = cssTexts.length; i < l; i++) {
-            if (typeof cssTexts[i] === 'object') {
-              const cssTextNode = document.createTextNode(cssTexts[i].toString());
-              const styleNode = document.createElement('style');
-              styleNode.appendChild(cssTextNode);
-              document.body.appendChild(styleNode);
-            }
-          }
+      if (this.styleNodesRendered === false && Array.isArray(cssTexts)) {
+        for (let i = 0, l = cssTexts.length; i < l; i++) {
+          const cssText = typeof cssTexts[i] === 'object' ? cssTexts[i].toString() : String(cssTexts[i]);
+          const cssTextNode = document.createTextNode(cssText);
+          const styleNode = document.createElement('style');
+          styleNode.appendChild(cssTextNode);
+          document.body.appendChild(styleNode);
         }
-        // Mark the rendered flag.
-        this.styleNodesRendered = true;
       }
+      // Mark the rendered flag.
+      this.styleNodesRendered = true;
     }
 
     render() {

--- a/packages/mp-runtime/src/createPage.js
+++ b/packages/mp-runtime/src/createPage.js
@@ -73,18 +73,6 @@ export default function createPage(renderFactory, requireCoreModule, config = {}
   const { document, location, evaluator, pageQuery, pageName, clientId } = pageContext;
   const { getWebViewSource, getWebViewOnMessage } = renderFactory;
 
-  const styleNodes = [];
-  if (Array.isArray(cssTexts)) {
-    for (let i = 0, l = cssTexts.length; i < l; i++) {
-      if (typeof cssTexts[i] === 'object') {
-        const cssTextNode = document.createTextNode(cssTexts[i].toString());
-        const styleNode = document.createElement('style');
-        styleNode.appendChild(cssTextNode);
-        styleNodes.push(styleNode);
-      }
-    }
-  }
-
   const render = getWebViewSource
     ? (data) => {
       const url = getWebViewSource(data);
@@ -257,9 +245,18 @@ export default function createPage(renderFactory, requireCoreModule, config = {}
      */
     styleNodesRendered = false;
     renderStyleOnce() {
+      // Side effect operation only run once.
       if (this.styleNodesRendered === false) {
-        const styleLength = styleNodes.length;
-        for (let i = 0; i < styleLength; i++) document.body.appendChild(styleNodes[i]);
+        if (Array.isArray(cssTexts)) {
+          for (let i = 0, l = cssTexts.length; i < l; i++) {
+            if (typeof cssTexts[i] === 'object') {
+              const cssTextNode = document.createTextNode(cssTexts[i].toString());
+              const styleNode = document.createElement('style');
+              styleNode.appendChild(cssTextNode);
+              document.body.appendChild(styleNode);
+            }
+          }
+        }
         // Mark the rendered flag.
         this.styleNodesRendered = true;
       }

--- a/packages/mp-runtime/src/createPage.js
+++ b/packages/mp-runtime/src/createPage.js
@@ -256,11 +256,11 @@ export default function createPage(renderFactory, requireCoreModule, config = {}
      * Render style node at first time render is called.
      */
     styleNodesRendered = false;
-
     renderStyleOnce() {
-      const styleLength = styleNodes.length;
       if (this.styleNodesRendered === false) {
+        const styleLength = styleNodes.length;
         for (let i = 0; i < styleLength; i++) document.body.appendChild(styleNodes[i]);
+        // Mark the rendered flag.
         this.styleNodesRendered = true;
       }
     }


### PR DESCRIPTION
不应该在 createPage 的时候直接插入元素.  

createPage 是返回页面组件, 这个时候真正的渲染生命周期还没有被触发，导致目前可能出现的样式丢失。

修复: 在页面被第一次 render 被调用的时候