### PR TITLE
feat: transform rpx to vw

### DIFF
--- a/packages/postcss-plugin-rpx2vw/README.md
+++ b/packages/postcss-plugin-rpx2vw/README.md
@@ -1,0 +1,92 @@
+# Postcss plugin rpx2vw
+
+> Transform rpx to vw.
+
+## Install
+
+```bash
+$ npm install --save postcss-plugin-rpx2vw
+```
+
+## Example
+
+### Input
+
+```css
+.a {
+  margin: -10rpx .5vh;
+  padding: 5vmin 9.5rpx 1rpx;
+  border: 3rpx solid black;
+  border-bottom-width: 1rpx;
+  font-size: 14rpx;
+  line-height: 20rpx;
+}
+
+.b {
+  border: 1rpx solid black;
+  margin-bottom: 1rpx;
+  font-size: 20rpx;
+  line-height: 30rpx;
+}
+
+@media (min-width: 750rpx) {
+  .c {
+    font-size: 16rpx;
+    line-height: 22rpx;
+  }
+}
+```
+
+### Output
+
+```css
+.a {
+  margin: -1.33333vw .5vh;
+  padding: 5vmin 1.26667vw 0.13333vw;
+  border: 0.4vw solid black;
+  border-bottom-width: 0.13333vw;
+  font-size: 1.86667vw;
+  line-height: 2.66667vw;
+}
+
+.b {
+  border: 0.13333vw solid black;
+  margin-bottom: 0.13333vw;
+  font-size: 2.66667vw;
+  line-height: 4vw;
+}
+
+@media (min-width: 100vw) {
+  .c {
+    font-size: 2.13333vw;
+    line-height: 2.93333vw;
+  }
+}
+```
+
+## Usage
+
+Default Options:
+
+```js
+{
+  viewportWidth: 750,
+  viewportUnit: 'vw',
+  fontViewportUnit: 'vw',
+  unitPrecision: 5,
+}
+```
+
+- `viewportWidth` The width of the viewport.
+- `viewportUnit` Expected unit.
+- `fontViewportUnit` Expected font unit.
+- `unitPrecision` The decimal point is exact to several digits.
+
+```javascript
+const PostcssPluginRpxToVw = require('postcss-plugin-rpx2vw');
+
+postcss([ PostcssPluginRpxToVw ]);
+```
+
+## Contributing
+   Want to file a bug, contribute some code, or improve documentation? Excellent! Read up on our guidelines for contributing.

--- a/packages/postcss-plugin-rpx2vw/package.json
+++ b/packages/postcss-plugin-rpx2vw/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "postcss-plugin-rpx2vw",
+  "version": "0.0.1",
+  "description": "Postcss plugin transform rpx to vw or rem.",
+  "main": "src/index.js",
+  "dependencies": {
+    "postcss": "^7.0.17"
+  }
+}

--- a/packages/postcss-plugin-rpx2vw/src/__tests__/index.js
+++ b/packages/postcss-plugin-rpx2vw/src/__tests__/index.js
@@ -1,0 +1,102 @@
+const postcss = require('postcss');
+const postcssRpxToVw = require('..');
+
+describe('postcssRpxToVw', () => {
+  it('should work simple example', () => {
+    const input = `
+.a {
+  margin: -10rpx .5vh;
+  padding: 5vmin 9.5rpx 1rpx;
+  border: 3rpx solid black;
+  border-bottom-width: 1rpx;
+  font-size: 14rpx;
+  line-height: 20rpx;
+}
+
+.b {
+  border: 1rpx solid black;
+  margin-bottom: 1rpx;
+  font-size: 20rpx;
+  line-height: 30rpx;
+}
+
+@media (min-width: 750rpx) {
+  .c {
+    font-size: 16rpx;
+    line-height: 22rpx;
+  }
+}    
+    `;
+    const output = `
+.a {
+  margin: -1.33333vw .5vh;
+  padding: 5vmin 1.26667vw 0.13333vw;
+  border: 0.4vw solid black;
+  border-bottom-width: 0.13333vw;
+  font-size: 1.86667vw;
+  line-height: 2.66667vw;
+}
+
+.b {
+  border: 0.13333vw solid black;
+  margin-bottom: 0.13333vw;
+  font-size: 2.66667vw;
+  line-height: 4vw;
+}
+
+@media (min-width: 100vw) {
+  .c {
+    font-size: 2.13333vw;
+    line-height: 2.93333vw;
+  }
+}    
+    `;
+
+    const processed = postcss(postcssRpxToVw()).process(input).css;
+    expect(processed).toBe(output);
+  });
+
+  it('should change viewportWidth from options', () => {
+    const input = '.box { width: 100rpx; height: 200rpx; }';
+    const output = '.box { width: 10vw; height: 20vw; }';
+
+    const processed = postcss(postcssRpxToVw({
+      viewportWidth: 1000
+    })).process(input).css;
+    expect(processed).toBe(output);
+  });
+
+  it('should change unitPrecision from options', () => {
+    const input = '.box { width: 100rpx; height: 200rpx; }';
+    const output = '.box { width: 13.33vw; height: 26.67vw; }';
+
+    const processed = postcss(postcssRpxToVw({
+      unitPrecision: 2
+    })).process(input).css;
+    expect(processed).toBe(output);
+  });
+
+  it('should not transform px', () => {
+    const input = '.box { width: 100px; height: 100px; }';
+    const output = '.box { width: 100px; height: 100px; }';
+
+    const processed = postcss(postcssRpxToVw()).process(input).css;
+    expect(processed).toBe(output);
+  });
+
+  it('should transform 0rpx to 0', () => {
+    const input = '.box { width: 0rpx; }';
+    const output = '.box { width: 0; }';
+
+    const processed = postcss(postcssRpxToVw()).process(input).css;
+    expect(processed).toBe(output);
+  });
+
+  it('should not transform media when not rpx', () => {
+    const input = '@media (min-width: 750px) {}';
+    const output = '@media (min-width: 750px) {}';
+
+    const processed = postcss(postcssRpxToVw()).process(input).css;
+    expect(processed).toBe(output);
+  });
+});

