### PR TITLE
fix: remove weex module requirement

### DIFF
--- a/packages/jsx2mp-cli/getWebpackConfig.js
+++ b/packages/jsx2mp-cli/getWebpackConfig.js
@@ -30,9 +30,10 @@ function getBabelConfig() {
 function getEntry(type, cwd, entryFilePath, options) {
   const entryPath = dirname(entryFilePath);
   const entry = {};
+  const { platform = 'ali' } = options;
 
   let loaderParams = JSON.stringify({
-    platform: platformConfig[options.platform],
+    platform: platformConfig[platform],
     entryPath: entryFilePath
   });
 
@@ -79,7 +80,7 @@ function getDepPath(path, rootContext) {
 const cwd = process.cwd();
 
 module.exports = (options = {}) => {
-  let { entryPath, type, workDirectory, distDirectory } = options;
+  let { entryPath, type, workDirectory, distDirectory, platform = 'ali' } = options;
   if (entryPath[0] !== '.') entryPath = './' + entryPath;
   entryPath = moduleResolve(workDirectory, entryPath, '.js') || moduleResolve(workDirectory, entryPath, '.jsx') || entryPath;
   const relativeEntryFilePath = './' + relative(workDirectory, entryPath); // src/app.js   or src/mobile/index.js
@@ -102,7 +103,7 @@ module.exports = (options = {}) => {
               options: {
                 mode: options.mode,
                 entryPath: relativeEntryFilePath,
-                platform: platformConfig[options.platform]
+                platform: platformConfig[platform]
               },
             },
             {
@@ -133,7 +134,7 @@ module.exports = (options = {}) => {
           NODE_ENV: '"production"',
         }
       }),
-      new RuntimeWebpackPlugin(),
+      new RuntimeWebpackPlugin({ platform }),
       new webpack.ProgressPlugin( (percentage, message) => {
         if (percentage === 0) {
           buildStartTime = Date.now();

--- a/packages/jsx2mp-loader/package.json
+++ b/packages/jsx2mp-loader/package.json
@@ -12,6 +12,7 @@
     "@babel/core": "^7.5.5",
     "@babel/plugin-proposal-class-properties": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
+    "chalk": "^2.4.2",
     "fs-extra": "^8.1.0",
     "jsx-compiler": "^0.2.0",
     "loader-utils": "^1.2.3"

--- a/packages/jsx2mp-loader/src/babel-plugin-rename-import.js
+++ b/packages/jsx2mp-loader/src/babel-plugin-rename-import.js
@@ -42,7 +42,6 @@ module.exports = function visitor({ types: t }, options) {
           node.arguments &&
           node.arguments.length === 1
         ) {
-
           if (t.isStringLiteral(node.arguments[0])) {
             if (isWeexModule(node.arguments[0].value)) {
               path.replaceWith(t.nullLiteral());
@@ -52,6 +51,7 @@ module.exports = function visitor({ types: t }, options) {
               ];
             }
           } else if (t.isExpression(node.arguments[0])) {
+            // require with expression, can not staticly find target.
             console.warn(chalk.yellow(`Critical requirement of "${path.toString()}", which have been removed at \n${state.filename}.`));
             path.replaceWith(t.nullLiteral());
           }

--- a/packages/jsx2mp-loader/src/file-loader.js
+++ b/packages/jsx2mp-loader/src/file-loader.js
@@ -20,6 +20,7 @@ module.exports = function fileLoader(content) {
   const rootContext = this.rootContext;
   const currentNodeModulePath = join(rootContext, 'node_modules');
   const outputPath = this._compiler.outputPath;
+  const relativeResourcePath = relative(rootContext, this.resourcePath);
 
   const isNodeModule = cached(function isNodeModule(path) {
     return path.indexOf(currentNodeModulePath) === 0;
@@ -85,7 +86,7 @@ module.exports = function fileLoader(content) {
 
       const distSourcePath = normalizeFileName(join(outputPath, 'npm', npmName, splitedNpmPath.join('/')));
       const npmRelativePath = relative(dirname(this.resourcePath), currentNodeModulePath);
-      const { code, map } = transformCode(rawContent, loaderOptions, npmRelativePath);
+      const { code, map } = transformCode(rawContent, loaderOptions, npmRelativePath, relativeResourcePath);
 
       const distSourceDirPath = dirname(distSourcePath);
       if (!existsSync(distSourceDirPath)) mkdirpSync(distSourceDirPath);
@@ -101,7 +102,7 @@ module.exports = function fileLoader(content) {
     const distSourceDirPath = dirname(distSourcePath);
     const npmRelativePath = relative(dirname(distSourcePath), join(outputPath, 'npm'));
 
-    const { code } = transformCode(rawContent, loaderOptions, npmRelativePath);
+    const { code } = transformCode(rawContent, loaderOptions, npmRelativePath, relativeResourcePath);
 
     if (!existsSync(distSourceDirPath)) mkdirpSync(distSourceDirPath);
     writeFileSync(distSourcePath, code, 'utf-8');
@@ -110,7 +111,7 @@ module.exports = function fileLoader(content) {
   return content;
 };
 
-function transformCode(rawCode, loaderOptions, npmRelativePath = '') {
+function transformCode(rawCode, loaderOptions, npmRelativePath = '', resourcePath) {
   const presets = [];
   const plugins = [
     [
@@ -128,6 +129,7 @@ function transformCode(rawCode, loaderOptions, npmRelativePath = '') {
 
   return transformSync(rawCode, {
     presets, plugins,
+    filename: resourcePath,
   });
 }
 

--- a/packages/jsx2mp-runtime/rollup.config.js
+++ b/packages/jsx2mp-runtime/rollup.config.js
@@ -3,12 +3,6 @@ import replace from 'rollup-plugin-replace';
 import filesize from 'rollup-plugin-filesize';
 import { name, version, author } from './package.json';
 
-const banner =
-        `${'/*!\n' + ' * '}${name}.js v${version}\n` +
-        ` * (c) 2019-${new Date().getFullYear()} ${author}\n` +
-        ' * Released under the BSD-3-Clause License.\n' +
-        ' */';
-
 function getPropsIdentifierName(platform) {
   switch (platform) {
     case 'wx':
@@ -44,6 +38,11 @@ function getBabelConfig({ platform = 'ali' }) {
 }
 
 function getRollupConfig(platform) {
+  const banner =
+    `${'/*!\n' + ' * '}${name}.${platform}.js v${version}\n` +
+    ` * (c) 2019-${new Date().getFullYear()} ${author}\n` +
+    ' * Released under the BSD-3-Clause License.\n' +
+    ' */';
   return {
     input: 'src/index.js',
     output: [


### PR DESCRIPTION
1. `requre('@weex-module')` 移除这类节点
2. jsx2mp target 适配多平台, 现在直接把 dist 文件复制到 npm/jsx2mp-runtime.js