### PR TITLE
fix: improved  for in loops of unmountChildren

### DIFF
--- a/packages/rax/src/vdom/native.js
+++ b/packages/rax/src/vdom/native.js
@@ -98,7 +98,7 @@ class NativeComponent extends BaseComponent {
     if (renderedChildren) {
       let keys = Object.keys(renderedChildren);
       let name;
-      while(name = keys.shift()) {
+      while (name = keys.shift()) {
         let renderedChild = renderedChildren[name];
         renderedChild.unmountComponent(shouldNotRemoveChild);
       }

--- a/packages/rax/src/vdom/native.js
+++ b/packages/rax/src/vdom/native.js
@@ -96,7 +96,9 @@ class NativeComponent extends BaseComponent {
     let renderedChildren = this._renderedChildren;
 
     if (renderedChildren) {
-      for (let name in renderedChildren) {
+      let keys = Object.keys(renderedChildren);
+      let name;
+      while(name = keys.shift()) {
         let renderedChild = renderedChildren[name];
         renderedChild.unmountComponent(shouldNotRemoveChild);
       }


### PR DESCRIPTION
The performance of unmountChildren was improved. For in loops, the time consumption of unmountChildren was 9.42%(10.7 ms) before optimization, and 2.20%(2.2ms) after optimization.

before optimization:
![image](https://user-images.githubusercontent.com/15956075/63072602-37c18480-bf57-11e9-9555-ef55589c162c.png)
 after optimization:
![image](https://user-images.githubusercontent.com/15956075/63072623-54f65300-bf57-11e9-93da-07ce7be6e892.png)
