### PR TITLE
fix: search npm module and support plugins

### DIFF
--- a/packages/jsx2mp-loader/src/babel-plugin-rename-import.js
+++ b/packages/jsx2mp-loader/src/babel-plugin-rename-import.js
@@ -16,22 +16,35 @@ const defaultOptions = {
   normalizeFileName: (s) => s,
 };
 
+function getNpmName(value) {
+  const isScopedNpm = /^_?@/.test(value);
+  return value.split('/').slice(0, isScopedNpm ? 2 : 1).join('/');
+}
+
 module.exports = function visitor({ types: t }, options) {
   options = Object.assign({}, defaultOptions, options);
   const { normalizeFileName, npmRelativePath } = options;
-  const source = (npmName, prefix, filename, rootContext) => {
+  const source = (value, prefix, filename, rootContext) => {
+    const npmName = getNpmName(value);
     // Example:
-    // value => '@ali/universal-goldlog'
+    // value => '@ali/universal-goldlog' or '@ali/xxx/foo/lib'
     // prefix => '../npm'
     // filename => '/Users/xxx/workspace/yyy/src/utils/logger.js'
     // rootContext => '/Users/xxx/workspace/yyy/'
     const nodeModulePath = join(rootContext, 'node_modules');
     const searchPaths = [nodeModulePath];
-    const target = require.resolve(npmName, { paths: searchPaths });
+    const target = require.resolve(value, { paths: searchPaths });
 
     // In tnpm, target will be like following (symbol linked path):
     // ***/_universal-toast_1.0.0_universal-toast/lib/index.js
-    const moduleBasePath = join(require.resolve(join(npmName, 'package.json'), { paths: searchPaths }), '..');
+    let packageJSONPath;
+    try {
+      packageJSONPath = require.resolve(join(npmName, 'package.json'), { paths: searchPaths });
+    } catch (err) {
+      throw new Error(`You may not have npm installed: "${npmName}"`);
+    }
+
+    const moduleBasePath = join(packageJSONPath, '..');
     const modulePathSuffix = relative(moduleBasePath, target);
     // ret => '../npm/_ali/universal-goldlog/lib/index.js
     return t.stringLiteral(normalizeFileName(join(prefix, npmName, modulePathSuffix)));

--- a/packages/jsx2mp-loader/src/file-loader.js
+++ b/packages/jsx2mp-loader/src/file-loader.js
@@ -117,10 +117,27 @@ function transformCode(rawCode, loaderOptions, npmRelativePath = '', resourcePat
     plugins.push(require('@babel/plugin-proposal-class-properties'));
   }
 
+  const babelParserOption = {
+    plugins: [
+      'classProperties',
+      'jsx',
+      'flow',
+      'flowComment',
+      'trailingFunctionCommas',
+      'asyncFunctions',
+      'exponentiationOperator',
+      'asyncGenerators',
+      'objectRestSpread',
+      ['decorators', { decoratorsBeforeExport: false }],
+      'dynamicImport',
+    ], // support all plugins
+  };
+
   return transformSync(rawCode, {
     presets,
     plugins,
     filename: resourcePath,
+    parserOpts: babelParserOption,
   });
 }
 


### PR DESCRIPTION
1. 修复 `import foo from 'xxx/lib/ccc'` 这种直接寻找文件的引入方式
2. 修复 file-loader babel 解析 jsx 报错的问题