### PR TITLE
feat: tansform jsx to html

### DIFF
--- a/packages/babel-plugin-transform-jsx-to-html/README.md
+++ b/packages/babel-plugin-transform-jsx-to-html/README.md
@@ -88,20 +88,15 @@ output
 
 ```js
 [{
-  __html: "<div class=\\"container\\""
+  __html: "<div class=\"container\""
 }, {
   __attrs: {
     style: style,
     onClick: onClick
   }
 }, {
-  __html: ">"
-}, [{
-  __html: "<div>"
-}, "a ", props.index, {
-  __html: "</div>"
-}], {
-  __html: "</div>"
+  __html: "><div>a "
+}, props.index, {
+  __html: "</div></div>"
 }]
-
 ```

--- a/packages/babel-plugin-transform-jsx-to-html/README.md
+++ b/packages/babel-plugin-transform-jsx-to-html/README.md
@@ -1,0 +1,107 @@
+# babel-plugin-transform-jsx-to-html
+> Transform jsx to html string for better ssr performance.
+
+## Installation
+
+```sh
+npm install --save-dev babel-plugin-transform-jsx-to-html
+```
+
+## Usage
+
+### Via `.babelrc`
+
+**.babelrc**
+
+```json
+{
+  "plugins": [
+    "babel-plugin-transform-jsx-to-html",
+    "babel/plugin-transform-react-jsx"
+  ]
+}
+```
+
+## Example
+
+### basic example
+
+Your `component.js` that contains this code:
+
+```js
+import { createElement, Component } from 'rax';
+
+class App extends Component {
+  render() {
+    return <div className="header" />
+  }
+}
+```
+
+Will be transpiled like this:
+
+```js
+import { createElement, Component } from 'rax';
+
+class App extends Component {
+  render() {
+    return [{
+      __html: '<div class="header" />'
+    }];
+  }
+}
+```
+
+These pre transpiled html can be used in server renderer, like [rax-server-renderer](https://github.com/alibaba/rax/tree/master/packages/rax-server-renderer)
+
+### more examples
+
+input 
+
+```jsx
+<div>
+  <View />
+</div>
+```
+
+output
+
+```js
+[{
+   __html: "<div>"
+}, 
+createElement(View, null),
+{
+  __html: "</div>"
+}]
+```
+
+input 
+
+```jsx
+<div className="container" style={style} onClick={onClick}>
+  <div>a {props.index}</div>
+</div>
+```
+
+output
+
+```js
+[{
+  __html: "<div class=\\"container\\""
+}, {
+  __attrs: {
+    style: style,
+    onClick: onClick
+  }
+}, {
+  __html: ">"
+}, [{
+  __html: "<div>"
+}, "a ", props.index, {
+  __html: "</div>"
+}], {
+  __html: "</div>"
+}]
+
+```

--- a/packages/babel-plugin-transform-jsx-to-html/package.json
+++ b/packages/babel-plugin-transform-jsx-to-html/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "babel-plugin-transform-jsx-to-html",
+  "version": "0.1.0",
+  "description": "Transform JSX to Html.",
+  "license": "BSD-3-Clause",
+  "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alibaba/rax.git"
+  },
+  "bugs": {
+    "url": "https://github.com/alibaba/rax/issues"
+  },
+  "homepage": "https://github.com/alibaba/rax#readme",
+  "engines": {
+    "npm": ">=3.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.5.5",
+    "@babel/preset-env": "^7.5.5",
+    "@babel/preset-react": "^7.0.0"
+  },
+  "dependencies": {
+    "@babel/types": "^7.5.5",
+    "esutils": "^2.0.3"
+  }
+}

--- a/packages/babel-plugin-transform-jsx-to-html/package.json
+++ b/packages/babel-plugin-transform-jsx-to-html/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-transform-jsx-to-html",
   "version": "0.1.0",
