### PR TITLE
refactor: rework jsx2mp appjs

### DIFF
--- a/packages/jsx-compiler/src/modules/code.js
+++ b/packages/jsx-compiler/src/modules/code.js
@@ -8,17 +8,14 @@ const traverse = require('../utils/traverseNodePath');
 const RAX_PACKAGE = 'rax';
 const SUPER_COMPONENT = 'Component';
 
-const CREATE_APP = 'createApp';
 const CREATE_COMPONENT = 'createComponent';
 const CREATE_PAGE = 'createPage';
 const CREATE_STYLE = 'createStyle';
 
 const SAFE_SUPER_COMPONENT = '__component__';
-const SAFE_CREATE_APP = '__create_app__';
 const SAFE_CREATE_COMPONENT = '__create_component__';
 const SAFE_CREATE_PAGE = '__create_page__';
 const SAFE_CREATE_STYLE = '__create_style__';
-const SAFE_ROUTER_MAP = '__router_map__';
 
 const USE_EFFECT = 'useEffect';
 const USE_STATE = 'useState';

--- a/packages/jsx-compiler/src/modules/code.js
+++ b/packages/jsx-compiler/src/modules/code.js
@@ -23,8 +23,7 @@ const USE_STATE = 'useState';
 const EXPORTED_DEF = '__def__';
 const RUNTIME = '/npm/jsx2mp-runtime';
 
