### PR TITLE
fix: error boundary bug and remove useless code

### DIFF
--- a/packages/rax/src/vdom/__tests__/composite.js
+++ b/packages/rax/src/vdom/__tests__/composite.js
@@ -562,6 +562,51 @@ describe('CompositeComponent', function() {
     ]);
   });
 
+  it('should boundary exec componentDidCatch when child setState throw error', () => {
+    let container = createNodeElement('div');
+    let child;
+
+    class Child extends Component {
+      state = {
+        count: 1
+      }
+      render() {
+        child = this;
+        if (this.state.count === 2) {
+          throw new Error('Hello');
+        }
+        return (
+          <span>Hello</span>
+        );
+      }
+    }
+
+    class ErrorBoundary extends Component {
+      state = {error: null};
+      componentDidCatch(error) {
+        this.setState({error});
+      }
+      render() {
+        if (this.state.error) {
+          return (
+            <div>{`Caught an error: ${this.state.error.message}.`}</div>
+          );
+        }
+        return (
+          <div>
+            <Child />
+          </div>
+        );
+      }
+    }
+
+    render(<ErrorBoundary><Child /></ErrorBoundary>, container);
+    expect(container.childNodes[0].childNodes[0].childNodes[0].data).toBe('Hello');
+    child.setState({count: 2});
+    jest.runAllTimers();
+    expect(container.childNodes[0].childNodes[0].data).toBe('Caught an error: Hello.');
+  });
+
   it('should render correct when prevRenderedComponent did not generate nodes', () => {
     let container = createNodeElement('div');
     class Frag extends Component {

--- a/packages/rax/src/vdom/__tests__/composite.js
+++ b/packages/rax/src/vdom/__tests__/composite.js
@@ -114,6 +114,45 @@ describe('CompositeComponent', function() {
     expect(triggered).toBe(true);
   });
 
+
+  it('setState callback triggered in didMount or didUpdate should receive latest state', function() {
+    let container = createNodeElement('div');
+    const logs = [];
+    class Foo extends Component {
+      constructor() {
+        super();
+        this.state = {
+          count: 1
+        };
+      }
+      componentDidMount() {
+        // eslint-disable-next-line react/no-did-mount-set-state
+        this.setState({
+          count: 2
+        }, () => {
+          logs.push(this.state.count);
+        });
+      }
+      componentDidUpdate() {
+        if (this.state.count === 2) {
+          // eslint-disable-next-line react/no-did-update-set-state
+          this.setState({
+            count: 3
+          }, () => {
+            logs.push(this.state.count);
+          });
+        };
+      }
+      render() {
+        return <span className={this.state.value} />;
+      }
+    }
+
+    render(<Foo />, container);
+    jest.runAllTimers();
+    expect(logs).toEqual([2, 3]);
+  });
+
   it('will call all the normal life cycle methods', function() {
     var lifeCycles = [];
     let container = createNodeElement('div');

--- a/packages/rax/src/vdom/__tests__/composite.js
+++ b/packages/rax/src/vdom/__tests__/composite.js
@@ -76,7 +76,7 @@ describe('CompositeComponent', function() {
     expect(container.childNodes[0].attributes.class).toBe('foo');
   });
 
-  it('setState callback triggered in componentWillMount', function() {
+  it('setState callback triggered', function() {
     let container = createNodeElement('div');
     let triggered = false;
     class Foo extends Component {
@@ -91,11 +91,25 @@ describe('CompositeComponent', function() {
           triggered = true;
         });
       }
+      componentWillReceiveProps() {
+        this.setState({
+          value: 'foo'
+        }, () => {
+          triggered = true;
+        });
+      }
       render() {
         return <span className={this.state.value} />;
       }
     }
 
+    const instance = render(<Foo />, container);
+    expect(triggered).toBe(true);
+    triggered = false;
+    instance.setState({}, () => triggered = true);
+    jest.runAllTimers();
+    expect(triggered).toBe(true);
+    triggered = false;
     render(<Foo />, container);
     expect(triggered).toBe(true);
   });

--- a/packages/rax/src/vdom/composite.js
+++ b/packages/rax/src/vdom/composite.js
@@ -182,7 +182,7 @@ class CompositeComponent extends BaseComponent {
       scheduleLayout(didMount);
     }
 
-    // Trigger setState callback in componentWillMount or boundary callback after rendered
+    // Trigger setState callback
     scheduleLayout(() => {
       let callbacks = this.__pendingCallbacks;
       if (callbacks) {
@@ -402,7 +402,7 @@ class CompositeComponent extends BaseComponent {
     }
 
     scheduleLayout(() => {
-      // Flush setState callbacks set in componentWillReceiveProps or boundary callback
+      // Flush setState callbacks
       let callbacks = this.__pendingCallbacks;
       if (callbacks) {
         this.__pendingCallbacks = null;

--- a/packages/rax/src/vdom/composite.js
+++ b/packages/rax/src/vdom/composite.js
@@ -133,7 +133,7 @@ class CompositeComponent extends BaseComponent {
     Host.owner = this;
     // Process pending state when call setState in componentWillMount
     instance.state = this.__processPendingState(publicProps, publicContext);
-    let callbacks = this.__pendingCallbacks;
+    const callbacks = this.__pendingCallbacks;
     this.__pendingCallbacks = null;
 
 
@@ -342,7 +342,7 @@ class CompositeComponent extends BaseComponent {
     let prevState = instance.state;
     // TODO: could delay execution processPendingState
     let nextState = this.__processPendingState(nextProps, nextContext);
-    let callbacks = this.__pendingCallbacks;
+    const callbacks = this.__pendingCallbacks;
     this.__pendingCallbacks = null;
 
     // ShouldComponentUpdate is not called when forceUpdate is used

--- a/packages/rax/src/vdom/updater.js
+++ b/packages/rax/src/vdom/updater.js
@@ -1,6 +1,5 @@
 import Host from './host';
 import { flushEffect, schedule, flushLayout } from './scheduler';
-import invokeFunctionsWithContext from '../invokeFunctionsWithContext';
 import { INTERNAL, RENDERED_COMPONENT } from '../constant';
 
 // Dirty components store
@@ -40,12 +39,6 @@ function runUpdate(component) {
 
   Host.__isUpdating = true;
 
-  // If updateComponent happens to enqueue any new updates, we
-  // shouldn't execute the callbacks until the next render happens, so
-  // stash the callbacks first
-  let callbacks = getPendingCallbacks(internal);
-  setPendingCallbacks(internal, null);
-
   let prevElement = internal.__currentElement;
   let prevUnmaskedContext = internal._context;
   let nextUnmaskedContext = internal.__penddingContext || prevUnmaskedContext;
@@ -60,8 +53,6 @@ function runUpdate(component) {
     );
     flushLayout();
   }
-
-  invokeFunctionsWithContext(callbacks, component);
 
   Host.__isUpdating = false;
 }
@@ -152,8 +143,7 @@ const Updater = {
   },
   forceUpdate(component, callback) {
     requestUpdate(component, null, callback);
-  },
-  runCallbacks: invokeFunctionsWithContext,
+  }
 };
 
 export default Updater;


### PR DESCRIPTION
1. 目前的error boundary在子节点单独渲染发生错误的时候，不会触发didCapture
2. didMount和didUpdate里面setState, callback执行的时机不太对，导致获取的state有问题
3.  [renderedElement的判断](https://github.com/alibaba/rax/compare/master...yongningfu:remove-update-callbacks?expand=1#diff-491d95b1578e65172a7f04a6dfda3ce3L132) 和 
[update中的stash callback](https://github.com/alibaba/rax/compare/master...yongningfu:remove-update-callbacks?expand=1#diff-32b231d4eaa6be874ac2c072653c6763L46) 逻辑看起来没用处
4. gzip:  6.27 -> 6.21