-  "description": "Transform JSX to Html.",
+  "description": "Transform JSX to HTML.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
   "repository": {

--- a/packages/babel-plugin-transform-jsx-to-html/src/__tests__/index.js
+++ b/packages/babel-plugin-transform-jsx-to-html/src/__tests__/index.js
@@ -30,17 +30,7 @@ describe('transform jsx to html', () => {
   <div>b</div>
 </div>
     `)).toBe(`[{
-  __html: "<div>"
-}, [{
-  __html: "<div>"
-}, "a", {
-  __html: "</div>"
-}], [{
-  __html: "<div>"
-}, "b", {
-  __html: "</div>"
-}], {
-  __html: "</div>"
+  __html: "<div><div>a</div><div>b</div></div>"
 }];`);
   });
 
@@ -63,13 +53,9 @@ describe('transform jsx to html', () => {
   <div>b</div>
 </View>
     `)).toBe(`createElement(View, null, [{
-  __html: "<div>"
-}, "a", {
-  __html: "</div>"
+  __html: "<div>a</div>"
 }], [{
-  __html: "<div>"
-}, "b", {
-  __html: "</div>"
+  __html: "<div>b</div>"
 }]);`);
   });
 
@@ -87,17 +73,11 @@ describe('transform jsx to html', () => {
     onClick: onClick
   }
 }, {
-  __html: ">"
-}, [{
-  __html: "<div>"
-}, "a ", props.index, {
-  __html: "</div>"
-}], [{
-  __html: "<div>"
-}, "b ", props.index, {
-  __html: "</div>"
-}], {
-  __html: "</div>"
+  __html: "><div>a "
+}, props.index, {
+  __html: "</div><div>b "
+}, props.index, {
+  __html: "</div></div>"
 }];`);
   });
 
@@ -113,13 +93,7 @@ describe('transform jsx to html', () => {
     className: className
   }, props)
 }, {
-  __html: ">"
-}, [{
-  __html: "<div>"
-}, "a", {
-  __html: "</div>"
-}], {
-  __html: "</div>"
+  __html: "><div>a</div></div>"
 }];`);
   });
 
@@ -130,10 +104,8 @@ const slot = <div>slot</div>;
 <div className="container">
   {slot}
 </div>
