### PR TITLE
build: npm run build ignore __mocks__ folder

### DIFF
--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -24,7 +24,7 @@ const chokidar = require('chokidar');
 const SRC_DIR = 'src';
 const BUILD_DIR = 'lib';
 const JS_FILES_PATTERN = '**/*.js';
-const IGNORE_PATTERN = '**/__tests__/**';
+const IGNORE_PATTERN = '**/{__tests__,__mocks__}/**';
 
 const args = parseArgs(process.argv);
 const customPackages = args.packages;


### PR DESCRIPTION
npm run build will release __mocks__ directory into lib folder and it will cause jest warning about duplicate Mock path.

![image](https://user-images.githubusercontent.com/4409743/64406065-71e3f900-d0b3-11e9-9729-ebc01ed5be3d.png)

