### PR TITLE
fix: reducer only exec once when reducer  set inner function component

### DIFF
--- a/packages/rax/src/hooks.js
+++ b/packages/rax/src/hooks.js
@@ -250,7 +250,7 @@ export function useReducer(reducer, initialArg, init) {
   const queue = hook[2];
   let next = hook[0];
 
-  if (currentInstance._reRenders > 0 || queue.eagerReducer != reducer) {
+  if (currentInstance._reRenders > 0) {
     for (let i = 0; i < queue.actions.length; i++) {
       next = reducer(next, queue.actions[i]);
     }


### PR DESCRIPTION
Current will exec twice when reducer direct set inner function component, this pr fix it:
```jsx
function init(initialCount) {
  return {count: initialCount};
}

function App({initialCount}) {
  const [state, dispatch] = useReducer(function reducer(state, action) {
   // Only exec once when dispatch new state
    console.log(action, state);
    switch (action.type) {
      case 'increment':
        return {count: state.count + 1};
      case 'decrement':
        return {count: state.count - 1};
      case 'reset':
        return init(action.payload);
      default:
        throw new Error();
    }
  }, initialCount, init);
  return (
    <>
      Count: {state.count}
      <button
        onClick={() => dispatch({type: 'reset', payload: initialCount})}>

        Reset
      </button>
      <button onClick={() => dispatch({type: 'increment'})}>+</button>
      <button onClick={() => dispatch({type: 'decrement'})}>-</button>
    </>
  );
}
```