### PR TITLE
ci: should run `build` command in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ before_script:
 script:
   - npm run lint:nofix
   - npm run test
+  - npm run build
 
-jobs: 
+jobs:
   include:
     - stage: bench
       addons:


### PR DESCRIPTION
Should include `npm run build` in CI.

Now there are build errors in master branch, there issue should be fixed before Pull Request merged: 
![image](https://user-images.githubusercontent.com/4409743/66040838-72a56900-e553-11e9-83d0-823e073b4b81.png)
