### PR TITLE
chore: freeze props

### DIFF
--- a/packages/rax/src/__tests__/createElement.js
+++ b/packages/rax/src/__tests__/createElement.js
@@ -21,14 +21,17 @@ describe('Element', () => {
   function renderToDocument(element) {
     let container = createNodeElement('div');
     render(element, container);
+    jest.runAllTimers();
   }
 
   beforeEach(function() {
     Host.driver = ServerDriver;
+    jest.useFakeTimers();
   });
 
   afterEach(function() {
     Host.driver = null;
+    jest.useRealTimers();
   });
 
   it('createElement', () => {
@@ -111,8 +114,12 @@ describe('Element', () => {
     ));
   });
 
-  it('does not warn when the child array contains non-element', () => {
-    void <div>{[{}, {}]}</div>;
+  it('trhow errors when the child array contains invalid element type', () => {
+    let container = createNodeElement('div');
+    expect(() => {
+      render(<div>{[{}, {}]}</div>, container);
+      jest.runAllTimers();
+    }).toThrowError(/Invalid element type/);
   });
 
   it('warns for fragments of multiple elements with same key', () => {
@@ -123,5 +130,18 @@ describe('Element', () => {
         <span key={'#2'}>3</span>
       </div>
     ))).toWarnDev('Warning: Encountered two children with the same key "#1".', {withoutStack: true});
+  });
+
+  it('throw errors in dev mode when modify props', () => {
+    let container = createNodeElement('div');
+    function Foo(props) {
+      props.foo = 'bar';
+      return null;
+    }
+
+    expect(() => {
+      render(<Foo foo="foo" />, container);
+      jest.runAllTimers();
+    }).toThrowError(/Cannot assign to read only property/);
   });
 });

--- a/packages/rax/src/__tests__/createElement.js
+++ b/packages/rax/src/__tests__/createElement.js
@@ -114,7 +114,7 @@ describe('Element', () => {
     ));
   });
 
-  it('trhow errors when the child array contains invalid element type', () => {
+  it('throw errors when the child array contains invalid element type', () => {
     let container = createNodeElement('div');
     expect(() => {
       render(<div>{[{}, {}]}</div>, container);

--- a/packages/rax/src/vdom/composite.js
+++ b/packages/rax/src/vdom/composite.js
@@ -57,6 +57,11 @@ class CompositeComponent extends BaseComponent {
     let publicProps = currentElement.props;
     let componentPrototype = Component.prototype;
 
+    // Props is immutable.
+    if (process.env.NODE_ENV !== 'production') {
+      Object.freeze(publicProps);
+    }
+
     // Context process
     let publicContext = this.__processContext(context);
 
@@ -286,6 +291,12 @@ class CompositeComponent extends BaseComponent {
       // Skip checking prop types again -- we don't read component.props to avoid
       // warning for DOM component props in this upgrade
       nextProps = nextElement.props;
+
+      // Props is immutable.
+      if (process.env.NODE_ENV !== 'production') {
+        Object.freeze(nextProps);
+      }
+
       if (prevElement !== nextElement) {
         willReceive = true;
       }

--- a/packages/rax/src/vdom/composite.js
+++ b/packages/rax/src/vdom/composite.js
@@ -57,11 +57,6 @@ class CompositeComponent extends BaseComponent {
     let publicProps = currentElement.props;
     let componentPrototype = Component.prototype;
 
-    // Props is immutable.
-    if (process.env.NODE_ENV !== 'production') {
-      Object.freeze(publicProps);
-    }
-
     // Context process
     let publicContext = this.__processContext(context);
 
@@ -291,11 +286,6 @@ class CompositeComponent extends BaseComponent {
       // Skip checking prop types again -- we don't read component.props to avoid
       // warning for DOM component props in this upgrade
       nextProps = nextElement.props;
-
-      // Props is immutable.
-      if (process.env.NODE_ENV !== 'production') {
-        Object.freeze(nextProps);
-      }
 
       if (prevElement !== nextElement) {
         willReceive = true;

--- a/packages/rax/src/vdom/element.js
+++ b/packages/rax/src/vdom/element.js
@@ -32,6 +32,11 @@ export default function Element(type, key, ref, props, owner) {
       writable: true,
       value: false
     });
+
+    // Props is immutable
+    if (Object.freeze) {
+      Object.freeze(props);
+    }
   }
 
   return element;


### PR DESCRIPTION
In dev mode, rax will freeze props.

```
function Foo(props) {
  props.foo = 1; // => throw error
}
```