### PR TITLE
fix(rax-scripts): command line option "--output-path" not working

### DIFF
--- a/packages/rax-scripts/src/config/path.config.js
+++ b/packages/rax-scripts/src/config/path.config.js
@@ -39,7 +39,7 @@ const nodePaths = (process.env.NODE_PATH || '')
 
 const paths = {
   appDirectory: appDirectory,
-  appBuild: resolveApp('build'),
+  appBuild: resolveApp(process.env.OUTPUT_PATH || 'build'),
   appDist: resolveApp('dist'),
   appPublic: resolveApp('public'),
   appHtml: resolveApp('public/index.html'),


### PR DESCRIPTION
The "--output-path" option of "rax-scripts" was not working. I've found the reason, and figured out a 
simple solution.

---
*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).
5. Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.
