### PR TITLE
refactor: improve driver dom performance for rpx

### DIFF
--- a/packages/driver-dom/src/index.js
+++ b/packages/driver-dom/src/index.js
@@ -1,7 +1,6 @@
 /**
  * Driver for Web DOM
  **/
-const IS_RPX_REG = /\d+rpx/;
 const RPX_REG = /[-+]?\d*\.?\d+(rpx)/g;
 const DANGEROUSLY_SET_INNER_HTML = 'dangerouslySetInnerHTML';
 const __HTML = '__html';
@@ -58,7 +57,6 @@ export function setDecimalPixelTransformer(transformer) {
   decimalPixelTransformer = transformer;
 }
 
-
 function unitTransformer(n) {
   return toFixed(parseFloat(n) / (viewportWidth / 100), unitPrecision) + 'vw';
 }
@@ -69,15 +67,21 @@ function toFixed(number, precision) {
   return Math.round(wholeNumber / 10) * 10 / multiplier;
 }
 
-function calcRpxToVw(value) {
-  return value.replace(RPX_REG, unitTransformer);
+/**
+ * Create a cached version of a pure function.
+ */
+function cached(fn) {
+  const cache = Object.create(null);
+  return function cachedFn(str) {
+    return cache[str] || (cache[str] = fn(str));
+  };
 }
 
+const calcRpxToVw = (value) => value.replace(RPX_REG, unitTransformer);
+const isRpx = cached((str) => str.slice(0, -3) === 'rpx');
+
 function convertUnit(value) {
-  value = decimalPixelTransformer(value);
-  return IS_RPX_REG.test(value)
-    ? calcRpxToVw(value)
-    : value;
+  return isRpx(value) ? calcRpxToVw(value) : value;
 }
 
 export function setTagNamePrefix(prefix) {

--- a/packages/driver-dom/src/index.js
+++ b/packages/driver-dom/src/index.js
@@ -77,12 +77,16 @@ function cached(fn) {
   };
 }
 
-const calcRpxToVw = (value) => value.replace(RPX_REG, unitTransformer);
-const isRpx = cached((str) => str.slice(0, -3) === 'rpx');
-
-function convertUnit(value) {
-  return isRpx(value) ? calcRpxToVw(value) : value;
+function calcRpxToVw(value) {
+  return value.replace(RPX_REG, unitTransformer);
 }
+
+function isRpx(str) {
+  return str.slice(0, -3) === 'rpx';
+}
+
+// Cache the convert fn.
+const convertUnit = cached((value) => isRpx(value) ? calcRpxToVw(value) : value);
 
 export function setTagNamePrefix(prefix) {
   tagNamePrefix = prefix;


### PR DESCRIPTION
为了支持 rpx 需要去做一些计算, 判断里尽量不用正则, 另外加了个缓存

---

创建 1000 节点性能数据   
preact vs rax   
1. 不支持 rpx,  1.00 VS 1.05
2. 支持 rpx (优化前), 1.00 VS  1.37
3. 支持 rpx (优化后), 1.00 VS 1.10

