### PR TITLE
perf: cache css value

### DIFF
--- a/packages/rax-server-renderer/src/__tests__/renderToString.js
+++ b/packages/rax-server-renderer/src/__tests__/renderToString.js
@@ -121,6 +121,86 @@ describe('renderToString', () => {
     expect(str).toBe('<div style="line-height:1;"><p style="line-height:10vw;">Hello</p></div>');
   });
 
+  it('render items with same style', () => {
+    const style = {
+      color: '#f00',
+      fontSize: '16px'
+    };
+
+    function MyComponent(props, context) {
+      const data = [1, 2];
+      return (
+        <div>
+          {
+            data.map(() => <div style={style}>hello</div>)
+          }
+        </div>
+      );
+    }
+
+    const str = renderToString(<MyComponent />);
+    expect(str).toBe('<div><div style="color:#f00;font-size:16px;">hello</div><div style="color:#f00;font-size:16px;">hello</div></div>');
+  });
+
+  it('render items with a base style', () => {
+    const style = {
+      color: '#f00',
+      fontSize: '16px'
+    };
+
+    function MyComponent(props, context) {
+      const data = [1, 2];
+      return (
+        <div>
+          {
+            data.map((item, index) => <div style={{...style, fontSize: index + 'px'}}>hello</div>)
+          }
+        </div>
+      );
+    }
+
+    const str = renderToString(<MyComponent />);
+    expect(str).toBe('<div><div style="color:#f00;font-size:0px;">hello</div><div style="color:#f00;font-size:1px;">hello</div></div>');
+  });
+
+  it('render items with change to base style', () => {
+    const style = {
+      color: '#f00',
+      fontSize: '16px'
+    };
+
+    function MyComponent(props, context) {
+      const data = [1, 2];
+      return (
+        <div>
+          {
+            data.map((item, index) => {
+              // after map, style.fontSize will be 1px
+              style.fontSize = index + 'px';
+              return <div style={style}>hello</div>;
+            })
+          }
+        </div>
+      );
+    }
+
+    const str = renderToString(<MyComponent />);
+    expect(str).toBe('<div><div style="color:#f00;font-size:1px;">hello</div><div style="color:#f00;font-size:1px;">hello</div></div>');
+  });
+
+  it('render component with style from props', () => {
+    function MyComponent(props, context) {
+      return (
+        <div style={{fontSize: props.size + 'px'}}>
+          hello
+        </div>
+      );
+    }
+
+    const str = renderToString(<MyComponent size={12} />);
+    expect(str).toBe('<div style="font-size:12px;">hello</div>');
+  });
+
   it('render with options which set default unit to rpx', () => {
     const styles = {
       container: {

--- a/packages/rax-server-renderer/src/index.js
+++ b/packages/rax-server-renderer/src/index.js
@@ -90,17 +90,17 @@ const DEFAULT_STYLE_OPTIONS = {
 const UPPERCASE_REGEXP = /[A-Z]/g;
 const NUMBER_REGEXP = /^[0-9]*$/;
 const CSSPropCache = {};
-const CSSCacheKey = '__cssValue__';
+const CSS_CACHE_KEY = '__cssValue__';
 
 function styleToCSS(style, options = {}) {
   const isObject = typeof style === 'object';
 
   // reuse the css value from cache
-  if (isObject && style[CSSCacheKey]) {
-    return style[CSSCacheKey];
+  if (isObject && style[CSS_CACHE_KEY]) {
+    return style[CSS_CACHE_KEY];
   }
 
-  let css = 'i';
+  let css = '';
 
   if (Array.isArray(style)) {
     style = style.reduce((prev, curr) => Object.assign(prev, curr), {});
@@ -128,7 +128,7 @@ function styleToCSS(style, options = {}) {
 
   if (isObject) {
     // cache css value for elements reuse the same style
-    Object.defineProperty(style, CSSCacheKey, {
+    Object.defineProperty(style, CSS_CACHE_KEY, {
       value: css
     });
   }

--- a/packages/rax-server-renderer/src/index.js
+++ b/packages/rax-server-renderer/src/index.js
@@ -90,7 +90,7 @@ const DEFAULT_STYLE_OPTIONS = {
 const UPPERCASE_REGEXP = /[A-Z]/g;
 const NUMBER_REGEXP = /^[0-9]*$/;
 const CSSPropCache = {};
-const CSS_CACHE_KEY = '__cssValue__';
+const CSS_CACHE_KEY = '__css__';
 
 function styleToCSS(style, options = {}) {
   const isObject = typeof style === 'object';

--- a/packages/rax-server-renderer/src/index.js
+++ b/packages/rax-server-renderer/src/index.js
@@ -90,9 +90,17 @@ const DEFAULT_STYLE_OPTIONS = {
 const UPPERCASE_REGEXP = /[A-Z]/g;
 const NUMBER_REGEXP = /^[0-9]*$/;
 const CSSPropCache = {};
+const CSSCacheKey = '__cssValue__';
 
 function styleToCSS(style, options = {}) {
-  let css = '';
+  const isObject = typeof style === 'object';
+
+  // reuse the css value from cache
+  if (isObject && style[CSSCacheKey]) {
+    return style[CSSCacheKey];
+  }
+
+  let css = 'i';
 
   if (Array.isArray(style)) {
     style = style.reduce((prev, curr) => Object.assign(prev, curr), {});
@@ -117,6 +125,14 @@ function styleToCSS(style, options = {}) {
     prop = CSSPropCache[prop] ? CSSPropCache[prop] : CSSPropCache[prop] = prop.replace(UPPERCASE_REGEXP, '-$&').toLowerCase();
     css = css + `${prop}:${val}${unit};`;
   }
+
+  if (isObject) {
+    // cache css value for elements reuse the same style
+    Object.defineProperty(style, CSSCacheKey, {
+      value: css
+    });
+  }
+
   return css;
 }
 


### PR DESCRIPTION
before

React#renderToString x 1,170 ops/sec ±1.24% (86 runs sampled)
Rax#renderToString x 2,032 ops/sec ±1.24% (89 runs sampled)
Inferno#renderToString x 4,121 ops/sec ±1.06% (88 runs sampled)

after

React#renderToString x 1,177 ops/sec ±1.28% (83 runs sampled)
Rax#renderToString x 4,908 ops/sec ±1.49% (83 runs sampled)
Inferno#renderToString x 3,649 ops/sec ±10.91% (79 runs sampled)