### PR TITLE
fix(miniapp): exclude weex module

### DIFF
--- a/packages/jsx2mp-cli/getWebpackConfig.js
+++ b/packages/jsx2mp-cli/getWebpackConfig.js
@@ -142,6 +142,9 @@ module.exports = (options = {}) => {
         if (/\.css$/.test(request)) {
           return callback(null, `commonjs2 ${request}`);
         }
+        if (/^@weex-module\//.test(request)) {
+          return callback(null, `commonjs2 ${request}`);
+        }
         callback();
       },
     ],


### PR DESCRIPTION
- exclude weex module when analyzing dependencies in miniapp