### PR TITLE
feat: support props check

### DIFF
--- a/packages/rax-create-class/package.json
+++ b/packages/rax-create-class/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "rax": "^1.0.0",
     "driver-server": "^1.0.0",
-    "rax-proptypes": "^1.0.0"
+    "prop-types": "^15.7.2"
   }
 }

--- a/packages/rax-create-class/src/__tests__/createClass.js
+++ b/packages/rax-create-class/src/__tests__/createClass.js
@@ -2,7 +2,7 @@
 /* eslint react/prefer-es6-class: "off" */
 
 import { createElement, render, shared } from 'rax';
-import PropTypes from 'rax-proptypes';
+import PropTypes from 'prop-types';
 import ServerDriver from 'driver-server';
 import createClass from '../';
 

--- a/packages/rax/package.json
+++ b/packages/rax/package.json
@@ -17,14 +17,12 @@
   },
   "types": "./index.d.ts",
   "dependencies": {
-    "driver-server": "^1.0.0",
     "@babel/runtime": "^7.2.0",
-    "rax-is-valid-element": "^1.0.0",
-    "rax-clone-element": "^1.0.0",
+    "driver-server": "^1.0.0",
     "rax-children": "^1.0.0",
-    "rax-create-factory": "^1.0.0"
-  },
-  "devDependencies": {
-    "rax-proptypes": "^1.0.0"
+    "rax-clone-element": "^1.0.0",
+    "rax-create-factory": "^1.0.0",
+    "rax-is-valid-element": "^1.0.0",
+    "prop-types": "^15.7.2"
   }
 }

--- a/packages/rax/src/vdom/__tests__/context.js
+++ b/packages/rax/src/vdom/__tests__/context.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import Component from '../component';
-import PropTypes from 'rax-proptypes';
+import PropTypes from 'prop-types';
 import createElement from '../../createElement';
 import Host from '../host';
 import render from '../../render';

--- a/packages/rax/src/vdom/__tests__/reactive.js
+++ b/packages/rax/src/vdom/__tests__/reactive.js
@@ -2,7 +2,7 @@
 /* @jsx createElement */
 
 import Component from '../component';
-import PropTypes from 'rax-proptypes';
+import PropTypes from 'prop-types';
 import createElement from '../../createElement';
 import Host from '../host';
 import ServerDriver from 'driver-server';

--- a/packages/rax/src/vdom/element.js
+++ b/packages/rax/src/vdom/element.js
@@ -1,3 +1,5 @@
+import checkPropTypes from 'prop-types/checkPropTypes';
+
 export default function Element(type, key, ref, props, owner) {
   let element = {
     // Built-in properties that belong on the element
@@ -10,6 +12,19 @@ export default function Element(type, key, ref, props, owner) {
   };
 
   if (process.env.NODE_ENV !== 'production') {
+    const propTypes = type.propTypes;
+
+    // Validate its props provided by the propTypes definition
+    if (propTypes) {
+      const displayName = type.displayName || type.name;
+      checkPropTypes(
+        propTypes,
+        props,
+        'prop',
+        displayName,
+      );
+    }
+
     // We make validation flag non-enumerable, so the test framework could ignore it
     Object.defineProperty(element, '__validated', {
       configurable: false,


### PR DESCRIPTION
```js
import PropTypes from 'prop-types';

const Link = ({ active, children, onClick }) => (
  <button
    onClick={onClick}
    disabled={active}
    style={{
      marginLeft: '4px',
    }}
  >
    {children}
  </button>
);

Link.propTypes = {
  active: PropTypes.bool.isRequired,
  children: PropTypes.node.isRequired,
  onClick: PropTypes.func.isRequired
};

render(<Link active={true}>Hello World</Link>);
```

And will print warning in console:

```
Warning: Failed prop type: The prop `onClick` is marked as required in `Link`, but its value is `undefined`.
```