### PR TITLE
fix: forget to set index state when slider onchange

### DIFF
--- a/components/rax-slider/src/index.js
+++ b/components/rax-slider/src/index.js
@@ -20,6 +20,9 @@ class Slider extends Component {
   }
 
   onChange = (e) => {
+    this.setState({
+      index: e.index
+    });
     this.props.onChange(e);
   }
 


### PR DESCRIPTION
**Description**: Slider change without updating index state.
[**Online Example**](https://jsplayground.taobao.org/raxplayground/c2887d9d-5f00-4cdf-83e1-b33e96995ba1) 
**Reproduction**:
1. swipe to second slide
2. click first red view，call this.refs.slider.slideTo, but it doesn't work.