### PR TITLE
Optimize scheduler size and performance

### DIFF
--- a/packages/rax/src/vdom/scheduler.js
+++ b/packages/rax/src/vdom/scheduler.js
@@ -11,7 +11,9 @@ if (process.env.NODE_ENV !== 'production') {
 
 // Schedule before next render
 export function schedule(callback) {
-  updateCallbacks.length === 0 && scheduler(flush);
+  if (updateCallbacks.length === 0) {
+    scheduler(flush);
+  }
   updateCallbacks.push(callback);
 }
 
@@ -24,7 +26,9 @@ export function flush() {
 }
 
 export function scheduleEffect(callback) {
-  effectCallbacks.length === 0 && scheduler(flushEffect);
+  if (effectCallbacks.length === 0) {
+    scheduler(flushEffect);
+  }
   effectCallbacks.push(callback);
 }
 

--- a/packages/rax/src/vdom/scheduler.js
+++ b/packages/rax/src/vdom/scheduler.js
@@ -11,32 +11,26 @@ if (process.env.NODE_ENV !== 'production') {
 
 // Schedule before next render
 export function schedule(callback) {
-  if (updateCallbacks.length === 0) {
-    scheduler(flush);
-  }
+  updateCallbacks.length === 0 && scheduler(flush);
   updateCallbacks.push(callback);
 }
 
 // Flush before next render
 export function flush() {
-  let callbacks = updateCallbacks;
-  if (callbacks.length !== 0) {
-    updateCallbacks = [];
-    callbacks.forEach(callback => callback());
+  let callback;
+  while (callback = updateCallbacks.shift()) {
+    callback();
   }
 }
 
 export function scheduleEffect(callback) {
-  if (effectCallbacks.length === 0) {
-    scheduler(flushEffect);
-  }
+  effectCallbacks.length === 0 && scheduler(flushEffect);
   effectCallbacks.push(callback);
 }
 
 export function flushEffect() {
-  let callbacks = effectCallbacks;
-  if (callbacks.length !== 0) {
-    effectCallbacks = [];
-    callbacks.forEach(callback => callback());
+  let callback;
+  while (callback = effectCallbacks.shift()) {
+    callback();
   }
 }


### PR DESCRIPTION
+ Performance: Use while instead of foreach for a small performance boost. [jsperf](https://jsperf.com/while-foreach)
+ Packet size： Reduce 0.0058 KB