### PR TITLE
fix: use for loop instead of while to avoid mutate array iteself

### DIFF
--- a/packages/rax/src/__tests__/fragment.js
+++ b/packages/rax/src/__tests__/fragment.js
@@ -431,4 +431,37 @@ describe('Fragment', () => {
     expect(el.childNodes[1].childNodes[0].data).toBe('2');
     expect(el.childNodes[2].childNodes[0].data).toBe('3');
   });
+
+  it('should render correct from not empty array to other', function() {
+    let el = createNodeElement('div');
+
+    function F({ type }) {
+      if (type === 'notEmpty') {
+        return ['4'];
+      }
+      return <div>2</div>;
+    }
+
+    class App extends Component {
+      render() {
+        return (
+          [
+            <div>1</div>,
+            <F type={this.props.type} />,
+            <div>3</div>,
+          ]
+        );
+      }
+    }
+
+    render(<App type={'notEmpty'} />, el);
+    expect(el.childNodes[0].childNodes[0].data).toBe('1');
+    expect(el.childNodes[1].data).toBe('4');
+    expect(el.childNodes[2].childNodes[0].data).toBe('3');
+
+    render(<App />, el);
+    expect(el.childNodes[0].childNodes[0].data).toBe('1');
+    expect(el.childNodes[1].childNodes[0].data).toBe('2');
+    expect(el.childNodes[2].childNodes[0].data).toBe('3');
+  });
 });

--- a/packages/rax/src/vdom/composite.js
+++ b/packages/rax/src/vdom/composite.js
@@ -271,8 +271,8 @@ class CompositeComponent extends BaseComponent {
     // Reset pending queue
     this.__pendingStateQueue = null;
     let nextState = assign({}, instance.state);
-    let partial;
-    while (partial = queue.shift()) {
+    for (let i = 0; i < queue.length; i ++) {
+      let partial = queue[i];
       assign(
         nextState,
         isFunction(partial) ?

--- a/packages/rax/src/vdom/fragment.js
+++ b/packages/rax/src/vdom/fragment.js
@@ -39,10 +39,9 @@ class FragmentComponent extends NativeComponent {
     let fragment = this.__getNativeNode();
 
     return this.__mountChildrenImpl(this._parent, children, context, (nativeNode) => {
-      let node;
       nativeNode = toArray(nativeNode);
-      while (node = nativeNode.shift()) {
-        fragment.push(node);
+      for (let i = 0; i < nativeNode.length; i++) {
+        fragment.push(nativeNode[i]);
       }
     });
   }


### PR DESCRIPTION
revert dcc7f2f
the original commit cause an bug
do not use arr.SHIFT() operation to array, because it will mutate the array itself.