### PR TITLE
feat: support multiple-platform-style

### DIFF
--- a/packages/jsx-compiler/src/adapter.js
+++ b/packages/jsx-compiler/src/adapter.js
@@ -19,8 +19,7 @@ const parserAdapters = {
       className: '__rax-view'
     },
 
-    className: 'class',
-    style: 'style'
+    styleKeyword: false,
   },
   'wechat': {
     if: 'wx:if',
@@ -41,9 +40,7 @@ const parserAdapters = {
       onTouchCancel: 'bindtouchcancel',
       className: '__rax-view'
     },
-
-    className: 'className',
-    style: 'styleSheet'
+    styleKeyword: true
   },
 };
 

--- a/packages/jsx-compiler/src/modules/__tests__/attribute.js
+++ b/packages/jsx-compiler/src/modules/__tests__/attribute.js
@@ -2,6 +2,7 @@ const t = require('@babel/types');
 const { _transformAttribute } = require('../attribute');
 const { parseExpression } = require('../../parser');
 const adapter = require('../../adapter').ali;
+const wxAdapter = require('../../adapter').wechat;
 const genCode = require('../../codegen/genCode');
 
 describe('Transform JSX Attribute', () => {
@@ -23,5 +24,17 @@ describe('Transform JSX Attribute', () => {
     const refs = _transformAttribute(ast, code, adapter);
     expect(genCode(ast).code).toEqual('<View ref="scrollViewRef">test</View>');
     expect(refs).toEqual([t.stringLiteral('scrollViewRef')]);
+  });
+  it('should transform wechat native component className into class', () => {
+    const code = '<rax-view className="box">test</rax-view>';
+    const ast = parseExpression(code);
+    _transformAttribute(ast, code, wxAdapter);
+    expect(genCode(ast).code).toEqual('<rax-view class="box">test</rax-view>');
+  });
+  it('should not transform wechat custom component className', () => {
+    const code = '<Custom className="box">test</Custom>';
+    const ast = parseExpression(code);
+    _transformAttribute(ast, code, wxAdapter);
+    expect(genCode(ast).code).toEqual('<Custom className="box">test</Custom>');
   });
 });

--- a/packages/jsx-compiler/src/modules/__tests__/attribute.js
+++ b/packages/jsx-compiler/src/modules/__tests__/attribute.js
@@ -13,10 +13,10 @@ describe('Transform JSX Attribute', () => {
     expect(genCode(ast).code).toEqual('<View a:key={1}>test</View>');
   });
   it('should transform attribute name is className', () => {
-    const code = '<View className="box">test</View>';
+    const code = '<rax-view className="box">test</rax-view>';
     const ast = parseExpression(code);
     _transformAttribute(ast, code, adapter);
-    expect(genCode(ast).code).toEqual('<View class="box">test</View>');
+    expect(genCode(ast).code).toEqual('<rax-view class="box">test</rax-view>');
   });
   it("should collect attribute name is ref and parse it's value as a string", () => {
     const code = '<View ref={scrollViewRef}>test</View>';
@@ -36,5 +36,21 @@ describe('Transform JSX Attribute', () => {
     const ast = parseExpression(code);
     _transformAttribute(ast, code, wxAdapter);
     expect(genCode(ast).code).toEqual('<Custom className="box">test</Custom>');
+  });
+  it('should not transform wechat native component style', () => {
+    const code = "<rax-view style={{width: '100rpx'}}>test</rax-view>";
+    const ast = parseExpression(code);
+    _transformAttribute(ast, code, wxAdapter);
+    expect(genCode(ast).code).toEqual(`<rax-view style={{
+  width: '100rpx'
+}}>test</rax-view>`);
+  });
+  it('should transform wechat custom component style into styleSheet', () => {
+    const code = "<Custom style={{width: '100rpx'}}>test</Custom>";
+    const ast = parseExpression(code);
+    _transformAttribute(ast, code, wxAdapter);
+    expect(genCode(ast).code).toEqual(`<Custom styleSheet={{
+  width: '100rpx'
+}}>test</Custom>`);
   });
 });

