### PR TITLE
fix: match search is not needed

### DIFF
--- a/packages/rax-use-router/package.json
+++ b/packages/rax-use-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-use-router",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Rax useRouter hook.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-use-router/src/index.js
+++ b/packages/rax-use-router/src/index.js
@@ -180,8 +180,8 @@ const router = {
   }
 };
 
-function matchLocation({ pathname, search }) {
-  router.match(`${pathname}${search}`);
+function matchLocation({ pathname }) {
+  router.match(pathname);
 }
 
 


### PR DESCRIPTION
匹配路由时应该只需要匹配 pathname 即可，search 不需要强制匹配：

```javascript
// routers
[
   {
      path: '/search',
      component: () => <Search />,
    }
]
```

可以匹配到

http://localhost:9999/search
http://localhost:9999/search?q=xxx
http://localhost:9999/search?q=xxx&any_query=xxxx

当前版本无法匹配带 query 的情况。