### PR TITLE
feat: support wechat miniprogram

### DIFF
--- a/packages/jsx-compiler/src/adapter.js
+++ b/packages/jsx-compiler/src/adapter.js
@@ -18,8 +18,10 @@ const parserAdapters = {
       onLongPress: 'onLongTap',
       className: '__rax-view'
     },
-
+    // Need transform style & class keyword
     styleKeyword: false,
+    // Need transform onClick -> bindonclick
+    needTransformEvent: false
   },
   'wechat': {
     if: 'wx:if',
@@ -40,7 +42,8 @@ const parserAdapters = {
       onTouchCancel: 'bindtouchcancel',
       className: '__rax-view'
     },
-    styleKeyword: true
+    styleKeyword: true,
+    needTransformEvent: true
   },
 };
 

--- a/packages/jsx-compiler/src/baseComponents.js
+++ b/packages/jsx-compiler/src/baseComponents.js
@@ -1,3 +1,11 @@
-module.exports = {
-  'rax-view': 'view'
-};
+module.exports = [
+  'rax-text',
+  'rax-scrollview',
+  'rax-textinput',
+  'rax-picture',
+  'rax-slider',
+  'rax-icon',
+  'rax-link',
+  'rax-video',
+  'rax-image'
+];

--- a/packages/jsx-compiler/src/compiledComponents.js
+++ b/packages/jsx-compiler/src/compiledComponents.js
@@ -1,0 +1,3 @@
+module.exports = {
+  'rax-view': 'view'
+};

