### PR TITLE
refactor: rename distPath to outputPath in jsx-compiler and jsx2mp-lo…

### DIFF
--- a/packages/jsx-compiler/README.md
+++ b/packages/jsx-compiler/README.md
@@ -20,7 +20,7 @@ export default class extends Component {
 Run jsx compiler.
 
 - type: Required, enum of `app`, `page`, `component`.
-- distPath: Required, string of dist path.
+- outputPath: Required, string of dist path.
 - sourcePath: Required, string of source path.
 - resourcePath: Required, string of original file path.
 

--- a/packages/jsx-compiler/src/modules/code.js
+++ b/packages/jsx-compiler/src/modules/code.js
@@ -96,12 +96,12 @@ module.exports = {
 
     const hooks = collectHooks(parsed.renderFunctionPath);
 
-    const targetFileDir = dirname(join(options.distPath, relative(options.sourcePath, options.resourcePath)));
+    const targetFileDir = dirname(join(options.outputPath, relative(options.sourcePath, options.resourcePath)));
 
     removeRaxImports(parsed.ast);
-    renameCoreModule(parsed.ast, options.distPath, targetFileDir);
+    renameCoreModule(parsed.ast, options.outputPath, targetFileDir);
     renameNpmModules(parsed.ast);
-    addDefine(parsed.ast, options.type, options.distPath, targetFileDir, userDefineType, eventHandlers, parsed.useCreateStyle, hooks);
+    addDefine(parsed.ast, options.type, options.outputPath, targetFileDir, userDefineType, eventHandlers, parsed.useCreateStyle, hooks);
     removeDefaultImports(parsed.ast);
 
     /**
@@ -166,12 +166,12 @@ function genTagIdExp(expressions) {
   return parseExpression(ret);
 }
 
-function renameCoreModule(ast, distPath, targetFileDir) {
+function renameCoreModule(ast, outputPath, targetFileDir) {
   traverse(ast, {
     ImportDeclaration(path) {
       const source = path.get('source');
       if (source.isStringLiteral() && isCoreModule(source.node.value)) {
-        let runtimeRelativePath = relative(targetFileDir, join(distPath, RUNTIME));
+        let runtimeRelativePath = relative(targetFileDir, join(outputPath, RUNTIME));
         runtimeRelativePath = runtimeRelativePath[0] !== '.' ? './' + runtimeRelativePath : runtimeRelativePath;
         source.replaceWith(t.stringLiteral(runtimeRelativePath));
       }
@@ -191,7 +191,7 @@ function renameNpmModules(ast) {
   });
 }
 
-function addDefine(ast, type, distPath, targetFileDir, userDefineType, eventHandlers, useCreateStyle, hooks) {
+function addDefine(ast, type, outputPath, targetFileDir, userDefineType, eventHandlers, useCreateStyle, hooks) {
   let safeCreateInstanceId;
   let importedIdentifier;
   switch (type) {
@@ -234,7 +234,7 @@ function addDefine(ast, type, distPath, targetFileDir, userDefineType, eventHand
         ));
       }
 
-      let runtimeRelativePath = relative(targetFileDir, join(distPath, RUNTIME));
+      let runtimeRelativePath = relative(targetFileDir, join(outputPath, RUNTIME));
       runtimeRelativePath = runtimeRelativePath[0] !== '.' ? './' + runtimeRelativePath : runtimeRelativePath;
 
       path.node.body.unshift(

--- a/packages/jsx-compiler/src/modules/components.js
+++ b/packages/jsx-compiler/src/modules/components.js
@@ -51,8 +51,8 @@ module.exports = {
         // npm module
         const pkg = getComponentConfig(alias.from);
         if (pkg.miniappConfig && pkg.miniappConfig.main) {
-          const targetFileDir = dirname(join(options.distPath, relative(options.sourcePath, options.resourcePath)));
-          let npmRelativePath = relative(targetFileDir, join(options.distPath, '/npm'));
+          const targetFileDir = dirname(join(options.outputPath, relative(options.sourcePath, options.resourcePath)));
+          let npmRelativePath = relative(targetFileDir, join(options.outputPath, '/npm'));
           npmRelativePath = npmRelativePath[0] !== '.' ? './' + npmRelativePath : npmRelativePath;
           return './' + join(npmRelativePath, alias.from, pkg.miniappConfig.main);
         } else {

--- a/packages/jsx2mp-loader/src/app-loader.js
+++ b/packages/jsx2mp-loader/src/app-loader.js
@@ -36,18 +36,18 @@ module.exports = function appLoader(content) {
   const rawContent = readFileSync(this.resourcePath, 'utf-8');
   const config = readJSONSync(appConfigPath);
 
-  const distPath = this._compiler.outputPath;
-  if (!existsSync(distPath)) mkdirSync(distPath);
+  const outputPath = this._compiler.outputPath;
+  if (!existsSync(outputPath)) mkdirSync(outputPath);
 
   const sourcePath = join(this.rootContext, entryPath);
   const relativeSourcePath = relative(sourcePath, this.resourcePath);
-  const targetFilePath = join(distPath, relativeSourcePath);
+  const targetFilePath = join(outputPath, relativeSourcePath);
 
-  const targetFileDir = dirname(join(distPath, relative(sourcePath, this.resourcePath)));
+  const targetFileDir = dirname(join(outputPath, relative(sourcePath, this.resourcePath)));
 
   const compilerOptions = Object.assign({}, compiler.baseOptions, {
     resourcePath: this.resourcePath,
-    distPath,
+    outputPath,
     sourcePath,
     type: 'app',
   });
@@ -56,11 +56,11 @@ module.exports = function appLoader(content) {
   this.addDependency(appConfigPath);
 
   const transformedAppConfig = transformAppConfig(entryPath, config);
-  writeFileSync(join(distPath, 'app.js'), transformed.code);
-  writeJSONSync(join(distPath, 'app.json'), transformedAppConfig, { spaces: 2 });
+  writeFileSync(join(outputPath, 'app.js'), transformed.code);
+  writeJSONSync(join(outputPath, 'app.json'), transformedAppConfig, { spaces: 2 });
 
   if (transformed.style) {
-    writeFileSync(join(distPath, 'app.acss'), transformed.style);
+    writeFileSync(join(outputPath, 'app.acss'), transformed.style);
   }
 
   return [

--- a/packages/jsx2mp-loader/src/component-loader.js
+++ b/packages/jsx2mp-loader/src/component-loader.js
@@ -12,16 +12,15 @@ module.exports = function componentLoader(content) {
   const resourcePath = this.resourcePath;
   const rootContext = this.rootContext;
 
-  const distPath = this._compiler.outputPath;
+  const outputPath = this._compiler.outputPath;
   const sourcePath = join(this.rootContext, dirname(entryPath));
   const relativeSourcePath = relative(sourcePath, this.resourcePath);
-  const targetFilePath = join(distPath, relativeSourcePath);
-  const distFileWithoutExt = removeExt(join(distPath, relativeSourcePath));
-  // console.log('targetFileDir', dirname(targetFilePath));
-  // console.log('合成路径：', dirname(join(distPath, relative(sourcePath, this.resourcePath))))
+  const targetFilePath = join(outputPath, relativeSourcePath);
+  const distFileWithoutExt = removeExt(join(outputPath, relativeSourcePath));
+
   const compilerOptions = Object.assign({}, compiler.baseOptions, {
     resourcePath: this.resourcePath,
-    distPath,
+    outputPath,
     sourcePath,
     type: 'component',
     platform
@@ -68,9 +67,9 @@ module.exports = function componentLoader(content) {
   if (transformed.assets) {
     Object.keys(transformed.assets).forEach((asset) => {
       const content = transformed.assets[asset];
-      const assetDirectory = dirname(join(distPath, asset));
+      const assetDirectory = dirname(join(outputPath, asset));
       if (!existsSync(assetDirectory)) mkdirpSync(assetDirectory);
-      writeFileSync(join(distPath, asset), content);
+      writeFileSync(join(outputPath, asset), content);
     });
   }
 

--- a/packages/jsx2mp-loader/src/file-loader.js
+++ b/packages/jsx2mp-loader/src/file-loader.js
@@ -19,7 +19,7 @@ module.exports = function fileLoader(content) {
   const rawContent = readFileSync(this.resourcePath, 'utf-8');
   const rootContext = this.rootContext;
   const currentNodeModulePath = join(rootContext, 'node_modules');
-  const distPath = this._compiler.outputPath;
+  const outputPath = this._compiler.outputPath;
 
   const isNodeModule = cached(function isNodeModule(path) {
     return path.indexOf(currentNodeModulePath) === 0;
@@ -44,11 +44,11 @@ module.exports = function fileLoader(content) {
         }
         copySync(
           join(currentNodeModulePath, npmName),
-          join(distPath, 'npm', npmName)
+          join(outputPath, 'npm', npmName)
         );
         // modify referenced component location
         if (pkg.miniappConfig.main) {
-          const componentConfigPath = join(distPath, 'npm', npmName, pkg.miniappConfig.main + '.json');
+          const componentConfigPath = join(outputPath, 'npm', npmName, pkg.miniappConfig.main + '.json');
           if (existsSync(componentConfigPath)) {
             const componentConfig = readJSONSync(componentConfigPath);
             if (componentConfig.usingComponents) {
@@ -68,7 +68,7 @@ module.exports = function fileLoader(content) {
       // Copy package.json
       if (!dependenciesCache[npmName]) {
         dependenciesCache[npmName] = true;
-        const target = join(distPath, 'npm', npmName, 'package.json');
+        const target = join(outputPath, 'npm', npmName, 'package.json');
         if (!existsSync(target))
           copySync(sourcePackageJSONPath, target, { errorOnExist: false });
       }
@@ -77,7 +77,7 @@ module.exports = function fileLoader(content) {
       const splitedNpmPath = relativeNpmPath.split('/');
       if (relativeNpmPath[0] === '@') splitedNpmPath.shift(); // Extra shift for scoped npm.
       splitedNpmPath.shift(); // Skip npm module package, for cnpm/tnpm will rewrite this.
-      const distSourcePath = join(distPath, 'npm', npmName, splitedNpmPath.join('/'));
+      const distSourcePath = join(outputPath, 'npm', npmName, splitedNpmPath.join('/'));
       const { code, map } = transformCode(rawContent, loaderOptions);
       const distSourceDirPath = dirname(distSourcePath);
       if (!existsSync(distSourceDirPath)) mkdirpSync(distSourceDirPath);
@@ -89,9 +89,9 @@ module.exports = function fileLoader(content) {
       join(rootContext, dirname(loaderOptions.entryPath)),
       this.resourcePath
     );
-    const distSourcePath = join(distPath, relativeFilePath);
+    const distSourcePath = join(outputPath, relativeFilePath);
     const distSourceDirPath = dirname(distSourcePath);
-    const npmRelativePath = relative(dirname(distSourcePath), join(distPath, '/npm/'));
+    const npmRelativePath = relative(dirname(distSourcePath), join(outputPath, '/npm/'));
     const { code } = transformCode(rawContent, loaderOptions, npmRelativePath);
 
     if (!existsSync(distSourceDirPath)) mkdirpSync(distSourceDirPath);

--- a/packages/jsx2mp-loader/src/page-loader.js
+++ b/packages/jsx2mp-loader/src/page-loader.js
@@ -13,14 +13,14 @@ module.exports = function pageLoader(content) {
   const resourcePath = this.resourcePath;
   const rootContext = this.rootContext;
 
-  const distPath = this._compiler.outputPath;
+  const outputPath = this._compiler.outputPath;
   const sourcePath = join(this.rootContext, dirname(entryPath));
   const relativeSourcePath = relative(sourcePath, this.resourcePath);
-  const targetFilePath = join(distPath, relativeSourcePath);
+  const targetFilePath = join(outputPath, relativeSourcePath);
 
   const compilerOptions = Object.assign({}, compiler.baseOptions, {
     resourcePath: this.resourcePath,
-    distPath,
+    outputPath,
     sourcePath,
     type: 'page',
     platform
@@ -31,7 +31,7 @@ module.exports = function pageLoader(content) {
   const pageDistDir = dirname(targetFilePath);
   if (!existsSync(pageDistDir)) mkdirpSync(pageDistDir);
 
-  const distFileWithoutExt = removeExt(join(distPath, relativeSourcePath));
+  const distFileWithoutExt = removeExt(join(outputPath, relativeSourcePath));
 
   const config = Object.assign({}, transformed.config);
   if (Array.isArray(transformed.dependencies)) {
@@ -69,9 +69,9 @@ module.exports = function pageLoader(content) {
   if (transformed.assets) {
     Object.keys(transformed.assets).forEach((asset) => {
       const content = transformed.assets[asset];
-      const assetDirectory = dirname(join(distPath, asset));
+      const assetDirectory = dirname(join(outputPath, asset));
       if (!existsSync(assetDirectory)) mkdirpSync(assetDirectory);
-      writeFileSync(join(distPath, asset), content);
+      writeFileSync(join(outputPath, asset), content);
     });
   }
 


### PR DESCRIPTION
- 将 jsx-compiler 和 jsx2mp-loader 中的 distPath 参数重命名为 outputPath 以对齐 webpack 命名方式