### PR TITLE
perf: improve creating & removing performace

### DIFF
--- a/packages/rax/package.json
+++ b/packages/rax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A universal React-compatible render engine.",
   "license": "BSD-3-Clause",
   "main": "index.js",

--- a/packages/rax/src/vdom/native.js
+++ b/packages/rax/src/vdom/native.js
@@ -116,6 +116,7 @@ class NativeComponent extends BaseComponent {
       if (!shouldNotRemoveChild) {
         Host.driver.removeChild(this._nativeNode, this._parent);
       }
+      shouldNotRemoveChild = true;
     }
 
     this.unmountChildren(shouldNotRemoveChild);
@@ -134,7 +135,12 @@ class NativeComponent extends BaseComponent {
     let nextProps = nextElement.props;
 
     this.updateProperties(prevProps, nextProps);
-    this.updateChildren(nextProps.children, nextContext);
+
+    if (prevProps.children && prevProps.children.length === 0) {
+      this.mountChildren(nextProps.children, nextContext);
+    } else {
+      this.updateChildren(nextProps.children, nextContext);
+    }
 
     if (process.env.NODE_ENV !== 'production') {
       Host.reconciler.receiveComponent(this);

--- a/packages/rax/src/vdom/native.js
+++ b/packages/rax/src/vdom/native.js
@@ -115,9 +115,10 @@ class NativeComponent extends BaseComponent {
 
       if (!shouldNotRemoveChild) {
         Host.driver.removeChild(this._nativeNode, this._parent);
+
+        // If the parent node has been removed, child node don't need to be removed
+        shouldNotRemoveChild = true;
       }
-      // If the parent node has been removed, child node don't need to be removed
-      shouldNotRemoveChild = true;
     }
 
     this.unmountChildren(shouldNotRemoveChild);

--- a/packages/rax/src/vdom/native.js
+++ b/packages/rax/src/vdom/native.js
@@ -116,6 +116,7 @@ class NativeComponent extends BaseComponent {
       if (!shouldNotRemoveChild) {
         Host.driver.removeChild(this._nativeNode, this._parent);
       }
+      // If the parent node has been removed, child node don't need to be removed
       shouldNotRemoveChild = true;
     }
 
@@ -136,6 +137,7 @@ class NativeComponent extends BaseComponent {
 
     this.updateProperties(prevProps, nextProps);
 
+    // If the prevElement has no child, mount children directly
     if (prevProps.children && prevProps.children.length === 0) {
       this.mountChildren(nextProps.children, nextContext);
     } else {


### PR DESCRIPTION
渲染性能：当前容器没有子元素时，直接 mountChildren ，跳过原有的比对
删除节点的性能：当父节点被 removeChild 后，子元素不再重复执行 removeChild

![image](https://user-images.githubusercontent.com/1303018/59330103-1cea4e00-8d23-11e9-8f41-6ed3807aad0a.png)
