### PR TITLE
fix: use for loop instead of while to avoid mutate array iteself

### DIFF
--- a/packages/rax/src/__tests__/fragment.js
+++ b/packages/rax/src/__tests__/fragment.js
@@ -5,6 +5,7 @@ import Host from '../vdom/host';
 import render from '../render';
 import ServerDriver from 'driver-server';
 import Fragment from '../fragment';
+import Component from '../vdom/component';
 
 describe('Fragment', () => {
   function createNodeElement(tagName) {
@@ -100,5 +101,38 @@ describe('Fragment', () => {
     const container = createNodeElement('div');
     render(<Fragment />, container);
     expect(container.childNodes[0].nodeType).toBe(8);
+  });
+
+  it('should render correct from not empty array to other', function() {
+    let el = createNodeElement('div');
+
+    function F({ type }) {
+      if (type === 'notEmpty') {
+        return ['4'];
+      }
+      return <div>2</div>;
+    }
+
+    class App extends Component {
+      render() {
+        return (
+          [
+            <div>1</div>,
+            <F type={this.props.type} />,
+            <div>3</div>,
+          ]
+        );
+      }
+    }
+
+    render(<App type={'notEmpty'} />, el);
+    expect(el.childNodes[0].childNodes[0].data).toBe('1');
+    expect(el.childNodes[1].data).toBe('4');
+    expect(el.childNodes[2].childNodes[0].data).toBe('3');
+
+    render(<App />, el);
+    expect(el.childNodes[0].childNodes[0].data).toBe('1');
+    expect(el.childNodes[1].childNodes[0].data).toBe('2');
+    expect(el.childNodes[2].childNodes[0].data).toBe('3');
   });
 });

--- a/packages/rax/src/vdom/composite.js
+++ b/packages/rax/src/vdom/composite.js
@@ -270,8 +270,8 @@ class CompositeComponent extends BaseComponent {
     // Reset pending queue
     this.__pendingStateQueue = null;
     let nextState = assign({}, instance.state);
-    let partial;
-    while (partial = queue.shift()) {
+    for (let i = 0; i < queue.length; i ++) {
+      let partial = queue[i];
       assign(
         nextState,
         isFunction(partial) ?

--- a/packages/rax/src/vdom/fragment.js
+++ b/packages/rax/src/vdom/fragment.js
@@ -39,10 +39,9 @@ class FragmentComponent extends NativeComponent {
     let fragment = this.__getNativeNode();
 
     return this.__mountChildrenImpl(this._parent, children, context, (nativeNode) => {
-      let node;
       nativeNode = toArray(nativeNode);
-      while (node = nativeNode.shift()) {
-        fragment.push(node);
+      for (let i = 0; i < nativeNode.length; i++) {
+        fragment.push(nativeNode[i]);
       }
     });
   }
@@ -78,7 +77,9 @@ class FragmentComponent extends NativeComponent {
   }
 
   __createNativeNode() {
-    return [];
+    let fragmentArr = [];
+    fragmentArr.__isFragmentNode = true;
+    return fragmentArr;
   }
 }
 


### PR DESCRIPTION
revert dcc7f2f9e8c85b3b707d61ac214366797254ec7d
the original commit cause an bug
do not use arr.SHIFT() operation to array, because it will mutate the array itself.