--- a/packages/jsx-compiler/src/modules/__tests__/components.js
+++ b/packages/jsx-compiler/src/modules/__tests__/components.js
@@ -38,8 +38,8 @@ describe('Transform components', () => {
     };
     const options = {};
     const { componentsAlias } = _transformComponents(parsed, options);
-    expect(genCode(ast).code).toEqual(`<rax-view __tagId="0">
-        <c-a94616 __parentId="{{__tagId}}" __tagId="1" />
+    expect(genCode(ast).code).toEqual(`<rax-view>
+        <c-a94616 __parentId="{{__tagId}}" __tagId="0" />
       </rax-view>`);
     expect(componentsAlias).toEqual({'c-a94616': {'default': true, 'from': '../components/CustomEl', 'isCustomEl': true, 'local': 'CustomEl', 'name': 'c-a94616'}});
   });

--- a/packages/jsx-compiler/src/modules/__tests__/list.js
+++ b/packages/jsx-compiler/src/modules/__tests__/list.js
@@ -64,7 +64,7 @@ describe('Transform list', () => {
       }</View>`;
     const ast = parseExpression(raw);
     _transformList(ast, [], adapter);
-    expect(genCode(ast).code).toEqual(`<View class="coupon-list"><block a:for={couponList.map(coupon => ({
+    expect(genCode(ast).code).toEqual(`<View class="coupon-list"><block a:for={couponList.map((coupon, index) => ({
     coupon: coupon
   }))} a:for-item="coupon" a:for-index="index"><Coupon coupon={coupon} onClick={this.handleClick} data-arg-context="this" data-arg-0={coupon} /></block></View>`);
   });
@@ -107,11 +107,21 @@ describe('Transform list', () => {
     expect(genCode(ast, { concise: true }).code).toEqual(`<View className="header" onClick={() => { setWorkYear(workYear + 1); }}>
   <View style={{ color: 'red' }}>workYear: {workYear}</View>
   <View style={{ color: 'red' }}>count: {count}</View>
-  <block a:for={arr.map(l1 => { return { l1: l1, l2: l2 }; })} a:for-item="l1" a:for-index="index"><View>
-        <block a:for={l1.map(l2 => { return { l2: l2 }; })} a:for-item="l2" a:for-index="index"><View>{l2}</View></block>
+  <block a:for={arr.map((l1, index) => { return { l1: l1, l2: l2, index: index }; })} a:for-item="l1" a:for-index="index"><View>
+        <block a:for={l1.map((l2, index) => { return { l2: l2 }; })} a:for-item="l2" a:for-index="index"><View>{l2}</View></block>
       </View></block>
   <Loading count={count} />
   {props.children}
 </View>`);
+  });
+
+  it('list default params', () => {
+    const raw = `<View>{[1,2,3].map(() => {
+      return <Text>test</Text>;
+    })}</View>`;
+    const ast = parseExpression(raw);
+    _transformList(ast, [], adapter);
+
+    expect(genCode(ast, { concise: true }).code).toEqual('<View><block a:for={[1, 2, 3].map((item, index) => { return {}; })} a:for-item="item" a:for-index="index"><Text>test</Text></block></View>');
   });
 });

--- a/packages/jsx-compiler/src/modules/attribute.js
+++ b/packages/jsx-compiler/src/modules/attribute.js
@@ -2,7 +2,7 @@ const t = require('@babel/types');
 const traverse = require('../utils/traverseNodePath');
 const genExpression = require('../codegen/genExpression');
 const CodeError = require('../utils/CodeError');
-const baseComponents = require('../baseComponents');
+const compiledComponents = require('../compiledComponents');
 
 function transformAttribute(ast, code, adapter) {
   const refs = [];
@@ -46,7 +46,7 @@ function isNativeComponent(path) {
   const {
     node: { name: tagName }
   } = path.parentPath.get('name');
-  return !!baseComponents[tagName];
+  return !!compiledComponents[tagName];
 }
 
 module.exports = {

--- a/packages/jsx-compiler/src/modules/components.js
+++ b/packages/jsx-compiler/src/modules/components.js
@@ -8,7 +8,7 @@ const traverse = require('../utils/traverseNodePath');
 const moduleResolve = require('../utils/moduleResolve');
 const createJSX = require('../utils/createJSX');
 const Expression = require('../utils/Expression');
-const baseComponents = require('../baseComponents');
+const compiledComponents = require('../compiledComponents');
 const replaceComponentTagName = require('../utils/replaceComponentTagName');
 
 const RELATIVE_COMPONENTS_REG = /^\..*(\.jsx?)?$/i;
@@ -31,42 +31,44 @@ function transformIdentifierComponentName(path, alias, dynamicValue, parsed, opt
   } = parsed;
   // Miniapp template tag name does not support special characters.
   const componentTag = alias.name.replace(/@|\//g, '_');
-  const parentJSXListEl = path.findParent(p => p.node.__jsxlist);
-  // <tag __tagId="tagId" />
-  let tagId = '' + tagCount++;
-  if (parentJSXListEl) {
-    const { args } = parentJSXListEl.node.__jsxlist;
-    const indexValue = args.length > 1 ? genExpression(args[1]) : 'index';
-    parentPath.node.__tagIdExpression = [tagId, new Expression(indexValue)];
-    tagId += '-{{' + indexValue + '}}';
-  }
-  parentPath.node.__tagId = tagId;
-  componentDependentProps[tagId] = componentDependentProps[tagId] || {};
-  if (parentPath.node.__tagIdExpression) {
-    componentDependentProps[tagId].tagIdExpression =
-      parentPath.node.__tagIdExpression;
-
-    if (renderFunctionPath) {
-      const { loopFnBody } = parentJSXListEl.node.__jsxlist;
-      componentDependentProps[tagId].parentNode = loopFnBody.body;
-    }
-  }
-
-  if (alias.isCustomEl) {
-    node.attributes.push(
-      t.jsxAttribute(
-        t.jsxIdentifier('__parentId'),
-        t.stringLiteral('{{__tagId}}'),
-      ),
-    );
-  }
-
-  node.attributes.push(
-    t.jsxAttribute(t.jsxIdentifier('__tagId'), t.stringLiteral(tagId)),
-  );
-
   replaceComponentTagName(path, t.jsxIdentifier(componentTag));
-  if (!baseComponents[componentTag]) {
+
+  if (!compiledComponents[componentTag]) {
+    const parentJSXListEl = path.findParent(p => p.node.__jsxlist);
+    // <tag __tagId="tagId" />
+    let tagId = '' + tagCount++;
+
+    if (parentJSXListEl) {
+      const { args } = parentJSXListEl.node.__jsxlist;
+      const indexValue = args.length > 1 ? genExpression(args[1]) : 'index';
+      parentPath.node.__tagIdExpression = [tagId, new Expression(indexValue)];
+      tagId += '-{{' + indexValue + '}}';
+    }
+    parentPath.node.__tagId = tagId;
+    componentDependentProps[tagId] = componentDependentProps[tagId] || {};
+    if (parentPath.node.__tagIdExpression) {
+      componentDependentProps[tagId].tagIdExpression =
+        parentPath.node.__tagIdExpression;
+
+      if (renderFunctionPath) {
+        const { loopFnBody } = parentJSXListEl.node.__jsxlist;
+        componentDependentProps[tagId].parentNode = loopFnBody.body;
+      }
+    }
+
+    if (alias.isCustomEl) {
+      node.attributes.push(
+        t.jsxAttribute(
+          t.jsxIdentifier('__parentId'),
+          t.stringLiteral('{{__tagId}}'),
+        ),
+      );
+    }
+
+    node.attributes.push(
+      t.jsxAttribute(t.jsxIdentifier('__tagId'), t.stringLiteral(tagId)),
+    );
+
     /**
      * Handle with special attrs.
      */

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -173,7 +173,7 @@ function transformTemplate(ast, scope = null, adapter, sourceCode, componentDepe
         path.remove();
         break;
 
-      // <tag xxxlick={() => {}} /> => <tag onClick="_e0" />
+      // <tag onClick={() => {}} /> => <tag onClick="_e0" />
       // <tag>{() => {}}</tag> => throw Error
       case 'ArrowFunctionExpression':
       case 'FunctionExpression':

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -5,12 +5,14 @@ const createBinding = require('../utils/createBinding');
 const createJSXBinding = require('../utils/createJSXBinding');
 const CodeError = require('../utils/CodeError');
 const DynamicBinding = require('../utils/DynamicBinding');
+const compiledComponents = require('../compiledComponents');
 const baseComponents = require('../baseComponents');
 const replaceComponentTagName = require('../utils/replaceComponentTagName');
 
 const ATTR = Symbol('attribute');
 const ELE = Symbol('element');
 const isDirectiveAttr = (attr) => /^(a:|wx:|x-)/.test(attr);
+const isEventHandlerAttr = (propKey) => /^on[A-Z]/.test(propKey);
 
 /**
  * 1. Normalize jsxExpressionContainer to binding var.
@@ -31,14 +33,25 @@ function transformTemplate(ast, scope = null, adapter, sourceCode, componentDepe
       ? ATTR // <View foo={bar} />
       : ELE; // <View>{xxx}</View>
     let { expression } = node;
-    const attributeName = type === ATTR
-      ? parentPath.node.name.name
-      : null;
+    let attributeName = null;
     const jsxEl = type === ATTR
       ? path.findParent(p => p.isJSXElement()).node
       : null;
 
-    const isDirective = isDirectiveAttr(attributeName);
+    let isDirective;
+
+    if (type === ATTR) {
+      attributeName = parentPath.node.name.name;
+      isDirective = isDirectiveAttr(attributeName);
+      if (!isDirective && jsxEl.__tagId && !compiledComponents[jsxEl.openingElement.name.name]) {
+        componentDependentProps[jsxEl.__tagId].props = componentDependentProps[jsxEl.__tagId].props || {};
+        componentDependentProps[jsxEl.__tagId].props[attributeName] = expression;
+      }
+    } else {
+      isDirective = isDirectiveAttr(attributeName);
+    }
+
+    const isEventHandler = isEventHandlerAttr(attributeName);
 
     switch (expression.type) {
       // <div foo={'string'} /> -> <div foo="string" />
@@ -134,7 +147,7 @@ function transformTemplate(ast, scope = null, adapter, sourceCode, componentDepe
           if (expression.name === 'undefined') {
             parentPath.remove(); // Remove jsxAttribute
             break;
-          } else if (isEventHandler(attributeName)) {
+          } else if (isEventHandler) {
             const name = dynamicEvents.add({
               expression,
               isDirective
@@ -143,10 +156,6 @@ function transformTemplate(ast, scope = null, adapter, sourceCode, componentDepe
           } else {
             const replaceNode = transformIdentifier(expression, dynamicValues, isDirective);
             path.replaceWith(t.stringLiteral(createBinding(genExpression(replaceNode))));
-          }
-          if (!isDirective && jsxEl.__tagId) {
-            componentDependentProps[jsxEl.__tagId].props = componentDependentProps[jsxEl.__tagId].props || {};
-            componentDependentProps[jsxEl.__tagId].props[attributeName] = expression;
           }
         } else if (type === ELE) {
           if (expression.name === 'undefined') {
@@ -164,13 +173,13 @@ function transformTemplate(ast, scope = null, adapter, sourceCode, componentDepe
         path.remove();
         break;
 
-      // <tag onClick={() => {}} /> => <tag onClick="_e0" />
+      // <tag xxxlick={() => {}} /> => <tag onClick="_e0" />
       // <tag>{() => {}}</tag> => throw Error
       case 'ArrowFunctionExpression':
       case 'FunctionExpression':
         if (type === ELE) throw new CodeError(sourceCode, node, node.loc, 'Unsupported Function in JSXElement:');
 
-        if (!isEventHandler(attributeName)) throw new CodeError(sourceCode, node, node.loc, `Only EventHandlers are supported in Mini Program, eg: onClick/onChange, instead of "${attributeName}".`);
+        if (!isEventHandler) throw new CodeError(sourceCode, node, node.loc, `Only EventHandlers are supported in Mini Program, eg: onClick/onChange, instead of "${attributeName}".`);
 
         const name = dynamicEvents.add({
           expression,
@@ -183,7 +192,7 @@ function transformTemplate(ast, scope = null, adapter, sourceCode, componentDepe
       // <tag>{ foo.bar }</tag> => <tag>{{ _d0.bar }}</tag>
       case 'MemberExpression':
         if (type === ATTR) {
-          if (isEventHandler(attributeName)) {
+          if (isEventHandler) {
             const name = dynamicEvents.add({
               expression,
               isDirective
@@ -195,10 +204,6 @@ function transformTemplate(ast, scope = null, adapter, sourceCode, componentDepe
             const replaceNode = transformMemberExpression(expression, dynamicValues, isDirective);
             replaceNode.__transformed = true;
             path.replaceWith(t.stringLiteral(createBinding(genExpression(replaceNode))));
-            if (!isDirective && jsxEl.__tagId) {
-              componentDependentProps[jsxEl.__tagId].props = componentDependentProps[jsxEl.__tagId].props || {};
-              componentDependentProps[jsxEl.__tagId].props[attributeName] = expression;
-            }
           }
         } else if (type === ELE) {
           const replaceNode = transformMemberExpression(expression, dynamicValues, isDirective);
@@ -211,7 +216,7 @@ function transformTemplate(ast, scope = null, adapter, sourceCode, componentDepe
       case 'CallExpression':
         if (type === ATTR) {
           if (
-            isEventHandler(attributeName)
+            isEventHandler
             && t.isMemberExpression(expression.callee)
             && t.isIdentifier(expression.callee.property, { name: 'bind' })
           ) {
@@ -335,7 +340,8 @@ function transformTemplate(ast, scope = null, adapter, sourceCode, componentDepe
         const componentTagNode = node.name;
         if (t.isJSXIdentifier(componentTagNode)) {
           const name = componentTagNode.name;
-          const replaceName = baseComponents[name];
+          // Handle rax-view
+          const replaceName = compiledComponents[name];
           if (replaceName) {
             replaceComponentTagName(path, t.jsxIdentifier(replaceName));
             const propsMap = adapter[replaceName];
@@ -354,6 +360,14 @@ function transformTemplate(ast, scope = null, adapter, sourceCode, componentDepe
               node.attributes.push(t.jsxAttribute(t.jsxIdentifier('class'), t.stringLiteral(propsMap.className)));
             }
           }
+          // Handle native components, like rax-text
+          if (baseComponents.indexOf(name) > -1 && adapter.needTransformEvent) {
+            node.attributes.forEach(attr => {
+              if (attr.value.value.indexOf('_e') > -1) {
+                attr.name.name = `bind${attr.name.name}`;
+              }
+            });
+          }
         }
       }
     }
@@ -362,9 +376,6 @@ function transformTemplate(ast, scope = null, adapter, sourceCode, componentDepe
   return { dynamicValues: dynamicValues.getStore(), dynamicEvents: dynamicEvents.getStore() };
 }
 
-function isEventHandler(propKey) {
-  return /^on[A-Z]/.test(propKey);
-}
 
 function hasComplexExpression(path) {
   let complex = false;

--- a/packages/jsx-compiler/src/modules/list.js
+++ b/packages/jsx-compiler/src/modules/list.js
@@ -75,8 +75,15 @@ function transformList(ast, renderItemFunctions, adapter) {
             */
             if (t.isFunction(args[0])) {
               const { params, body } = args[0];
-              const forItem = params[0] || t.identifier('item');
-              const forIndex = params[1] || t.identifier('index');
+              // If item or index doesn't exist， set default value to params
+              if (!params[0]) {
+                params[0] = t.identifier('item');
+              }
+              if (!params[1]) {
+                params[1] = t.identifier('index');
+              }
+              const forItem = params[0];
+              const forIndex = params[1];
               const properties = [];
               let returnElPath;
               if (t.isBlockStatement(body)) {

--- a/packages/jsx2mp-cli/__tests__/component.js
+++ b/packages/jsx2mp-cli/__tests__/component.js
@@ -31,14 +31,14 @@ afterAll(() => {
 describe('Component compiled result', () => {
   it('should return correct axml', () => {
     expect(axmlContent).toEqual(
-      `<block a:if="{{$ready}}"><view __tagId="0" class="__rax-view">
+      `<block a:if="{{$ready}}"><view class="__rax-view">
       Hello World!
-      <rax-image source="{{ uri: _d0 }}" __tagId="1" /></view></block>`);
+      <rax-image source="{{ uri: _d0 }}" __tagId="0" /></view></block>`);
   });
 
   it('should return correct js', () => {
     expect(jsContent).toEqual(
-      '\"use strict\";var _jsx2mpRuntime=require(\"./npm/jsx2mp-runtime\"),img=\"./assets/rax.png\",__def__=function(){this._updateData({_d0:img}),this._updateMethods({})};Component((0,_jsx2mpRuntime.createComponent)(__def__));'
+      '\"use strict\";var _jsx2mpRuntime=require(\"./npm/jsx2mp-runtime\"),img=\"./assets/rax.png\",__def__=function(){this._updateChildProps(\"0\",{source:{uri:img}}),this._updateData({_d0:img}),this._updateMethods({})};Component((0,_jsx2mpRuntime.createComponent)(__def__));'
     );
   });
 

--- a/packages/jsx2mp-runtime/src/bridge.js
+++ b/packages/jsx2mp-runtime/src/bridge.js
@@ -119,7 +119,6 @@ function createProxyMethods(events) {
         }
         // Concat args.
         args = datasetArgs.concat(args);
-
         if (this.instance._methods[eventName]) {
           return this.instance._methods[eventName].apply(context, args);
         } else {
@@ -154,7 +153,10 @@ function createConfig(component, options) {
   const cycles = isPage ? getPageCycles(Klass) : getComponentCycles(Klass);
   const config = {
     data: {},
-    props: {},
+    [PROPS]: {
+      __tagId: null,
+      __parentId: null
+    },
     ...cycles,
   };
 
@@ -167,9 +169,6 @@ function createConfig(component, options) {
 
   return config;
 }
-
-function noop() {}
-
 
 /**
  * Bridge App definition.

--- a/packages/jsx2mp-runtime/src/component.js
+++ b/packages/jsx2mp-runtime/src/component.js
@@ -3,7 +3,7 @@
  * Base Component class definition.
  */
 import Host from './host';
-import {updateChildProps, removeComponentProps} from './updater';
+import {updateChildProps, removeComponentProps, getComponentProps} from './updater';
 import {enqueueRender} from './enqueueRender';
 import isFunction from './isFunction';
 import sameValue from './sameValue';
@@ -312,7 +312,8 @@ export default class Component {
    */
   _setInternal(internal) {
     this._internal = internal;
-    this.props = internal[PROPS];
+    const props = internal[PROPS];
+    this.props = Object.assign({}, props, getComponentProps(props.__tagId));
     if (!this.state) this.state = {};
     Object.assign(this.state, internal.data);
   }


### PR DESCRIPTION
1. 解决微信小程序 props 传值和支付宝不一致的问题
2. 去除增加无意义的 tagId
3. map 循环渲染补全参数, `array.map(() => <View></View>)` => `array.map((item, index) => <View></View>)`
