### PR TITLE
Fix npm support

### DIFF
--- a/packages/jsx2mp-loader/src/babel-plugin-rename-import.js
+++ b/packages/jsx2mp-loader/src/babel-plugin-rename-import.js
@@ -1,7 +1,8 @@
-const { join } = require('path');
+const { join, relative } = require('path');
+const { existsSync, statSync } = require('fs-extra');
 const chalk = require('chalk');
 
-const WEEX_MODULE_REG = /^@weex\//;
+const WEEX_MODULE_REG = /^@weex(-module)?\//;
 
 function isNpmModule(value) {
   return !(value[0] === '.' || value[0] === '/');
@@ -18,20 +19,27 @@ const defaultOptions = {
 module.exports = function visitor({ types: t }, options) {
   options = Object.assign({}, defaultOptions, options);
   const { normalizeFileName, npmRelativePath } = options;
-  const source = (value, prefix) => t.stringLiteral(
-    normalizeFileName(
-      join(prefix, value)
-    )
-  );
+  const source = (value, prefix, filename, rootContext) => {
+    // Example:
+    // value => '@ali/universal-goldlog'
+    // prefix => '../npm'
+    // filename => '/Users/xxx/workspace/yyy/src/utils/logger.js'
+    // rootContext => '/Users/xxx/workspace/yyy/'
+    const nodeModulePath = join(rootContext, 'node_modules');
+    const target = require.resolve(value, { paths: [nodeModulePath] });
+    const modulePathSuffix = relative(join(nodeModulePath, value), target);
+    // ret => '../npm/_ali/universal-goldlog/lib/index.js
+    return t.stringLiteral(normalizeFileName(join(prefix, value, modulePathSuffix)));
+  };
 
   return {
     visitor: {
-      ImportDeclaration(path) {
+      ImportDeclaration(path, state) {
         const { value } = path.node.source;
         if (isWeexModule(value)) {
           path.remove();
         } else if (isNpmModule(value)) {
-          path.node.source = source(value, npmRelativePath);
+          path.node.source = source(value, npmRelativePath, state.filename, state.cwd);
         }
       },
 
@@ -47,7 +55,7 @@ module.exports = function visitor({ types: t }, options) {
               path.replaceWith(t.nullLiteral());
             } else if (isNpmModule(node.arguments[0].value)) {
               path.node.arguments = [
-                source(node.arguments[0].value, npmRelativePath)
+                source(node.arguments[0].value, npmRelativePath, state.filename, state.cwd)
               ];
             }
           } else if (t.isExpression(node.arguments[0])) {

--- a/packages/jsx2mp-loader/src/file-loader.js
+++ b/packages/jsx2mp-loader/src/file-loader.js
@@ -71,12 +71,8 @@ module.exports = function fileLoader(content) {
         }
       }
     } else {
-      // Copy package.json
       if (!dependenciesCache[npmName]) {
         dependenciesCache[npmName] = true;
-        const target = normalizeFileName(join(outputPath, 'npm', npmName, 'package.json'));
-        if (!existsSync(target))
-          copySync(sourcePackageJSONPath, target, { errorOnExist: false });
       }
 
       // Copy file

--- a/packages/jsx2mp-loader/src/file-loader.js
+++ b/packages/jsx2mp-loader/src/file-loader.js
@@ -48,7 +48,9 @@ module.exports = function fileLoader(content) {
       const source = join(sourcePackagePath, firstLevelFolder);
       const target = join(outputPath, 'npm', npmName, firstLevelFolder);
       mkdirpSync(target);
-      copySync(source, target);
+      copySync(source, target, {
+        filter: (filename) => !/__(mocks|tests?)__/.test(filename),
+      });
 
       // Modify referenced component location
       const componentConfigPath = join(outputPath, 'npm', npmName, pkg.miniappConfig.main + '.json');

--- a/packages/jsx2mp-runtime/package.json
+++ b/packages/jsx2mp-runtime/package.json
@@ -4,7 +4,7 @@
   "description": "Runtime for jsx2mp.",
   "miniprogram": {
     "ali": "dist/jsx2mp-runtime.ali.esm.js",
-    "wx": "dist/jsx2mp-runtime.wx.esm.js"
+    "wechat": "dist/jsx2mp-runtime.wx.esm.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
1. 解析 npm 依赖和依赖的依赖的路径, 支持微信, 如

```js
import { isMiniApp } from 'universal-env';
```

现在会直接解析成

```js
import { isMiniApp } from '../npm/universal-env/lib/index.js';
```

并且只有 `lib/index.js` 这一个文件会被复制到 dist (按需)

2. 复制同构组件的支付宝小程序实现部分时，只复制一级目录, 不整个复制, 解决微信会无脑编译所有文件(包括测试用例)导致报错的问题