### PR TITLE
Refactor new context

### DIFF
--- a/packages/rax-server-renderer/src/index.js
+++ b/packages/rax-server-renderer/src/index.js
@@ -202,8 +202,10 @@ function renderElementToString(element, context, options) {
   if (type) {
     const props = element.props || EMPTY_OBJECT;
     if (type.prototype && type.prototype.render) {
-      const instance = new type(props, context, updater); // eslint-disable-line new-cap
+      const instance = new type(props, context); // eslint-disable-line new-cap
       let currentContext = instance.context = context;
+      // Inject the updater into instance
+      instance.updater = updater;
 
       let childContext;
       if (instance.getChildContext) {

--- a/packages/rax-server-renderer/src/index.js
+++ b/packages/rax-server-renderer/src/index.js
@@ -167,9 +167,9 @@ class ReactiveComponent {
   }
 
   readContext(context) {
-    const Provider = context.Provider;
-    const contextProp = Provider.contextProp;
-    return this.context[contextProp] ? this.context[contextProp].value : Provider.defaultValue;
+    const readEmitter = context.Provider.readEmitter;
+    const contextEmitter = readEmitter(this);
+    return contextEmitter.value;
   }
 
   render() {

--- a/packages/rax/src/createContext.js
+++ b/packages/rax/src/createContext.js
@@ -36,7 +36,7 @@ export default function createContext(defaultValue) {
 
     componentWillReceiveProps(nextProps) {
       if (this.props.value !== nextProps.value) {
-        this.emitter.value = nextProps.value;
+        this.emitter.value = nextProps.value !== undefined ? nextProps.value : defaultValue;
       }
     }
 

--- a/packages/rax/src/createContext.js
+++ b/packages/rax/src/createContext.js
@@ -70,9 +70,9 @@ export default function createContext(defaultValue) {
   class Consumer extends Component {
     componentWillMount() {
       this.emitter = readEmitter(this);
-      this.state = {
+      this.setState({
         value: this.emitter.value
-      };
+      });
       this.onUpdate = value => this.state.value !== value && this.setState({value});
     }
 

--- a/packages/rax/src/createContext.js
+++ b/packages/rax/src/createContext.js
@@ -19,7 +19,10 @@ class ValueEmitter {
   }
 }
 
+let uniqueId = 0;
+
 export default function createContext(defaultValue) {
+  const contextProp = '__context_' + uniqueId++ + '__';
   const stack = [];
   const defaultEmitter = new ValueEmitter(defaultValue);
 
@@ -66,6 +69,7 @@ export default function createContext(defaultValue) {
   }
 
   Provider.readEmitter = readEmitter;
+  Provider.contextProp = contextProp;
 
   class Consumer extends Component {
     componentWillMount() {

--- a/packages/rax/src/createContext.js
+++ b/packages/rax/src/createContext.js
@@ -56,7 +56,7 @@ export default function createContext(defaultValue) {
   function readEmitter(instance) {
     const emitter = stack[stack.length - 1];
     if (emitter) return emitter;
-    while (instance) {
+    while (instance && instance._internal) {
       if (instance instanceof Provider) {
         break;
       }
@@ -70,9 +70,9 @@ export default function createContext(defaultValue) {
   class Consumer extends Component {
     componentWillMount() {
       this.emitter = readEmitter(this);
-      this.setState({
+      this.state = {
         value: this.emitter.value
-      });
+      };
       this.onUpdate = value => this.state.value !== value && this.setState({value});
     }
 

--- a/packages/rax/src/vdom/reactive.js
+++ b/packages/rax/src/vdom/reactive.js
@@ -22,7 +22,7 @@ class ReactiveComponent extends Component {
     this.isScheduled = false;
     this.shouldUpdate = false;
     this._children = null;
-    this.dependencies = new Map();
+    this._dependencies = {};
 
     this.state = {};
 
@@ -57,9 +57,11 @@ class ReactiveComponent extends Component {
   }
 
   readContext(context) {
-    let contextItem = this.dependencies.get(context);
+    const Provider = context.Provider;
+    const contextProp = Provider.contextProp;
+    let contextItem = this._dependencies[contextProp];
     if (!contextItem) {
-      const readEmitter = context.Provider.readEmitter;
+      const readEmitter = Provider.readEmitter;
       const contextEmitter = readEmitter(this);
       contextItem = {
         emitter: contextEmitter,
@@ -77,7 +79,7 @@ class ReactiveComponent extends Component {
       this.willUnmount.push(() => {
         contextItem.emitter.off(contextUpdater);
       });
-      this.dependencies.set(context, contextItem);
+      this._dependencies[contextProp] = contextItem;
     }
     return contextItem.renderedContext = contextItem.emitter.value;
   }

--- a/packages/rax/src/vdom/reactive.js
+++ b/packages/rax/src/vdom/reactive.js
@@ -64,7 +64,6 @@ class ReactiveComponent extends Component {
       contextItem = {
         emitter: contextEmitter,
         renderedContext: contextEmitter.value,
-        off: () => {},
       };
 
       const contextUpdater = (newContext) => {
@@ -75,7 +74,9 @@ class ReactiveComponent extends Component {
       };
 
       contextItem.emitter.on(contextUpdater);
-      contextItem.off = () => contextItem.emitter.off(contextUpdater);
+      this.willUnmount.push(() => {
+        contextItem.emitter.off(contextUpdater);
+      });
       this.dependencies.set(context, contextItem);
     }
     return contextItem.renderedContext = contextItem.emitter.value;
@@ -99,7 +100,6 @@ class ReactiveComponent extends Component {
 
   componentWillUnmount() {
     this.willUnmount.forEach(handler => handler());
-    this.dependencies.forEach(contextItem => contextItem.off());
   }
 
   update() {


### PR DESCRIPTION
### 重构new context

之前的new context 之前走老的context, 每次new context 更新造成context更新，导致jsx缓存失效，造成全量更新，new context应该独立，保证组件更新粒度
