### PR TITLE
fix: add webkitLineClamp whitelist

### DIFF
--- a/packages/driver-dom/src/index.js
+++ b/packages/driver-dom/src/index.js
@@ -33,6 +33,9 @@ const UNITLESS_NUMBER_PROPS = {
   gridRow: TRUE,
   gridColumn: TRUE,
   fontWeight: TRUE,
+  // Main-stream browsers(like chrome) will not remove webkit prefix in the short term.
+  // ref: CSSOM webkit-based attribute: https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-webkit-cased-attribute
+  webkitLineClamp: TRUE,
   lineClamp: TRUE,
   lineHeight: TRUE,
   opacity: TRUE,

--- a/packages/driver-universal/package.json
+++ b/packages/driver-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "driver-universal",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Driver for Universal App.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
@@ -18,7 +18,7 @@
   "dependencies": {
     "driver-dom": "^1.0.0",
     "driver-weex": "^1.0.0",
-    "style-unit": "^1.0.1-0",
+    "style-unit": "^1.0.1",
     "universal-env": "^1.0.0"
   }
 }

--- a/packages/style-unit/package.json
+++ b/packages/style-unit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-unit",
-  "version": "1.0.1-0",
+  "version": "1.0.1",
   "description": "style-unit",
   "license": "BSD-3-Clause",
   "main": "src/index.js",

--- a/packages/style-unit/src/index.js
+++ b/packages/style-unit/src/index.js
@@ -19,6 +19,9 @@ const UNITLESS_NUMBER_PROPS = {
   gridRow: true,
   gridColumn: true,
   fontWeight: true,
+  // Main-stream browsers(like chrome) will not remove webkit prefix in the short term.
+  // ref: CSSOM webkit-based attribute: https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-webkit-cased-attribute
+  webkitLineClamp: true,
   lineClamp: true,
   // We make lineHeight default is px that is diff with w3c spec
   // lineHeight: true,


### PR DESCRIPTION
修复 webkitLineClamp 不在白名单里导致数字类型值变 px 然后不生效的问题