--- a/packages/jsx-compiler/src/modules/attribute.js
+++ b/packages/jsx-compiler/src/modules/attribute.js
@@ -46,7 +46,7 @@ function isNativeComponent(path) {
   const {
     node: { name: tagName }
   } = path.parentPath.get('name');
-  return baseComponents[tagName];
+  return !!baseComponents[tagName];
 }
 
 module.exports = {

--- a/packages/jsx-compiler/src/modules/attribute.js
+++ b/packages/jsx-compiler/src/modules/attribute.js
@@ -2,6 +2,7 @@ const t = require('@babel/types');
 const traverse = require('../utils/traverseNodePath');
 const genExpression = require('../codegen/genExpression');
 const CodeError = require('../utils/CodeError');
+const baseComponents = require('../baseComponents');
 
 function transformAttribute(ast, code, adapter) {
   const refs = [];
@@ -14,7 +15,14 @@ function transformAttribute(ast, code, adapter) {
           node.name.name = adapter.key;
           break;
         case 'className':
-          node.name.name = adapter.className;
+          if (!adapter.styleKeyword || isNativeComponent(path)) {
+            node.name.name = 'class';
+          }
+          break;
+        case 'style':
+          if (adapter.styleKeyword && !isNativeComponent(path)) {
+            node.name.name = 'styleSheet';
+          }
           break;
         case 'ref':
           if (t.isJSXExpressionContainer(node.value)) {
@@ -32,6 +40,13 @@ function transformAttribute(ast, code, adapter) {
     }
   });
   return refs;
+}
+
+function isNativeComponent(path) {
+  const {
+    node: { name: tagName }
+  } = path.parentPath.get('name');
+  return baseComponents[tagName];
 }
 
 module.exports = {

--- a/packages/jsx-compiler/src/modules/components.js
+++ b/packages/jsx-compiler/src/modules/components.js
@@ -299,16 +299,20 @@ function getComponentPath(alias, options) {
     const pkgName = getRealNpmPkgName(realNpmFile);
     // npm module
     const pkg = getComponentConfig(alias.from, options.resourcePath);
-    if (pkg.miniappConfig && pkg.miniappConfig.main) {
+    let mainName = 'main';
+    if (options.platform.type !== 'ali') {
+      mainName += `:${options.platform.type}`;
+    }
+    if (pkg.miniappConfig && pkg.miniappConfig[mainName]) {
       if (disableCopyNpm) {
-        return join(pkg.name, pkg.miniappConfig.main);
+        return join(pkg.name, pkg.miniappConfig[mainName]);
       }
 
       const targetFileDir = dirname(join(options.outputPath, relative(options.sourcePath, options.resourcePath)));
       let npmRelativePath = relative(targetFileDir, join(options.outputPath, '/npm'));
       npmRelativePath = npmRelativePath[0] !== '.' ? './' + npmRelativePath : npmRelativePath;
 
-      const miniappConfigRelativePath = relative(pkg.main, pkg.miniappConfig.main);
+      const miniappConfigRelativePath = relative(pkg.main, pkg.miniappConfig[mainName]);
       const realMiniappAbsPath = resolve(realNpmFile, miniappConfigRelativePath);
       const realMiniappRelativePath = realMiniappAbsPath.slice(realMiniappAbsPath.indexOf(pkgName) + pkgName.length);
       return './' + join(npmRelativePath, pkgName.replace(/@/g, '_'), realMiniappRelativePath);

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -339,7 +339,7 @@ function transformTemplate(ast, scope = null, adapter, sourceCode, componentDepe
           if (replaceName) {
             replaceComponentTagName(path, t.jsxIdentifier(replaceName));
             const propsMap = adapter[replaceName];
-            const classAttrName = adapter.styleKeyword ? 'class' : 'className';
+            const classAttrName = adapter.styleKeyword ? 'className' : 'class';
             let hasClassName = false;
             node.attributes.forEach(attr => {
               if (t.isJSXIdentifier(attr.name)) {

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -331,7 +331,7 @@ function transformTemplate(ast, scope = null, adapter, sourceCode, componentDepe
     JSXExpressionContainer: handleJSXExpressionContainer,
     JSXOpeningElement: {
       exit(path) {
-        const { node, parent } = path;
+        const { node } = path;
         const componentTagNode = node.name;
         if (t.isJSXIdentifier(componentTagNode)) {
           const name = componentTagNode.name;
@@ -339,10 +339,11 @@ function transformTemplate(ast, scope = null, adapter, sourceCode, componentDepe
           if (replaceName) {
             replaceComponentTagName(path, t.jsxIdentifier(replaceName));
             const propsMap = adapter[replaceName];
+            const classAttrName = adapter.styleKeyword ? 'class' : 'className';
             let hasClassName = false;
             node.attributes.forEach(attr => {
               if (t.isJSXIdentifier(attr.name)) {
-                if (attr.name.name === adapter.className) {
+                if (attr.name.name === classAttrName) {
                   attr.value.value = propsMap.className + ' ' + attr.value.value;
                   hasClassName = true;
                 } else if (propsMap[attr.name.name]) {
@@ -351,7 +352,7 @@ function transformTemplate(ast, scope = null, adapter, sourceCode, componentDepe
               }
             });
             if (!hasClassName) {
-              node.attributes.push(t.jsxAttribute(t.jsxIdentifier(adapter.className), t.stringLiteral(propsMap.className)));
+              node.attributes.push(t.jsxAttribute(t.jsxIdentifier(classAttrName), t.stringLiteral(propsMap.className)));
             }
           }
         }

--- a/packages/jsx2mp-loader/src/component-loader.js
+++ b/packages/jsx2mp-loader/src/component-loader.js
@@ -15,12 +15,10 @@ module.exports = function componentLoader(content) {
   const { platform, entryPath, constantDir, mode, disableCopyNpm } = loaderOptions;
   const rawContent = readFileSync(this.resourcePath, 'utf-8');
   const resourcePath = this.resourcePath;
-  const rootContext = this.rootContext;
 
   const outputPath = this._compiler.outputPath;
   const sourcePath = join(this.rootContext, dirname(entryPath));
   const relativeSourcePath = relative(sourcePath, this.resourcePath);
-  const targetFilePath = join(outputPath, relativeSourcePath);
   const distFileWithoutExt = removeExt(join(outputPath, relativeSourcePath));
 
   const isFromConstantDir = cached(function isFromConstantDir(dir) {


### PR DESCRIPTION
微信等平台小程序通过 Web Components 实现的自定义组件，导致 style 和 class 等样式标准命名被过滤掉，从而无法设置 shadow-root 内部元素样式。此次提交通过 styleSheet 和 className 等命名绕过该限制。