### PR TITLE
Add tests for hooks in SSR

### DIFF
--- a/packages/rax-server-renderer/package.json
+++ b/packages/rax-server-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-server-renderer",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Rax renderer for server-side render.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-server-renderer/src/__tests__/basic.js
+++ b/packages/rax-server-renderer/src/__tests__/basic.js
@@ -5,7 +5,7 @@ import {renderToString} from '../index';
 
 describe('renderToString', () => {
   describe('basic rendering', function() {
-    it('a blank div', () => {
+    it('render a blank div', () => {
       function MyComponent() {
         return <div />;
       }
@@ -14,7 +14,7 @@ describe('renderToString', () => {
       expect(str).toBe('<div></div>');
     });
 
-    it('a self-closing tag', () => {
+    it('render a self-closing tag', () => {
       function MyComponent() {
         return <br />;
       }
@@ -23,7 +23,7 @@ describe('renderToString', () => {
       expect(str).toBe('<br>');
     });
 
-    it('a self-closing tag as a child', () => {
+    it('render a self-closing tag as a child', () => {
       function MyComponent() {
         return (
           <div>
@@ -36,7 +36,7 @@ describe('renderToString', () => {
       expect(str).toBe('<div><br></div>');
     });
 
-    it('a string', () => {
+    it('render a string', () => {
       function MyComponent() {
         return 'Hello';
       }
@@ -45,7 +45,7 @@ describe('renderToString', () => {
       expect(str).toBe('Hello');
     });
 
-    it('a number', () => {
+    it('render a number', () => {
       function MyComponent() {
         return 42;
       }
@@ -54,7 +54,18 @@ describe('renderToString', () => {
       expect(str).toBe('42');
     });
 
-    it('an array with one child', () => {
+    it('render child with zero value', () => {
+      const value = 0;
+
+      function MyComponent() {
+        return <span>{value}</span>;
+      }
+
+      let str = renderToString(<MyComponent />);
+      expect(str).toBe('<span>0</span>');
+    });
+
+    it('render an array with one child', () => {
       function MyComponent() {
         return [<div key={1}>text1</div>];
       }
@@ -63,7 +74,7 @@ describe('renderToString', () => {
       expect(str).toBe('<div>text1</div>');
     });
 
-    it('an array with several children', () => {
+    it('render an array with several children', () => {
       let Header = props => {
         return <p>header</p>;
       };
@@ -84,7 +95,7 @@ describe('renderToString', () => {
       expect(str).toBe('<div>text1</div><span>text2</span><p>header</p><h2>footer</h2><h3>about</h3>');
     });
 
-    it('a nested array', () => {
+    it('render a nested array', () => {
       function MyComponent() {
         return [
           [<div key={1}>text1</div>],
@@ -98,10 +109,10 @@ describe('renderToString', () => {
     });
 
     // TODO: render an iterable
-    it('an iterable', async() => {
+    it('render an iterable', async() => {
     });
 
-    it('emptyish value', () => {
+    it('render emptyish value', () => {
       expect(renderToString(0)).toBe('0');
       expect(renderToString(<div>{''}</div>)).toBe('<div></div>');
       expect(renderToString([])).toBe('');

--- a/packages/rax-server-renderer/src/__tests__/hooks.js
+++ b/packages/rax-server-renderer/src/__tests__/hooks.js
@@ -39,11 +39,9 @@ describe('hooks', () => {
         }
       }
 
-      try {
+      expect(() => {
         renderToString(<Counter />);
-      } catch (err) {
-        expect(err.message).toContain('Hooks can only be called inside a component.');
-      }
+      }).toThrowError('Hooks can only be called inside a component.');
     });
 
     it('should ignore setCount on the server', () => {

--- a/packages/rax-server-renderer/src/__tests__/hooks.js
+++ b/packages/rax-server-renderer/src/__tests__/hooks.js
@@ -31,19 +31,6 @@ describe('hooks', () => {
       expect(str).toBe('<span>Count: 0</span>');
     });
 
-    it('if used inside a class component', () => {
-      class Counter extends Component {
-        render() {
-          let [count] = useState(0);
-          return <Text text={count} />;
-        }
-      }
-
-      expect(() => {
-        renderToString(<Counter />);
-      }).toThrowError('Hooks can only be called inside a component.');
-    });
-
     it('should ignore setCount on the server', () => {
       function Counter() {
         let [count, setCount] = useState(0);

--- a/packages/rax-server-renderer/src/__tests__/hooks.js
+++ b/packages/rax-server-renderer/src/__tests__/hooks.js
@@ -1,0 +1,225 @@
+/* @jsx createElement */
+
+import {createElement, Component, useState, useReducer, useMemo, forwardRef, createRef, useRef, useEffect, useCallback, useImperativeHandle, useLayoutEffect} from 'rax';
+import {renderToString} from '../index';
+
+function Text(props) {
+  return <span>{props.text}</span>;
+}
+
+describe('hooks', () => {
+  describe('useState', () => {
+    it('basic render', () => {
+      function Counter(props) {
+        const [count] = useState(0);
+        return <span>Count: {count}</span>;
+      }
+
+      let str = renderToString(<Counter />);
+      expect(str).toBe('<span>Count: 0</span>');
+    });
+
+    it('lazy state initialization', () => {
+      function Counter(props) {
+        const [count] = useState(() => {
+          return 0;
+        });
+        return <span>Count: {count}</span>;
+      }
+
+      let str = renderToString(<Counter />);
+      expect(str).toBe('<span>Count: 0</span>');
+    });
+
+    it('if used inside a class component', () => {
+      class Counter extends Component {
+        render() {
+          let [count] = useState(0);
+          return <Text text={count} />;
+        }
+      }
+
+      try {
+        renderToString(<Counter />);
+      } catch (err) {
+        expect(err.message).toContain('Hooks can only be called inside a component.');
+      }
+    });
+
+    it('should ignore setCount on the server', () => {
+      function Counter() {
+        let [count, setCount] = useState(0);
+        if (count < 3) {
+          setCount(count + 1);
+        }
+        return <span>Count: {count}</span>;
+      }
+
+      let str = renderToString(<Counter />);
+      expect(str).toBe('<span>Count: 0</span>');
+    });
+  });
+
+  describe('useReducer', () => {
+    it('render with initial state', () => {
+      function reducer(state, action) {
+        return action === 'increment' ? state + 1 : state;
+      }
+
+      function Counter() {
+        let [count] = useReducer(reducer, 0);
+        return <Text text={count} />;
+      }
+
+      let str = renderToString(<Counter />);
+      expect(str).toBe('<span>0</span>');
+    });
+
+    it('lazy initialization', () => {
+      function reducer(state, action) {
+        return action === 'increment' ? state + 1 : state;
+      }
+      function Counter() {
+        let [count] = useReducer(reducer, 0, c => c + 1);
+        return <Text text={count} />;
+      }
+
+      let str = renderToString(<Counter />);
+      expect(str).toBe('<span>1</span>');
+    });
+
+    it('should ignore dispatch on the server', () => {
+      function reducer(state, action) {
+        return action === 'increment' ? state + 1 : state;
+      }
+      function Counter() {
+        let [count, dispatch] = useReducer(reducer, 0);
+        if (count < 3) {
+          dispatch('increment');
+        }
+
+        return <Text text={count} />;
+      }
+
+      let str = renderToString(<Counter />);
+      expect(str).toBe('<span>0</span>');
+    });
+  });
+
+  describe('useMemo', () => {
+    it('basic render', () => {
+      function CapitalizedText(props) {
+        const text = props.text;
+        const capitalizedText = useMemo(
+          () => {
+            return text.toUpperCase();
+          },
+          [text],
+        );
+        return <Text text={capitalizedText} />;
+      }
+
+      let str = renderToString(<CapitalizedText text="hello" />);
+      expect(str).toBe('<span>HELLO</span>');
+    });
+
+    it('if no inputs are provided', () => {
+      function CapitalizedText(props) {
+        const computed = useMemo(props.compute);
+        return <Text text={computed} />;
+      }
+
+      function computeA() {
+        return 'A';
+      }
+
+      let str = renderToString(<CapitalizedText compute={computeA} />);
+      expect(str).toBe('<span>A</span>');
+    });
+  });
+
+  describe('useRef', () => {
+    it('basic render', () => {
+      function Counter() {
+        const count = useRef(0);
+        return <span>Count: {count.current}</span>;
+      }
+
+      let str = renderToString(<Counter />);
+      expect(str).toBe('<span>Count: 0</span>');
+    });
+  });
+
+  describe('useEffect', () => {
+    it('should ignore effects on the server', () => {
+      function Counter(props) {
+        useEffect(() => {
+          throw new Error('should not be invoked');
+        });
+        return <span>Count: {props.count}</span>;
+      }
+
+      let str = renderToString(<Counter count={0} />);
+      expect(str).toBe('<span>Count: 0</span>');
+    });
+  });
+
+  describe('useCallback', () => {
+    it('should ignore callbacks on the server', () => {
+      function Counter(props) {
+        useCallback(() => {
+          throw new Error('should not be invoked');
+        });
+        return <span>Count: {props.count}</span>;
+      }
+
+      let str = renderToString(<Counter count={0} />);
+      expect(str).toBe('<span>Count: 0</span>');
+    });
+
+    it('should support render time callbacks', () => {
+      function Counter(props) {
+        const renderCount = useCallback(increment => {
+          return 'Count: ' + (props.count + increment);
+        });
+        return <span>{renderCount(3)}</span>;
+      }
+
+      let str = renderToString(<Counter count={2} />);
+      expect(str).toBe('<span>Count: 5</span>');
+    });
+  });
+
+  describe('useImperativeHandle', () => {
+    it('should not be invoked on the server', () => {
+      function Counter(props, ref) {
+        useImperativeHandle(ref, () => {
+          throw new Error('should not be invoked');
+        });
+        return <span>{props.label + ': ' + ref.current}</span>;
+      }
+
+      Counter = forwardRef(Counter);
+      const counter = createRef();
+      counter.current = 0;
+
+      let str = renderToString(<Counter label="Count" ref={counter} />);
+      expect(str).toBe('<span>Count: 0</span>');
+    });
+  });
+
+  describe('useLayoutEffect', () => {
+    it('should not be invoked on the server', () => {
+      function Counter() {
+        useLayoutEffect(() => {
+          throw new Error('should not be invoked');
+        });
+
+        return <span>Count: 0</span>;
+      }
+
+      let str = renderToString(<Counter />);
+      expect(str).toBe('<span>Count: 0</span>');
+    });
+  });
+});

--- a/packages/rax-server-renderer/src/index.js
+++ b/packages/rax-server-renderer/src/index.js
@@ -302,6 +302,7 @@ function renderElementToString(element, context, options) {
       instance.updater = updater;
 
       shared.Host.owner = {
+        // Give the component name in render error info(only for development)
         __getName: () => type.name,
         _instance: instance
       };
@@ -347,6 +348,7 @@ function renderElementToString(element, context, options) {
       instance.context = context;
 
       shared.Host.owner = {
+        // Give the component name in render error info(only for development)
         __getName: () => type.name,
         _instance: instance
       };

--- a/packages/rax-server-renderer/src/index.js
+++ b/packages/rax-server-renderer/src/index.js
@@ -234,8 +234,8 @@ class ServerReactiveComponent {
     this.didUpdate = [];
     this.willUnmount = [];
 
-    if (pureRender.__forwardRef) {
-      this.__forwardRef = ref;
+    if (pureRender._forwardRef) {
+      this._forwardRef = ref;
     }
   }
 
@@ -259,7 +259,7 @@ class ServerReactiveComponent {
 
   render() {
     this._hookID = 0;
-    let children = this._render(this.props, this.__forwardRef ? this.__forwardRef : this.context);
+    let children = this._render(this.props, this._forwardRef ? this._forwardRef : this.context);
     return children;
   }
 }

--- a/packages/rax/src/__tests__/hooks.js
+++ b/packages/rax/src/__tests__/hooks.js
@@ -9,6 +9,7 @@ import {useState, useContext, useEffect, useLayoutEffect, useRef, useReducer, us
 import forwardRef from '../forwardRef';
 import createRef from '../createRef';
 import memo from '../memo';
+import Component from '../vdom/component';
 
 describe('hooks', () => {
   function createNodeElement(tagName) {
@@ -45,6 +46,24 @@ describe('hooks', () => {
 
     render(<App value={2} />, container);
     expect(container.childNodes[0].childNodes[0].data).toEqual('2');
+  });
+
+  it('thorw error if used inside a class component', () => {
+    const container = createNodeElement('div');
+
+    class Counter extends Component {
+      render() {
+        let [count] = useState(0);
+        return <span>{count}</span>;
+      }
+    }
+
+    try {
+      render(<Counter />, container);
+      jest.runAllTimers();
+    } catch (err) {
+      expect(err.message).toContain('Hooks can only be called inside a component.');
+    }
   });
 
   it('lazy state initializer', () => {

--- a/packages/rax/src/__tests__/hooks.js
+++ b/packages/rax/src/__tests__/hooks.js
@@ -58,12 +58,10 @@ describe('hooks', () => {
       }
     }
 
-    try {
+    expect(() => {
       render(<Counter />, container);
       jest.runAllTimers();
-    } catch (err) {
-      expect(err.message).toContain('Hooks can only be called inside a component.');
-    }
+    }).toThrowError('Hooks can only be called inside a component.');
   });
 
   it('lazy state initializer', () => {

--- a/packages/rax/src/__tests__/hooks.js
+++ b/packages/rax/src/__tests__/hooks.js
@@ -48,22 +48,6 @@ describe('hooks', () => {
     expect(container.childNodes[0].childNodes[0].data).toEqual('2');
   });
 
-  it('thorw error if used inside a class component', () => {
-    const container = createNodeElement('div');
-
-    class Counter extends Component {
-      render() {
-        let [count] = useState(0);
-        return <span>{count}</span>;
-      }
-    }
-
-    expect(() => {
-      render(<Counter />, container);
-      jest.runAllTimers();
-    }).toThrowError('Hooks can only be called inside a component.');
-  });
-
   it('lazy state initializer', () => {
     const container = createNodeElement('div');
     let stateUpdater = null;

--- a/packages/rax/src/forwardRef.js
+++ b/packages/rax/src/forwardRef.js
@@ -1,4 +1,5 @@
 export default function(render) {
-  render.__forwardRef = true;
+  // _forwardRef is also use in rax server renderer
+  render._forwardRef = true;
   return render;
 }

--- a/packages/rax/src/hooks.js
+++ b/packages/rax/src/hooks.js
@@ -11,7 +11,7 @@ function getCurrentInstance() {
 
 function getCurrentRenderingInstance() {
   const currentInstance = getCurrentInstance();
-  if (currentInstance) {
+  if (currentInstance && currentInstance.getHooks) {
     return currentInstance;
   } else {
     if (process.env.NODE_ENV === 'production') {

--- a/packages/rax/src/hooks.js
+++ b/packages/rax/src/hooks.js
@@ -11,7 +11,7 @@ function getCurrentInstance() {
 
 function getCurrentRenderingInstance() {
   const currentInstance = getCurrentInstance();
-  if (currentInstance && currentInstance.getHooks) {
+  if (currentInstance) {
     return currentInstance;
   } else {
     if (process.env.NODE_ENV === 'production') {

--- a/packages/rax/src/vdom/composite.js
+++ b/packages/rax/src/vdom/composite.js
@@ -165,7 +165,7 @@ class CompositeComponent extends BaseComponent {
       handleError(instance, error);
     }
 
-    if (!currentElement.type.__forwardRef && ref) {
+    if (!currentElement.type._forwardRef && ref) {
       attachRef(currentElement._owner, ref, this);
     }
 
@@ -214,7 +214,7 @@ class CompositeComponent extends BaseComponent {
       let currentElement = this.__currentElement;
       let ref = currentElement.ref;
 
-      if (!currentElement.type.__forwardRef && ref) {
+      if (!currentElement.type._forwardRef && ref) {
         detachRef(currentElement._owner, ref, this);
       }
 
@@ -329,9 +329,9 @@ class CompositeComponent extends BaseComponent {
     }
 
     // Update refs
-    if (this.__currentElement.type.__forwardRef) {
+    if (this.__currentElement.type._forwardRef) {
       instance.__prevForwardRef = prevElement.ref;
-      instance.__forwardRef = nextElement.ref;
+      instance._forwardRef = nextElement.ref;
     } else {
       updateRef(prevElement, nextElement, this);
     }

--- a/packages/rax/src/vdom/reactive.js
+++ b/packages/rax/src/vdom/reactive.js
@@ -31,8 +31,8 @@ export default class ReactiveComponent extends Component {
 
     this.state = {};
 
-    if (pureRender.__forwardRef) {
-      this.__prevForwardRef = this.__forwardRef = ref;
+    if (pureRender._forwardRef) {
+      this.__prevForwardRef = this._forwardRef = ref;
     }
 
     const compares = pureRender.__compares;
@@ -48,7 +48,7 @@ export default class ReactiveComponent extends Component {
           }
         }
 
-        return !arePropsEqual || this.__prevForwardRef !== this.__forwardRef;
+        return !arePropsEqual || this.__prevForwardRef !== this._forwardRef;
       };
     }
   }
@@ -121,7 +121,7 @@ export default class ReactiveComponent extends Component {
     this.__hookID = 0;
     this.__reRenders = 0;
     this.__isScheduled = false;
-    let children = this.__render(this.props, this.__forwardRef ? this.__forwardRef : this.context);
+    let children = this.__render(this.props, this._forwardRef ? this._forwardRef : this.context);
 
     while (this.__isScheduled) {
       this.__reRenders++;
@@ -135,7 +135,7 @@ export default class ReactiveComponent extends Component {
 
       this.__hookID = 0;
       this.__isScheduled = false;
-      children = this.__render(this.props, this.__forwardRef ? this.__forwardRef : this.context);
+      children = this.__render(this.props, this._forwardRef ? this._forwardRef : this.context);
     }
 
     if (this.__shouldUpdate) {


### PR DESCRIPTION
### support forwardRef in ssr

### throw error when hooks is used inside a class component

before
`Uncaught TypeError: currentInstance.getHookID is not a function`

after
`Uncaught Error: Hooks can only be called inside a component.`

### fix error when render child with zero value

```jsx
      const value = 0;

      function MyComponent() {
        return <span>{value}</span>;
      }

      let str = renderToString(<MyComponent />);
```

before

```jsx
<span></span>
```

after

```jsx
<span>0</span>
```