-const APP_RUNTIME = ['rax-app', '@core/app', '@core/page', '@core/router', 'universal-app-runtime'];
-const isAppRuntime = (mod) => APP_RUNTIME.indexOf(mod) > -1;
+const isAppRuntime = (mod) => mod === 'rax-app';
 const isFileModule = (mod) => /\.(png|jpe?g|gif|bmp|webp)$/.test(mod);
 
 function getConstructor(type) {

--- a/packages/jsx-compiler/src/modules/code.js
+++ b/packages/jsx-compiler/src/modules/code.js
@@ -299,18 +299,6 @@ function addDefine(ast, type, outputPath, targetFileDir, userDefineType, eventHa
       // Component(__create_component__(__class_def__));
       const args = [t.identifier(EXPORTED_DEF)];
 
-      // Insert routerMap import declaration
-      // if (type === 'app') {
-      //   path.node.body.unshift(
-      //     t.importDeclaration(
-      //       [t.importDefaultSpecifier(t.identifier(SAFE_ROUTER_MAP))],
-      //       t.stringLiteral('./routerMap')
-      //     )
-      //   );
-      //   // App(__create_app__(__class_def__, __router_map__));
-      //   args.push(t.identifier(SAFE_ROUTER_MAP));
-      // }
-
       // import { createComponent as __create_component__ } from "/__helpers/component";
       const specifiers = [t.importSpecifier(localIdentifier, t.identifier(importedIdentifier))];
       if ((type === 'page' || type === 'component') && userDefineType === 'class') {

--- a/packages/jsx-compiler/src/modules/code.js
+++ b/packages/jsx-compiler/src/modules/code.js
@@ -23,11 +23,8 @@ const USE_STATE = 'useState';
 const EXPORTED_DEF = '__def__';
 const RUNTIME = '/npm/jsx2mp-runtime';
 
-/**
- * match rax-app package
- */
-const isRaxApp = (mod) => /^rax\-app/.test(mod);
-
+const APP_RUNTIME = ['rax-app', '@core/app', '@core/page', '@core/router', 'universal-app-runtime'];
+const isAppRuntime = (mod) => APP_RUNTIME.indexOf(mod) > -1;
 const isFileModule = (mod) => /\.(png|jpe?g|gif|bmp|webp)$/.test(mod);
 
 function getConstructor(type) {
@@ -177,7 +174,7 @@ function renameCoreModule(ast, outputPath, targetFileDir) {
   traverse(ast, {
     ImportDeclaration(path) {
       const source = path.get('source');
-      if (source.isStringLiteral() && isRaxApp(source.node.value)) {
+      if (source.isStringLiteral() && isAppRuntime(source.node.value)) {
         let runtimeRelativePath = relative(targetFileDir, join(outputPath, RUNTIME));
         runtimeRelativePath = runtimeRelativePath[0] !== '.' ? './' + runtimeRelativePath : runtimeRelativePath;
         source.replaceWith(t.stringLiteral(runtimeRelativePath));

--- a/packages/jsx-compiler/src/modules/code.js
+++ b/packages/jsx-compiler/src/modules/code.js
@@ -27,10 +27,9 @@ const EXPORTED_DEF = '__def__';
 const RUNTIME = '/npm/jsx2mp-runtime';
 
 /**
- * match universal-app package
+ * match rax-app package
  */
-const isCoreModule = (mod) => /^@core\//.test(mod);
-const isUniversalAppRuntime = (mod) => /^universal\-app\-runtime/.test(mod);
+const isRaxApp = (mod) => /^rax\-app/.test(mod);
 
 const isFileModule = (mod) => /\.(png|jpe?g|gif|bmp|webp)$/.test(mod);
 
@@ -186,7 +185,7 @@ function renameCoreModule(ast, outputPath, targetFileDir) {
   traverse(ast, {
     ImportDeclaration(path) {
       const source = path.get('source');
-      if (source.isStringLiteral() && (isCoreModule(source.node.value) || isUniversalAppRuntime(source.node.value))) {
+      if (source.isStringLiteral() && isRaxApp(source.node.value)) {
         let runtimeRelativePath = relative(targetFileDir, join(outputPath, RUNTIME));
         runtimeRelativePath = runtimeRelativePath[0] !== '.' ? './' + runtimeRelativePath : runtimeRelativePath;
         source.replaceWith(t.stringLiteral(runtimeRelativePath));

--- a/packages/jsx2mp-cli/getWebpackConfig.js
+++ b/packages/jsx2mp-cli/getWebpackConfig.js
@@ -50,8 +50,8 @@ function getEntry(type, cwd, entryFilePath, options) {
       process.exit(1);
     }
     entry.app = AppLoader + '?' + JSON.stringify({ entryPath }) + '!./' + join(entryPath, 'app.js');
-    if (Array.isArray(appConfig.routes)) {
-      appConfig.routes.forEach(({ path, component }) => {
+    if (Array.isArray(appConfig.source)) {
+      appConfig.source.forEach(({ path, component }) => {
         entry['page@' + component] = PageLoader + '?' + loaderParams + '!' + getDepPath(component, entryPath);
       });
     } else if (Array.isArray(appConfig.pages)) {

--- a/packages/jsx2mp-cli/getWebpackConfig.js
+++ b/packages/jsx2mp-cli/getWebpackConfig.js
@@ -50,8 +50,9 @@ function getEntry(type, cwd, entryFilePath, options) {
       process.exit(1);
     }
     entry.app = AppLoader + '?' + JSON.stringify({ entryPath }) + '!./' + join(entryPath, 'app.js');
-    if (Array.isArray(appConfig.source)) {
-      appConfig.source.forEach(({ path, component }) => {
+    if (Array.isArray(appConfig.routes)) {
+      appConfig.routes.forEach(({ source, component }) => {
+        component = source || component;
         entry['page@' + component] = PageLoader + '?' + loaderParams + '!' + getDepPath(component, entryPath);
       });
     } else if (Array.isArray(appConfig.pages)) {

--- a/packages/jsx2mp-loader/src/app-loader.js
+++ b/packages/jsx2mp-loader/src/app-loader.js
@@ -80,7 +80,7 @@ function transformAppConfig(entryPath, originalConfig) {
   for (let key in originalConfig) {
     const value = originalConfig[key];
     switch (key) {
-      case 'routes':
+      case 'source':
         const pages = [];
         if (Array.isArray(value)) {
           // only resolve first level of routes.

--- a/packages/jsx2mp-loader/src/app-loader.js
+++ b/packages/jsx2mp-loader/src/app-loader.js
@@ -1,5 +1,5 @@
 const { readJSONSync, writeJSONSync, writeFileSync, readFileSync, existsSync, mkdirSync } = require('fs-extra');
-const { relative, join, dirname, resolve } = require('path');
+const { join } = require('path');
 const compiler = require('jsx-compiler');
 const { getOptions } = require('loader-utils');
 const moduleResolve = require('./utils/moduleResolve');
@@ -41,10 +41,6 @@ module.exports = function appLoader(content) {
   if (!existsSync(outputPath)) mkdirSync(outputPath);
 
   const sourcePath = join(this.rootContext, entryPath);
-  const relativeSourcePath = relative(sourcePath, this.resourcePath);
-  const targetFilePath = join(outputPath, relativeSourcePath);
-
-  const targetFileDir = dirname(join(outputPath, relative(sourcePath, this.resourcePath)));
 
   const compilerOptions = Object.assign({}, compiler.baseOptions, {
     resourcePath: this.resourcePath,
@@ -59,11 +55,8 @@ module.exports = function appLoader(content) {
   const transformedAppConfig = transformAppConfig(entryPath, config);
   writeFileSync(join(outputPath, 'app.js'), transformed.code);
   writeJSONSync(join(outputPath, 'app.json'), transformedAppConfig, { spaces: 2 });
-  const routerMap = {};
-  config.routes.map(route => {
-    routerMap[route.path] = route.component;
-  });
-  writeFileSync(join(outputPath, 'routerMap.js'), `export default ${JSON.stringify(routerMap, null, 2)};`);
+  // Write app.raw.json for route information.
+  writeJSONSync(join(outputPath, 'app.raw.json'), config, { spaces: 2 });
 
   const appCssPath = join(outputPath, 'app.acss');
   const appCss = transformed.style ? defaultStyle + transformed.style : defaultStyle;
@@ -79,20 +72,23 @@ function transformAppConfig(entryPath, originalConfig) {
   const config = {};
   for (let key in originalConfig) {
     const value = originalConfig[key];
+
     switch (key) {
-      case 'source':
+      case 'routes':
         const pages = [];
         if (Array.isArray(value)) {
-          // only resolve first level of routes.
-          value.forEach(({ path, component }) => {
-            pages.push(moduleResolve(entryPath, getRelativePath(component)));
+          // Only resolve first level of routes.
+          value.forEach(({ component, source }) => {
+            // Compatible with old version definition of `component`.
+            pages.push(moduleResolve(entryPath, getRelativePath(source || component)));
           });
         }
         config.pages = pages;
         break;
 
       default:
-        config[key] = value; break;
+        config[key] = value;
+        break;
     }
   }
 

--- a/packages/jsx2mp-loader/src/page-loader.js
+++ b/packages/jsx2mp-loader/src/page-loader.js
@@ -11,7 +11,6 @@ module.exports = function pageLoader(content) {
   const { platform, entryPath } = loaderOptions;
   const rawContent = readFileSync(this.resourcePath, 'utf-8');
   const resourcePath = this.resourcePath;
-  const rootContext = this.rootContext;
 
   const outputPath = this._compiler.outputPath;
   const sourcePath = join(this.rootContext, dirname(entryPath));

--- a/packages/jsx2mp-runtime/src/app.js
+++ b/packages/jsx2mp-runtime/src/app.js
@@ -1,10 +1,16 @@
+const LAUNCH = 'launch';
+
 export const cycles = {};
 
 export function useAppEffect(cycle, callback) {
   switch (cycle) {
-    case 'launch':
+    case LAUNCH:
       cycles[cycle] = cycles[cycle] || [];
       cycles[cycle].push(callback);
       break;
   }
+}
+
+export function useAppLaunch(callback) {
+  return useAppEffect(LAUNCH, callback);
 }

--- a/packages/jsx2mp-runtime/src/bridge.js
+++ b/packages/jsx2mp-runtime/src/bridge.js
@@ -192,14 +192,14 @@ export function createApp(definedApp, routerMap) {
 
 export function runApp(appConfig) {
   if (_appConfig) {
-    throw new Error('runApp can only be called once.')
+    throw new Error('runApp can only be called once.');
   }
 
   _appConfig = appConfig; // Store raw app config to parse router.
   const appOptions = {
     // Bridge app launch.
     onLaunch(launchOptions) {
-      const launchQueue = appCycles['launch'];
+      const launchQueue = appCycles.launch;
       if (Array.isArray(launchQueue) && launchQueue.length > 0) {
         let fn;
         while (fn = launchQueue.pop()) { // eslint-disable-line

--- a/packages/jsx2mp-runtime/src/bridge.js
+++ b/packages/jsx2mp-runtime/src/bridge.js
@@ -28,7 +28,10 @@ function getPageCycles(Klass) {
       this.instance._setInternal(this);
       // Add route information for page.
       history.location.__updatePageOption(options);
-      this.instance.props.history = history;
+      Object.assign(this.instance.props, {
+        history,
+        location: history.location
+      });
       this.data = this.instance.state;
 
       if (this.instance.__ready) return;

--- a/packages/jsx2mp-runtime/src/bridge.js
+++ b/packages/jsx2mp-runtime/src/bridge.js
@@ -6,6 +6,7 @@ import { setComponentInstance, getComponentProps, executeCallbacks } from './upd
 import { getComponentLifecycle } from '@@ADAPTER@@';
 
 const GET_DERIVED_STATE_FROM_PROPS = 'getDerivedStateFromProps';
+let _appConfig;
 
 /**
  * Reference relationship.
@@ -187,6 +188,29 @@ export function createApp(definedApp, routerMap) {
   };
   definedApp.call(appConfig, appProps);
   return appConfig;
+}
+
+export function runApp(appConfig) {
+  if (_appConfig) {
+    throw new Error('runApp can only be called once.')
+  }
+
+  _appConfig = appConfig; // Store raw app config to parse router.
+  const appOptions = {
+    // Bridge app launch.
+    onLaunch(launchOptions) {
+      const launchQueue = appCycles['launch'];
+      if (Array.isArray(launchQueue) && launchQueue.length > 0) {
+        let fn;
+        while (fn = launchQueue.pop()) { // eslint-disable-line
+          fn.call(this, launchOptions);
+        }
+      }
+    },
+  };
+
+  // eslint-disable-next-line
+  App(appOptions);
 }
 
 export function createPage(definition, options = {}) {

--- a/packages/jsx2mp-runtime/src/history.js
+++ b/packages/jsx2mp-runtime/src/history.js
@@ -25,6 +25,7 @@ class MiniAppHistory {
 class Location {
   constructor() {
     this._options = {};
+    this.hash = '';
   }
 
   __updatePageOption(options) {
@@ -42,10 +43,6 @@ class Location {
       }
     });
     return search;
-  }
-
-  get hash() {
-    return null;
   }
 
   get pathname() {

--- a/packages/jsx2mp-runtime/src/history.js
+++ b/packages/jsx2mp-runtime/src/history.js
@@ -1,0 +1,64 @@
+/* global getCurrentPages, PROPS */
+import { push, replace, go, goBack, canGo, goForward } from './router';
+
+export function createMiniAppHistory() {
+  const defaultActions = {
+    push,
+    replace,
+    goBack,
+    go,
+    canGo,
+    goForward,
+  };
+  return Object.assign(new MiniAppHistory(), defaultActions);
+}
+
+class MiniAppHistory {
+  constructor() {
+    this.location = new Location();
+  }
+  get length() {
+    return getCurrentPages().length;
+  }
+}
+
+class Location {
+  constructor() {
+    this._options = {};
+  }
+
+  __updatePageOption(options) {
+    this._options = options;
+  }
+
+  get search() {
+    let search = '';
+    Object.keys(this._options).map((key, index) => {
+      const query = `${key}=${this._options[key]}`;
+      if (index === 0) {
+        search += `?${query}`;
+      } else {
+        search += `&${query}`;
+      }
+    });
+    return search;
+  }
+
+  get hash() {
+    return null;
+  }
+
+  get pathname() {
+    return getCurrentPageUrl();
+  }
+}
+
+function getCurrentPageUrl() {
+  const pages = getCurrentPages();
+  const currentPage = pages[pages.length - 1];
+  return addLeadingSlash(currentPage.route);
+}
+
+function addLeadingSlash(str) {
+  return str[0] === '/' ? str : '/' + str;
+}

--- a/packages/jsx2mp-runtime/src/history.js
+++ b/packages/jsx2mp-runtime/src/history.js
@@ -2,21 +2,17 @@
 import { push, replace, go, goBack, canGo, goForward } from './router';
 
 export function createMiniAppHistory() {
-  const defaultActions = {
-    push,
-    replace,
-    goBack,
-    go,
-    canGo,
-    goForward,
-  };
-  return Object.assign(new MiniAppHistory(), defaultActions);
+  return new MiniAppHistory();
 }
 
 class MiniAppHistory {
   constructor() {
     this.location = new Location();
+
+    // Apply actions for history.
+    Object.assign(this, { push, replace, goBack, go, canGo, goForward });
   }
+
   get length() {
     return getCurrentPages().length;
   }
@@ -24,36 +20,29 @@ class MiniAppHistory {
 
 class Location {
   constructor() {
-    this._options = {};
+    this._currentPageOptions = {};
     this.hash = '';
   }
 
-  __updatePageOption(options) {
-    this._options = options;
+  __updatePageOption(pageOptions) {
+    this._currentPageOptions = pageOptions;
   }
 
   get search() {
     let search = '';
-    Object.keys(this._options).map((key, index) => {
-      const query = `${key}=${this._options[key]}`;
-      if (index === 0) {
-        search += `?${query}`;
-      } else {
-        search += `&${query}`;
-      }
+    Object.keys(this._currentPageOptions).forEach((key, index) => {
+      const query = `${key}=${this._currentPageOptions[key]}`;
+      search += index === 0 ? '?' : '&';
+      search += query;
     });
     return search;
   }
 
   get pathname() {
-    return getCurrentPageUrl();
+    const pages = getCurrentPages();
+    const currentPage = pages[pages.length - 1];
+    return addLeadingSlash(currentPage.route);
   }
-}
-
-function getCurrentPageUrl() {
-  const pages = getCurrentPages();
-  const currentPage = pages[pages.length - 1];
-  return addLeadingSlash(currentPage.route);
 }
 
 function addLeadingSlash(str) {

--- a/packages/jsx2mp-runtime/src/index.js
+++ b/packages/jsx2mp-runtime/src/index.js
@@ -1,13 +1,12 @@
-import { runApp, createApp, createPage, createComponent } from './bridge';
+import { runApp, createPage, createComponent } from './bridge';
 import { useAppEffect, useAppLaunch } from './app';
 import { usePageEffect, usePageShow, usePageHide } from './page';
-import { useRouter, withRouter, push, replace, go, goBack, goForward, canGo } from './router';
+import { withRouter } from './router';
 import Component from './component';
 import createStyle from './createStyle';
 
 export {
   runApp,
-  createApp,
   createPage,
   createComponent,
   createStyle,
@@ -24,14 +23,7 @@ export {
   usePageEffect,
 
   // Router
-  useRouter,
   withRouter,
-  push,
-  replace,
-  go,
-  goBack,
-  goForward,
-  canGo,
 };
 
 /* hooks */

--- a/packages/jsx2mp-runtime/src/index.js
+++ b/packages/jsx2mp-runtime/src/index.js
@@ -1,11 +1,12 @@
-import { createApp, createPage, createComponent } from './bridge';
-import { useAppEffect } from './app';
-import { usePageEffect } from './page';
+import { runApp, createApp, createPage, createComponent } from './bridge';
+import { useAppEffect, useAppLaunch } from './app';
+import { usePageEffect, usePageShow, usePageHide } from './page';
 import { useRouter, withRouter, push, replace, go, goBack, goForward, canGo } from './router';
 import Component from './component';
 import createStyle from './createStyle';
 
 export {
+  runApp,
   createApp,
   createPage,
   createComponent,
@@ -13,7 +14,12 @@ export {
 
   Component,
 
-  // Cycle
+  // Cycles
+  useAppLaunch,
+  usePageShow,
+  usePageHide,
+
+  // Compatible old version of cycles.
   useAppEffect,
   usePageEffect,
 

--- a/packages/jsx2mp-runtime/src/page.js
+++ b/packages/jsx2mp-runtime/src/page.js
@@ -1,20 +1,30 @@
 import isFunction from './isFunction';
 
+const SHOW = 'show';
+const HIDE = 'hide';
+
 export const cycles = {
-  show: [],
-  hide: [],
+  [SHOW]: [],
+  [HIDE]: [],
 };
 
-// TODO: get current rendering page.
 export function usePageEffect(cycle, callback) {
   switch (cycle) {
-    case 'show':
-    case 'hide':
+    case SHOW:
+    case HIDE:
       if (isFunction(callback)) {
         cycles[cycle].push(callback);
       }
       break;
     default:
-      throw new Error('Unsupported cycle name ' + cycle);
+      throw new Error('Unsupported page cycle ' + cycle);
   }
+}
+
+export function usePageShow(callback) {
+  return usePageEffect(SHOW, callback);
+}
+
+export function usePageHide(callback) {
+  return usePageEffect(HIDE, callback);
 }

--- a/packages/jsx2mp-runtime/src/router.js
+++ b/packages/jsx2mp-runtime/src/router.js
@@ -75,5 +75,5 @@ export function canGo() {
 function generateUrl(path) {
   const [pathname, query] = path.split('?');
   const miniappPath = __routerMap[pathname];
-  return query ? `/${miniappPath}?${query}` : `/${miniappPath}`
+  return query ? `/${miniappPath}?${query}` : `/${miniappPath}`;
 }

--- a/packages/jsx2mp-runtime/src/router.js
+++ b/packages/jsx2mp-runtime/src/router.js
@@ -75,5 +75,8 @@ export function canGo() {
 function generateUrl(path) {
   const [pathname, query] = path.split('?');
   const miniappPath = __routerMap[pathname];
+  if (!miniappPath) {
+    throw new Error(`Path ${path} is not found`);
+  }
   return query ? `/${miniappPath}?${query}` : `/${miniappPath}`;
 }

--- a/packages/jsx2mp-runtime/src/router.js
+++ b/packages/jsx2mp-runtime/src/router.js
@@ -29,14 +29,14 @@ export function withRouter(Klass) {
  * Navigate to given path.
  */
 export function push(path) {
-  return navigateTo({ url: `/${__routerMap[path]}` });
+  return navigateTo({ url: generateUrl(path) });
 }
 
 /**
  * Navigate replace.
  */
 export function replace(path) {
-  return redirectTo({ url: `/${__routerMap[path]}` });
+  return redirectTo({ url: generateUrl(path) });
 }
 
 /**
@@ -66,4 +66,14 @@ export function goForward() {
  */
 export function canGo() {
   return true;
+}
+
+/**
+ * Generate MiniApp url
+ * @param {String} path
+ */
+function generateUrl(path) {
+  const [pathname, query] = path.split('?');
+  const miniappPath = __routerMap[pathname];
+  return query ? `/${miniappPath}?${query}` : `/${miniappPath}`
 }

--- a/packages/jsx2mp-runtime/src/router.js
+++ b/packages/jsx2mp-runtime/src/router.js
@@ -1,11 +1,12 @@
-import { navigateTo, redirectTo, navigateBack} from '@@ADAPTER@@';
+import { navigateTo, redirectTo, navigateBack } from '@@ADAPTER@@';
 
 let router;
+let __routerMap = {};
 
-export function useRouter(routerConfig) {
-  const history = routerConfig && routerConfig.history;
-  router = { config: routerConfig, history };
-  return { Router: null, history }; // just noop
+export function __updateRouterMap(appConfig) {
+  appConfig.routes.map(route => {
+    __routerMap[route.path] = route.source;
+  });
 }
 
 /**
@@ -28,14 +29,14 @@ export function withRouter(Klass) {
  * Navigate to given path.
  */
 export function push(path) {
-  return navigateTo({ url: `/${router.config[path]}` });
+  return navigateTo({ url: `/${__routerMap[path]}` });
 }
 
 /**
  * Navigate replace.
  */
 export function replace(path) {
-  return redirectTo({ url: `/${router.config[path]}` });
+  return redirectTo({ url: `/${__routerMap[path]}` });
 }
 
 /**

--- a/packages/jsx2mp-runtime/src/router.js
+++ b/packages/jsx2mp-runtime/src/router.js
@@ -10,11 +10,16 @@ export function useRouter(routerConfig) {
 
 /**
  * With router decorator.
+ * Inject history and location.
  * @param Klass
  */
 export function withRouter(Klass) {
   if (Klass) Klass.defaultProps = Klass.defaultProps || {};
-  Klass.defaultProps.router = router;
+  Object.assign(Klass.defaultProps, {
+    router,
+    history: router.history,
+    location: router.history.location,
+  });
 
   return Klass;
 }


### PR DESCRIPTION
Support new format of `app.js`.

```js
import { runApp } from 'rax-app';
import appConfig from './app.json';

runApp(appConfig);
```

compiled to:

```js
import { runApp } from "./npm/jsx2mp-runtime";
import appConfig from "./app.raw.json";
runApp(appConfig);
```