-    `)).toBe(`var slot = [{
-  __html: "<div>"
-}, "slot", {
-  __html: "</div>"
+`)).toBe(`var slot = [{
+  __html: "<div>slot</div>"
 }];
 [{
   __html: "<div class=\\"container\\">"
@@ -160,23 +132,19 @@ const slot = createElement('div', null, 'slot');
     expect(getTransfromCode(`
 <div dangerouslySetInnerHTML={{__html: "<div>a</div>"}} />
     `)).toBe(`[{
-  __html: "<div>"
-}, {
-  __html: "<div>a</div>"
-}, {
-  __html: "</div>"
+  __html: "<div><div>a</div></div>"
 }];`);
   });
 
   it('tansform with children and innnerHtml', () => {
     expect(getTransfromCode(`
-<div dangerouslySetInnerHTML={{__html: "<div>a</div>"}}>
+<div dangerouslySetInnerHTML={{__html: a}}>
   123
 </div>
     `)).toBe(`[{
   __html: "<div>"
 }, {
-  __html: "<div>a</div>"
+  __html: a
 }, {
   __html: "</div>"
 }];`);

--- a/packages/babel-plugin-transform-jsx-to-html/src/__tests__/index.js
+++ b/packages/babel-plugin-transform-jsx-to-html/src/__tests__/index.js
@@ -1,0 +1,160 @@
+const jsxToHtmlPlugin = require('../index');
+const { transformSync } = require('@babel/core');
+
+function getTransfromCode(code, opts) {
+  return transformSync(code, {
+    filename: './',
+    presets: [
+      ['@babel/preset-env', {
+        'loose': true,
+        'modules': false
+      }],
+      require.resolve('@babel/preset-react'),
+    ],
+    plugins: [
+      jsxToHtmlPlugin,
+      ['@babel/plugin-transform-react-jsx', {
+        pragma: 'createElement'
+      }],
+    ],
+  }).code;
+}
+
+describe('transform jsx to html', () => {
+  it('tansform with pure html tags', () => {
+    expect(getTransfromCode(`
+<div>
+  <div>a</div>
+  <div>b</div>
+</div>
+    `)).toBe(`[{
+  __html: "<div>"
+}, [{
+  __html: "<div>"
+}, "a", {
+  __html: "</div>"
+}], [{
+  __html: "<div>"
+}, "b", {
+  __html: "</div>"
+}], {
+  __html: "</div>"
+}];`);
+  });
+
+  it('tansform with component', () => {
+    expect(getTransfromCode(`
+<div>
+  <View />
+</div>
+    `)).toBe(`[{
+  __html: "<div>"
+}, createElement(View, null), {
+  __html: "</div>"
+}];`);
+  });
+
+  it('tansform component with children', () => {
+    expect(getTransfromCode(`
+<View>
+  <div>a</div>
+  <div>b</div>
+</View>
+    `)).toBe(`createElement(View, null, [{
+  __html: "<div>"
+}, "a", {
+  __html: "</div>"
+}], [{
+  __html: "<div>"
+}, "b", {
+  __html: "</div>"
+}]);`);
+  });
+
+  it('tansform with props', () => {
+    expect(getTransfromCode(`
+<div className="container" style={style} onClick={onClick}>
+  <div>a {props.index}</div>
+  <div>b {props.index}</div>
+</div>
+    `)).toBe(`[{
+  __html: "<div class=\\"container\\""
+}, {
+  __attrs: {
+    style: style,
+    onClick: onClick
+  }
+}, {
+  __html: ">"
+}, [{
+  __html: "<div>"
+}, "a ", props.index, {
+  __html: "</div>"
+}], [{
+  __html: "<div>"
+}, "b ", props.index, {
+  __html: "</div>"
+}], {
+  __html: "</div>"
+}];`);
+  });
+
+  it('tansform with slot', () => {
+    expect(getTransfromCode(`
+const slot = <div>slot</div>;
+
+<div className="container">
+  {slot}
+</div>
+    `)).toBe(`var slot = [{
+  __html: "<div>"
+}, "slot", {
+  __html: "</div>"
+}];
+[{
+  __html: "<div class=\\"container\\">"
+}, slot, {
+  __html: "</div>"
+}];`);
+  });
+
+  it('tansform with es5 component', () => {
+    expect(getTransfromCode(`
+const slot = createElement('div', null, 'slot');
+<div className="container">
+  {slot}
+</div>
+    `)).toBe(`var slot = createElement('div', null, 'slot');
+[{
+  __html: "<div class=\\"container\\">"
+}, slot, {
+  __html: "</div>"
+}];`);
+  });
+
+  it('tansform with innnerHtml', () => {
+    expect(getTransfromCode(`
+<div dangerouslySetInnerHTML={{__html: "<div>a</div>"}} />
+    `)).toBe(`[{
+  __html: "<div>"
+}, {
+  __html: "<div>a</div>"
+}, {
+  __html: "</div>"
+}];`);
+  });
+
+  it('tansform with children and innnerHtml', () => {
+    expect(getTransfromCode(`
+<div dangerouslySetInnerHTML={{__html: "<div>a</div>"}}>
+  123
+</div>
+    `)).toBe(`[{
+  __html: "<div>"
+}, {
+  __html: "<div>a</div>"
+}, {
+  __html: "</div>"
+}];`);
+  });
+});

--- a/packages/babel-plugin-transform-jsx-to-html/src/__tests__/index.js
+++ b/packages/babel-plugin-transform-jsx-to-html/src/__tests__/index.js
@@ -12,7 +12,9 @@ function getTransfromCode(code, opts) {
       require.resolve('@babel/preset-react'),
     ],
     plugins: [
-      jsxToHtmlPlugin,
+      [jsxToHtmlPlugin, {
+        useBuiltIns: true
+      }],
       ['@babel/plugin-transform-react-jsx', {
         pragma: 'createElement'
       }],
@@ -93,6 +95,28 @@ describe('transform jsx to html', () => {
 }], [{
   __html: "<div>"
 }, "b ", props.index, {
+  __html: "</div>"
+}], {
+  __html: "</div>"
+}];`);
+  });
+
+  it('transform wisth jsx spread attribute', () => {
+    expect(getTransfromCode(`
+<div className={className} {...props}>
+  <div>a</div>
+</div>
+    `)).toBe(`[{
+  __html: "<div"
+}, {
+  __attrs: Object.assign({
+    className: className
+  }, props)
+}, {
+  __html: ">"
+}, [{
+  __html: "<div>"
+}, "a", {
   __html: "</div>"
 }], {
   __html: "</div>"

--- a/packages/babel-plugin-transform-jsx-to-html/src/index.js
+++ b/packages/babel-plugin-transform-jsx-to-html/src/index.js
@@ -103,7 +103,7 @@ function buildOpeningElementAttributes(attribs, file) {
   while (attribs.length) {
     const prop = attribs.shift();
 
-    if (prop.name.name === 'dangerouslySetInnerHTML') {
+    if (prop.name && prop.name.name === 'dangerouslySetInnerHTML') {
       innerHTML = prop.value.expression;
     } else if (t.isJSXSpreadAttribute(prop)) {
       _props = pushProps(_props, objs);

--- a/packages/babel-plugin-transform-jsx-to-html/src/index.js
+++ b/packages/babel-plugin-transform-jsx-to-html/src/index.js
@@ -1,0 +1,191 @@
+const esutils = require('esutils');
+const t = require('@babel/types');
+
+const KEY_FOR_HTML = '__html';
+const KEY_FOR_ATTRS = '__attrs';
+
+module.exports = function() {
+  return {
+    visitor: {
+      JSXElement: {
+        exit(path, file) {
+          const openingPath = path.get('openingElement');
+          const tag = openingPath.node.name;
+          const tagName = tag.name;
+
+          if (!t.react.isCompatTag(tagName)) {
+            return;
+          }
+
+          let result = [];
+
+          let html = '<' + tagName;
+
+          let attrs = openingPath.node.attributes;
+          if (attrs.length) {
+            attrs = buildOpeningElementAttributes(attrs, file);
+          } else {
+            attrs = {};
+          }
+
+          const {
+            staticAttrs,
+            dynamicAttrs,
+            innerHTML
+          } = attrs;
+
+          if (staticAttrs) {
+            html = html + staticAttrs;
+          }
+
+          if (dynamicAttrs) {
+            result.push(buildObject(KEY_FOR_HTML, t.stringLiteral(html)));
+            result.push(buildObject(KEY_FOR_ATTRS, dynamicAttrs));
+            html = '';
+          }
+
+          html = html + (openingPath.node.selfClosing && !innerHTML ? '/>' : '>');
+          result.push(buildObject(KEY_FOR_HTML, t.stringLiteral(html)));
+          html = '';
+
+          if (innerHTML) {
+            // {__html: 'First &middot; Second'}
+            // structure of dangerouslySetInnerHTML is same as {KEY_FOR_HTML: xxx}
+            result.push(innerHTML);
+          } else {
+            const children = t.react.buildChildren(openingPath.parent);
+            result = result.concat(children);
+          }
+
+          if (path.node.closingElement || innerHTML) {
+            html = '</' + tagName + '>';
+            result.push(buildObject(KEY_FOR_HTML, t.stringLiteral(html)));
+          }
+
+          if (result && result.length) {
+            path.replaceWith(t.arrayExpression(result));
+          }
+        }
+      }
+    }
+  };
+};
+
+function buildObject(name, value) {
+  let obj = t.objectProperty(t.identifier(name), value);
+  return t.objectExpression([obj]);
+}
+
+/**
+ * The logic for this is quite terse. It's because we need to
+ * support spread elements. We loop over all attributes,
+ * breaking on spreads, we then push a new object containing
+ * all prior attributes to an array for later processing.
+ *
+ * based on babel-helper-builder-react-jsx
+ */
+function buildOpeningElementAttributes(attribs, file) {
+  let staticAttrs = '';
+  let dynamicAttrs;
+  let innerHTML;
+
+  let _props = [];
+  const objs = [];
+
+  const useBuiltIns = file.opts.useBuiltIns || false;
+  if (typeof useBuiltIns !== 'boolean') {
+    throw new Error(
+      'transform-react-jsx currently only accepts a boolean option for ' +
+        'useBuiltIns (defaults to false)',
+    );
+  }
+
+  while (attribs.length) {
+    const prop = attribs.shift();
+
+    if (prop.name.name === 'dangerouslySetInnerHTML') {
+      innerHTML = prop.value.expression;
+    } else if (t.isJSXSpreadAttribute(prop)) {
+      _props = pushProps(_props, objs);
+      objs.push(prop.argument);
+    } else {
+      if (t.isStringLiteral(prop.value)) {
+        let name = prop.name.name;
+        if (name === 'className') {
+          name = 'class';
+        }
+        const value = prop.value.value.replace(/\n\s+/g, ' ');
+        staticAttrs = staticAttrs + ' ' + name + '="' + value + '"';
+      } else {
+        _props.push(convertAttribute(prop));
+      }
+    }
+  }
+
+  pushProps(_props, objs);
+
+  if (!objs.length) {
+    // noop
+  } else if (objs.length === 1) {
+    // only one object
+    dynamicAttrs = objs[0];
+  } else {
+    // looks like we have multiple objects
+    if (!t.isObjectExpression(objs[0])) {
+      objs.unshift(t.objectExpression([]));
+    }
+
+    const helper = useBuiltIns
+      ? t.memberExpression(t.identifier('Object'), t.identifier('assign'))
+      : file.addHelper('extends');
+
+    // spread it
+    dynamicAttrs = t.callExpression(helper, objs);
+  }
+
+  return {
+    staticAttrs: staticAttrs,
+    dynamicAttrs: dynamicAttrs,
+    innerHTML: innerHTML
+  };
+}
+
+function pushProps(_props, objs) {
+  if (!_props.length) return _props;
+
+  objs.push(t.objectExpression(_props));
+  return [];
+}
+
+function convertAttributeValue(node) {
+  if (t.isJSXExpressionContainer(node)) {
+    return node.expression;
+  } else {
+    return node;
+  }
+}
+
+function convertAttribute(node) {
+  const value = convertAttributeValue(node.value || t.booleanLiteral(true));
+
+  if (t.isStringLiteral(value) && !t.isJSXExpressionContainer(node.value)) {
+    value.value = value.value.replace(/\n\s+/g, ' ');
+
+    // "raw" JSXText should not be used from a StringLiteral because it needs to be escaped.
+    if (value.extra && value.extra.raw) {
+      delete value.extra.raw;
+    }
+  }
+
+  if (t.isJSXNamespacedName(node.name)) {
+    node.name = t.stringLiteral(
+      node.name.namespace.name + ':' + node.name.name.name,
+    );
+  } else if (esutils.keyword.isIdentifierNameES6(node.name.name)) {
+    node.name.type = 'Identifier';
+  } else {
+    node.name = t.stringLiteral(node.name.name);
+  }
+
+  return t.inherits(t.objectProperty(node.name, value), node);
+}

--- a/packages/rax-server-renderer/src/__tests__/renderToString.js
+++ b/packages/rax-server-renderer/src/__tests__/renderToString.js
@@ -373,7 +373,7 @@ describe('renderToString', () => {
     expect(str).toBe('<div>Count: 0</div>');
   });
 
-  it('render with pre compined html and attrs', () => {
+  it('render with pre compiled html and attrs', () => {
     function View(props) {
       return (
         <div>{props.name}</div>
@@ -410,5 +410,52 @@ describe('renderToString', () => {
 
     let str = renderToString(<MyComponent title="welcome" name="rax" version="1.0" />);
     expect(str).toBe('<div class="container" title="welcome"><div>hello</div><div>rax</div>1.0</div>');
+  });
+
+  it('render pre compiled html with state hook', () => {
+    function MyComponent(props) {
+      const [name, setName] = useState(props.name);
+
+      return [
+        {
+          __html: '<h1>Hello ',
+        },
+        name,
+        {
+          __html: '</h1>'
+        }
+      ];
+    };
+
+    let str = renderToString(<MyComponent name="rax" />);
+    expect(str).toBe('<h1>Hello rax</h1>');
+  });
+
+  it('render pre compiled html with context', () => {
+    const ThemeContext = createContext('light');
+
+    function MyContext() {
+      return (
+        <ThemeContext.Provider value={'dark'}>
+          <MyComponent />
+        </ThemeContext.Provider>
+      );
+    };
+
+    function MyComponent() {
+      const value = useContext(ThemeContext);
+      return [
+        {
+          __html: '<div>Current theme is ',
+        },
+        value,
+        {
+          __html: '</div>'
+        }
+      ];
+    };
+
+    let str = renderToString(<MyContext />);
+    expect(str).toBe('<div>Current theme is dark</div>');
   });
 });

--- a/packages/rax-server-renderer/src/__tests__/renderToString.js
+++ b/packages/rax-server-renderer/src/__tests__/renderToString.js
@@ -372,4 +372,43 @@ describe('renderToString', () => {
     let str = renderToString(<MyComponent initialCount={0} />);
     expect(str).toBe('<div>Count: 0</div>');
   });
+
+  it('render with pre compined html and attrs', () => {
+    function View(props) {
+      return (
+        <div>{props.name}</div>
+      );
+    }
+
+    function MyComponent(props) {
+      // <div className="container" title={props.title}>
+      //   <div>hello</div>
+      //   <View name={props.name} />
+      //   {props.version}
+      // </div>
+
+      return (
+        [{
+          __html: '<div class="container"'
+        }, {
+          __attrs: {
+            title: props.title
+          }
+        }, {
+          __html: '>'
+        }, [{
+          __html: '<div>'
+        }, 'hello', {
+          __html: '</div>'
+        }], createElement(View, {
+          name: props.name
+        }), props.version, {
+          __html: '</div>'
+        }]
+      );
+    }
+
+    let str = renderToString(<MyComponent title="welcome" name="rax" version="1.0" />);
+    expect(str).toBe('<div class="container" title="welcome"><div>hello</div><div>rax</div>1.0</div>');
+  });
 });


### PR DESCRIPTION
pre tansform jsx to html for better ssr performance.

input 

```jsx
<div className="container" style={style} onClick={onClick}>
  <div>a {props.index}</div>
</div>
```

output

```js
[{
  __html: "<div class=\\"container\\""
}, {
  __attrs: {
    style: style,
    onClick: onClick
  }
}, {
  __html: ">"
}, [{
  __html: "<div>"
}, "a ", props.index, {
  __html: "</div>"
}], {
  __html: "</div>"
}]
```

benchmark (use inline style, about 1000 nodes)

```bash
mean:0.883ms
React#renderToString x 1,132 ops/sec ±2.17% (84 runs sampled)
mean:0.315ms
Rax#renderToString x 3,173 ops/sec ±1.64% (86 runs sampled)
```

benchmark (use className, about 1000 nodes))

```bash
mean:0.626ms
React#renderToString x 1,598 ops/sec ±3.11% (82 runs sampled)
mean:0.099ms
Rax#renderToString x 10,101 ops/sec ±1.85% (83 runs sampled)
mean:0.075ms
Marko#renderToString x 13,332 ops/sec ±2.45% (85 runs sampled)
mean:0.090ms
Xtpl#renderFile x 11,065 ops/sec ±5.92% (67 runs sampled)
```