--- a/packages/postcss-plugin-rpx2vw/src/index.js
+++ b/packages/postcss-plugin-rpx2vw/src/index.js
@@ -1,0 +1,52 @@
+const postcss = require('postcss');
+// !singlequotes|!doublequotes|!url()|pixelunit
+const rpxRegex = /"[^"]+"|'[^']+'|url\([^\)]+\)|(\d*\.?\d+)rpx/g;
+
+const defaults = {
+  viewportWidth: 750,
+  viewportUnit: 'vw',
+  fontViewportUnit: 'vw',
+  unitPrecision: 5,
+};
+
+module.exports = postcss.plugin('postcss-rpx2vw', function(options) {
+  const opts = Object.assign({}, defaults, options);
+
+  return function(root) {
+    root.walkDecls(function(decl, i) {
+      // This should be the fastest test and will remove most declarations
+      if (decl.value.indexOf('rpx') === -1) return;
+
+      const unit = getUnit(decl.prop, opts);
+      decl.value = decl.value.replace(rpxRegex, createRpxReplace(opts, unit, opts.viewportWidth));
+    });
+
+    root.walkAtRules('media', function(rule) {
+      if (rule.params.indexOf('rpx') === -1) return;
+
+      rule.params = rule.params.replace(rpxRegex, createRpxReplace(opts, opts.viewportUnit, opts.viewportWidth));
+    });
+  };
+});
+
+function toFixed(number, precision) {
+  const multiplier = Math.pow(10, precision + 1);
+  const wholeNumber = Math.floor(number * multiplier);
+
+  return Math.round(wholeNumber / 10) * 10 / multiplier;
+}
+
+// transform rpx to vw
+function createRpxReplace(opts, viewportUnit, viewportSize) {
+  return function(m, $1) {
+    if (!$1) return m;
+    const pixels = parseFloat($1);
+    const parsedVal = toFixed(pixels / viewportSize * 100, opts.unitPrecision);
+    return parsedVal === 0 ? '0' : parsedVal + viewportUnit;
+  };
+}
+
+// get unit, font can also use vmin.
+function getUnit(prop, opts) {
+  return prop.indexOf('font') === -1 ? opts.viewportUnit : opts.fontViewportUnit;
+}


### PR DESCRIPTION
## Background

- Unified `rpx` as standard unit.
- Eliminate the differences between web and universal.

## Example

### Input

```css
.a {
  margin: -10rpx .5vh;
  padding: 5vmin 9.5rpx 1rpx;
  border: 3rpx solid black;
  border-bottom-width: 1rpx;
  font-size: 14rpx;
  line-height: 20rpx;
}

.b {
  border: 1rpx solid black;
  margin-bottom: 1rpx;
  font-size: 20rpx;
  line-height: 30rpx;
}
```

### Output

```css
.a {
  margin: -1.33333vw .5vh;
  padding: 5vmin 1.26667vw 0.13333vw;
  border: 0.4vw solid black;
  border-bottom-width: 0.13333vw;
  font-size: 1.86667vw;
  line-height: 2.66667vw;
}

.b {
  border: 0.13333vw solid black;
  margin-bottom: 0.13333vw;
  font-size: 2.66667vw;
  line-height: 4vw;
}
```