### PR TITLE
refactor: improve performance with clearing all children

### DIFF
--- a/packages/driver-dom/src/index.js
+++ b/packages/driver-dom/src/index.js
@@ -355,3 +355,11 @@ export function afterRender({ container }) {
     isHydrating = false;
   }
 }
+
+/**
+ * Remove all children from node.
+ * @NOTE: Fast path support in web.
+ */
+export function removeChildren(node) {
+  node.innerHTML = '';
+}

--- a/packages/rax/src/vdom/native.js
+++ b/packages/rax/src/vdom/native.js
@@ -340,10 +340,9 @@ class NativeComponent extends BaseComponent {
     let prevFirstNativeNode;
     let shouldUnmountPrevFirstChild;
 
-    let shouldRemoveAllChildren = false;
-    if (nextChildrenElements && nextChildrenElements.length > 0 && driver.removeChildren) {
-      shouldRemoveAllChildren = true;
-    }
+    // Directly remove all children from component, if nextChildren is empty.
+    // `driver.removeChildren` is optional driver protocol.
+    let shouldRemoveAllChildren = Boolean(nextChildrenElements && nextChildrenElements.length > 0 && driver.removeChildren);
 
     // Unmount children that are no longer present.
     if (prevChildren != null) {

--- a/packages/rax/src/vdom/native.js
+++ b/packages/rax/src/vdom/native.js
@@ -340,6 +340,11 @@ class NativeComponent extends BaseComponent {
     let prevFirstNativeNode;
     let shouldUnmountPrevFirstChild;
 
+    let shouldRemoveAllChildren = false;
+    if (nextChildrenElements && nextChildrenElements.length > 0 && driver.removeChildren) {
+      shouldRemoveAllChildren = true;
+    }
+
     // Unmount children that are no longer present.
     if (prevChildren != null) {
       for (let name in prevChildren) {
@@ -356,7 +361,7 @@ class NativeComponent extends BaseComponent {
             prevFirstNativeNode = prevFirstNativeNode[0];
           }
         } else if (shouldUnmount) {
-          prevChild.unmountComponent();
+          prevChild.unmountComponent(shouldRemoveAllChildren);
         }
       }
     }
@@ -442,7 +447,11 @@ class NativeComponent extends BaseComponent {
     }
 
     if (shouldUnmountPrevFirstChild) {
-      prevFirstChild.unmountComponent();
+      prevFirstChild.unmountComponent(shouldRemoveAllChildren);
+    }
+
+    if (shouldRemoveAllChildren) {
+      driver.removeChildren(this._nativeNode);
     }
 
     this._renderedChildren = nextChildren;


### PR DESCRIPTION
case: 当 updateComponent 的时候, nextChildren 为空, 对 nativeNode 的操作由原来的逐个从 prevChild 去移除变成直接从当前节点清除所有 children (目前仅 Web)

![image](https://user-images.githubusercontent.com/3922719/63023749-487ee580-bed8-11e9-845b-598a70796340.png)
