### PR TITLE
fix: update exception when rise a element type error

### DIFF
--- a/packages/rax/src/vdom/__tests__/composite.js
+++ b/packages/rax/src/vdom/__tests__/composite.js
@@ -247,6 +247,48 @@ describe('CompositeComponent', function() {
     expect(container.childNodes[0].childNodes[0].data).toBe('Caught an error: Hello.');
   });
 
+  it('catches component update error in a boundary', () => {
+    let container = createNodeElement('div');
+    class ErrorBoundary extends Component {
+      state = {error: null};
+      componentDidCatch(error) {
+        this.setState({error});
+      }
+      render() {
+        if (this.state.error) {
+          return (
+            <span>{`Caught an error: ${this.state.error.message}.`}</span>
+          );
+        }
+        return this.props.children;
+      }
+    }
+
+    class BrokenRender extends Component {
+      state = {str: 'Hello'};
+      componentDidMount() {
+        this.setState({
+          str: {
+            a: 2
+          }
+        });
+      }
+      render() {
+        return (
+          <span>{this.state.str}</span>
+        );
+      }
+    }
+
+    render(
+      <ErrorBoundary>
+        <BrokenRender />
+      </ErrorBoundary>, container);
+
+    jest.runAllTimers();
+    expect(container.childNodes[0].childNodes[0].data).toContain('Caught an error: Invalid element type');
+  });
+
   it('catches lifeCycles errors in a boundary', () => {
     let container = createNodeElement('div');
     class ErrorBoundary extends Component {

--- a/packages/rax/src/vdom/__tests__/composite.js
+++ b/packages/rax/src/vdom/__tests__/composite.js
@@ -267,10 +267,12 @@ describe('CompositeComponent', function() {
     class BrokenRender extends Component {
       state = {str: 'Hello'};
       componentDidMount() {
-        this.setState({
-          str: {
-            a: 2
-          }
+        setTimeout(() => {
+          this.setState({
+            str: {
+              a: 2
+            }
+          });
         });
       }
       render() {

--- a/packages/rax/src/vdom/__tests__/composite.js
+++ b/packages/rax/src/vdom/__tests__/composite.js
@@ -217,6 +217,44 @@ describe('CompositeComponent', function() {
     ]);
   });
 
+  it('not break other component render when one component rise an error', () => {
+    let container = createNodeElement('div');
+    class MyComponent extends Component {
+      render() {
+        return [
+          <BrokenRender key="a" />,
+          <NoBrokenRender key="b" />
+        ];
+      }
+    }
+
+    class BrokenRender extends Component {
+      constructor() {
+        throw new Error('Hello');
+      }
+      render() {
+        return (
+          <span>Hello 1</span>
+        );
+      }
+    }
+
+    class NoBrokenRender extends Component {
+      render() {
+        return (
+          <span>Hello 2</span>
+        );
+      }
+    }
+
+    expect(() => {
+      render(<MyComponent />, container);
+      jest.runAllTimers();
+    }).toThrowError(/Hello/);
+
+    expect(container.childNodes[0].childNodes[0].data).toBe('Hello 2');
+  });
+
   it('catches render error in a boundary', () => {
     let container = createNodeElement('div');
     class ErrorBoundary extends Component {

--- a/packages/rax/src/vdom/composite.js
+++ b/packages/rax/src/vdom/composite.js
@@ -445,12 +445,15 @@ class CompositeComponent extends BaseComponent {
       // If getChildContext existed and invoked when component updated that will make
       // prevRenderedUnmaskedContext not equal nextRenderedUnmaskedContext under the tree
       if (prevRenderedElement !== nextRenderedElement || prevRenderedUnmaskedContext !== nextRenderedUnmaskedContext) {
-        prevRenderedComponent.__updateComponent(
-          prevRenderedElement,
-          nextRenderedElement,
-          prevRenderedUnmaskedContext,
-          nextRenderedUnmaskedContext
-        );
+        // If element type is illegal catch the error
+        performInSandbox(() => {
+          prevRenderedComponent.__updateComponent(
+            prevRenderedElement,
+            nextRenderedElement,
+            prevRenderedUnmaskedContext,
+            nextRenderedUnmaskedContext
+          );
+        }, instance);
       }
 
       if (process.env.NODE_ENV !== 'production') {

--- a/packages/rax/src/vdom/performInSandbox.js
+++ b/packages/rax/src/vdom/performInSandbox.js
@@ -6,7 +6,6 @@ export default function performInSandbox(fn, instance, callback) {
   try {
     return fn();
   } catch (e) {
-    debugger;
     if (callback) {
       callback(e);
     } else {

--- a/packages/rax/src/vdom/performInSandbox.js
+++ b/packages/rax/src/vdom/performInSandbox.js
@@ -1,0 +1,37 @@
+import getNearestParent from './getNearestParent';
+import { scheduler, scheduleLayout } from './scheduler';
+import { INTERNAL } from '../constant';
+
+export default function performInSandbox(fn, instance, callback) {
+  try {
+    return fn();
+  } catch (e) {
+    debugger;
+    if (callback) {
+      callback(e);
+    } else {
+      handleError(instance, e);
+    }
+  }
+}
+
+export function handleError(instance, error) {
+  let boundary = getNearestParent(instance, parent => parent.componentDidCatch);
+
+  if (boundary) {
+    scheduleLayout(() => {
+      const boundaryInternal = boundary[INTERNAL];
+      // Should not attempt to recover an unmounting error boundary
+      if (boundaryInternal) {
+        performInSandbox(() => {
+          boundary.componentDidCatch(error);
+        }, boundaryInternal.__parentInstance);
+      }
+    });
+  } else {
+    // Do not break when error happens
+    scheduler(() => {
+      throw error;
+    }, 0);
+  }
+}

--- a/packages/rax/src/vdom/updater.js
+++ b/packages/rax/src/vdom/updater.js
@@ -1,7 +1,6 @@
 import Host from './host';
 import { flushEffect, schedule, flushLayout } from './scheduler';
-import { INSTANCE, INTERNAL, RENDERED_COMPONENT } from '../constant';
-import performInSandbox from './performInSandbox';
+import { INTERNAL, RENDERED_COMPONENT } from '../constant';
 
 // Dirty components store
 let dirtyComponents = [];
@@ -46,17 +45,14 @@ function runUpdate(component) {
   internal.__penddingContext = undefined;
 
   if (getPendingStateQueue(internal) || internal.__isPendingForceUpdate) {
-    const instance = internal[INSTANCE];
-    performInSandbox(() => {
-      internal.__updateComponent(
-        prevElement,
-        prevElement,
-        prevUnmaskedContext,
-        nextUnmaskedContext
-      );
-    }, instance);
+    internal.__updateComponent(
+      prevElement,
+      prevElement,
+      prevUnmaskedContext,
+      nextUnmaskedContext
+    );
 
-    performInSandbox(flushLayout, instance);
+    flushLayout();
   }
 
   Host.__isUpdating = false;

--- a/packages/rax/src/vdom/updater.js
+++ b/packages/rax/src/vdom/updater.js
@@ -1,6 +1,7 @@
 import Host from './host';
 import { flushEffect, schedule, flushLayout } from './scheduler';
-import { INTERNAL, RENDERED_COMPONENT } from '../constant';
+import { INSTANCE, INTERNAL, RENDERED_COMPONENT } from '../constant';
+import performInSandbox from './performInSandbox';
 
 // Dirty components store
 let dirtyComponents = [];
@@ -45,13 +46,17 @@ function runUpdate(component) {
   internal.__penddingContext = undefined;
 
   if (getPendingStateQueue(internal) || internal.__isPendingForceUpdate) {
-    internal.__updateComponent(
-      prevElement,
-      prevElement,
-      prevUnmaskedContext,
-      nextUnmaskedContext
-    );
-    flushLayout();
+    const instance = internal[INSTANCE];
+    performInSandbox(() => {
+      internal.__updateComponent(
+        prevElement,
+        prevElement,
+        prevUnmaskedContext,
+        nextUnmaskedContext
+      );
+    }, instance);
+
+    performInSandbox(flushLayout, instance);
   }
 
   Host.__isUpdating = false;


### PR DESCRIPTION
Fix below code that will make rax update exception:
```
const App = () => {
  const [data, setData] = useState('string');

  console.log('Host.__isUpdating', shared.Host.__isUpdating);
  return (
    <div onClick={() => {
      setData({ a: 2 });
    }}>
      Hello World
      <span>{data}</span>
    </div>
  );
};

```