### PR TITLE
fix: react compatibility

### DIFF
--- a/packages/rax-dom/src/index.js
+++ b/packages/rax-dom/src/index.js
@@ -1,21 +1,31 @@
 import { render } from 'rax';
-import DriverDOM from 'driver-dom';
+import * as DriverDOM from 'driver-dom';
 import hydrate from 'rax-hydrate';
 import unmountComponentAtNode from 'rax-unmount-component-at-node';
 import findDOMNode from 'rax-find-dom-node';
 import createPortal from 'rax-create-portal';
 
-export default {
-  render: (element, container, callback) => render(
-    element,
-    container,
-    {
-      driver: DriverDOM
-    },
-    callback
-  ),
+const raxDomRender = (element, container, callback) => render(
+  element,
+  container,
+  {
+    driver: DriverDOM,
+  },
+  callback,
+);
+
+export {
+  raxDomRender as render,
   hydrate,
   unmountComponentAtNode,
   findDOMNode,
-  createPortal
+  createPortal,
+};
+
+export default {
+  render: raxDomRender,
+  hydrate,
+  unmountComponentAtNode,
+  findDOMNode,
+  createPortal,
 };

--- a/packages/rax-dom/src/index.js
+++ b/packages/rax-dom/src/index.js
@@ -5,7 +5,7 @@ import unmountComponentAtNode from 'rax-unmount-component-at-node';
 import findDOMNode from 'rax-find-dom-node';
 import createPortal from 'rax-create-portal';
 
-const raxDomRender = (element, container, callback) => render(
+const domRender = (element, container, callback) => render(
   element,
   container,
   {
@@ -15,7 +15,7 @@ const raxDomRender = (element, container, callback) => render(
 );
 
 export {
-  raxDomRender as render,
+  domRender as render,
   hydrate,
   unmountComponentAtNode,
   findDOMNode,
@@ -23,7 +23,7 @@ export {
 };
 
 export default {
-  render: raxDomRender,
+  render: domRender,
   hydrate,
   unmountComponentAtNode,
   findDOMNode,

--- a/packages/rax/src/compat/index.js
+++ b/packages/rax/src/compat/index.js
@@ -1,5 +1,19 @@
+import * as Rax from '../index';
+import Children from 'rax-children';
+import isValidElement from 'rax-is-valid-element';
+import createFactory from 'rax-create-factory';
+import cloneElement from 'rax-clone-element';
+
+Rax.Children = Children;
+Rax.isValidElement = isValidElement;
+Rax.createFactory = createFactory;
+Rax.cloneElement = cloneElement;
+
 export * from '../index';
-export Children from 'rax-children';
-export isValidElement from 'rax-is-valid-element';
-export createFactory from 'rax-create-factory';
-export cloneElement from 'rax-clone-element';
+export {
+  Children,
+  isValidElement,
+  createFactory,
+  cloneElement,
+};
+export default Rax;


### PR DESCRIPTION
默认导出default，不然会出现下面情况。

```js
import React, { useState } from 'react'

console.log(useState); // function
console.log(React); // undefined
```

driver-dom 引用有问题
```js
import DriverDOM from 'driver-dom';
// to
import * as DriverDOM from 'driver-dom';
```