### PR TITLE
fix: collect dynamic identifier instead of object prop

### DIFF
--- a/packages/jsx-compiler/src/modules/__tests__/element.js
+++ b/packages/jsx-compiler/src/modules/__tests__/element.js
@@ -268,7 +268,7 @@ describe('Transform JSXElement', () => {
     });
 
     it('should collect object expression', () => {
-      const sourceCode = `<Image style={{...styles.avator, ...styles[\`\${rank}Avator\`]}} source={{ uri: avator }}></Image>`;
+      const sourceCode = '<Image style={{...styles.avator, ...styles[\`\${rank}Avator\`]}} source={{ uri: avator }}></Image>';
       const ast = parseExpression(sourceCode);
       const { dynamicValues } = _transform(ast, null, null, sourceCode);
       expect(genInlineCode(ast).code).toEqual('<Image style="{{_d0}}" source="{{ uri: _d1 }}"></Image>');

--- a/packages/jsx-compiler/src/modules/__tests__/element.js
+++ b/packages/jsx-compiler/src/modules/__tests__/element.js
@@ -267,6 +267,14 @@ describe('Transform JSXElement', () => {
       expect(genDynamicAttrs(dynamicValues)).toEqual('{ _d0: styles, _d1: data }');
     });
 
+    it('should collect object expression', () => {
+      const sourceCode = `<Image style={{...styles.avator, ...styles[\`\${rank}Avator\`]}} source={{ uri: avator }}></Image>`;
+      const ast = parseExpression(sourceCode);
+      const { dynamicValues } = _transform(ast, null, null, sourceCode);
+      expect(genInlineCode(ast).code).toEqual('<Image style="{{_d0}}" source="{{ uri: _d1 }}"></Image>');
+      expect(genDynamicAttrs(dynamicValues)).toEqual('{ _d0: { ...styles.avator, ...styles[`${rank}Avator`] }, _d1: avator }');
+    });
+
     it('unsupported', () => {
       expect(() => {
         _transform(parseExpression('<View>{a = 1}</View>'));

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -308,7 +308,7 @@ function transformTemplate(ast, scope = null, adapter, sourceCode, componentDepe
                 const { key, value } = property;
                 let replaceNode;
                 if (t.isIdentifier(value)) {
-                  replaceNode = transformIdentifier(innerPath.node, dynamicValues, isDirective);
+                  replaceNode = transformIdentifier(value, dynamicValues, isDirective);
                 }
                 if (t.isMemberExpression(value)) {
                   replaceNode = transformMemberExpression(value, dynamicValues, isDirective);


### PR DESCRIPTION
修复收集 `<div attr={{ key: value }} />` 时 value 变成对象的问题, 看代码应该是手误