### PR TITLE
Fix: prevent the same reference

### DIFF
--- a/packages/rax/src/__tests__/createElement.js
+++ b/packages/rax/src/__tests__/createElement.js
@@ -145,7 +145,7 @@ describe('Element', () => {
     }).toThrowError(/Cannot assign to read only property/);
   });
 
-  it('make children output correct when thisProps does not change', () => {
+  it('make children output correct when components use the same props object', () => {
     let thisProps = {};
     let tagA = <div {...thisProps}>A</div>;
     let tagB = <div {...thisProps} a={1}>B</div>;

--- a/packages/rax/src/__tests__/createElement.js
+++ b/packages/rax/src/__tests__/createElement.js
@@ -144,4 +144,15 @@ describe('Element', () => {
       jest.runAllTimers();
     }).toThrowError(/Cannot assign to read only property/);
   });
+
+
+  it('The writing method of <Tag {...props} /> props can not reuse the same object', () => {
+    let thisProps = {};
+    let tagA = <div {...thisProps}>A</div>;
+    let tagB = <div {...thisProps} a={1}>B</div>;
+    let tagC = <div {...thisProps}>C</div>;
+    expect(tagA.props.children).toBe('A');
+    expect(tagB.props.children).toBe('B');
+    expect(tagC.props.children).toBe('C');
+  });
 });

--- a/packages/rax/src/__tests__/createElement.js
+++ b/packages/rax/src/__tests__/createElement.js
@@ -146,7 +146,7 @@ describe('Element', () => {
   });
 
 
-  it('The writing method of <Tag {...props} /> props can not reuse the same object', () => {
+  it('uses its own values, with the same props', () => {
     let thisProps = {};
     let tagA = <div {...thisProps}>A</div>;
     let tagB = <div {...thisProps} a={1}>B</div>;

--- a/packages/rax/src/__tests__/createElement.js
+++ b/packages/rax/src/__tests__/createElement.js
@@ -146,7 +146,7 @@ describe('Element', () => {
   });
 
 
-  it('uses its own values, with the same props', () => {
+  it('uses its own children, with the same props', () => {
     let thisProps = {};
     let tagA = <div {...thisProps}>A</div>;
     let tagB = <div {...thisProps} a={1}>B</div>;

--- a/packages/rax/src/__tests__/createElement.js
+++ b/packages/rax/src/__tests__/createElement.js
@@ -145,8 +145,7 @@ describe('Element', () => {
     }).toThrowError(/Cannot assign to read only property/);
   });
 
-
-  it('uses its own children, with the same props', () => {
+  it('make children output correct when thisProps does not change', () => {
     let thisProps = {};
     let tagA = <div {...thisProps}>A</div>;
     let tagB = <div {...thisProps} a={1}>B</div>;

--- a/packages/rax/src/createElement.js
+++ b/packages/rax/src/createElement.js
@@ -33,7 +33,7 @@ export default function createElement(type, config, children) {
 
     if (process.env.NODE_ENV !== 'production') {
       if (isString(ref) && !ownerComponent) {
-        console.error('createElement: adding a string ref "' + ref + '" outside the render method.');
+        warning('createElement: adding a string ref "' + ref + '" outside the render method.');
       }
     }
 

--- a/packages/rax/src/createElement.js
+++ b/packages/rax/src/createElement.js
@@ -46,7 +46,8 @@ export default function createElement(type, config, children) {
     }
 
     // If no reserved props, assign config to props for better performance
-    if (hasReservedProps || config.children) { // When the property childern exists in config, prevent the same reference
+    // The writing method of <Tag {...props} /> props will reuse the same object, and at the same time, the value of config.children will be overwritten
+    if (hasReservedProps || config.children != undefined) {
       for (propName in config) {
         // Extract reserved props
         if (!RESERVED_PROPS[propName]) {

--- a/packages/rax/src/createElement.js
+++ b/packages/rax/src/createElement.js
@@ -46,7 +46,7 @@ export default function createElement(type, config, children) {
     }
 
     // If no reserved props, assign config to props for better performance
-    if (hasReservedProps) {
+    if (hasReservedProps || config.children) { // When the property childern exists in config, prevent the same reference
       for (propName in config) {
         // Extract reserved props
         if (!RESERVED_PROPS[propName]) {

--- a/packages/rax/src/createElement.js
+++ b/packages/rax/src/createElement.js
@@ -28,34 +28,20 @@ export default function createElement(type, config, children) {
   const ownerComponent = Host.owner;
 
   if (config != null) {
-    let hasReservedProps = false;
+    ref = config.ref === undefined ? null : config.ref;
+    key = config.key === undefined ? null : '' + config.key;
 
-    if (config.ref != null) {
-      hasReservedProps = true;
-      ref = config.ref;
-      if (process.env.NODE_ENV !== 'production') {
-        if (isString(ref) && !ownerComponent) {
-          warning('createElement: adding a string ref "' + ref + '" outside the render method.');
-        }
+    if (process.env.NODE_ENV !== 'production') {
+      if (isString(ref) && !ownerComponent) {
+        console.error('createElement: adding a string ref "' + ref + '" outside the render method.');
       }
     }
 
-    if (config.key != null) {
-      hasReservedProps = true;
-      key = '' + config.key;
-    }
-
-    // If no reserved props, assign config to props for better performance
-    // The writing method of <Tag {...props} /> props will reuse the same object, and at the same time, the value of config.children will be overwritten
-    if (hasReservedProps || config.children != undefined) {
-      for (propName in config) {
-        // Extract reserved props
-        if (!RESERVED_PROPS[propName]) {
-          props[propName] = config[propName];
-        }
+    // Remaining properties are added to a new props object
+    for (propName in config) {
+      if (!RESERVED_PROPS[propName]) {
+        props[propName] = config[propName];
       }
-    } else {
-      props = config;
     }
   }
 


### PR DESCRIPTION
```jsx
const App = () => {
  let thisProps = {};
  return (
    <View>
      <View {...thisProps}>A</View>
      <View {...thisProps}>B</View>
      <View {...thisProps} a={1}>C</View>
      <View {...thisProps}>D</View>
    </View>
  );
};
```
This code will output  D D C D.
The same object ‘thisProps’ will be assigned continuously, Assign 'children' value D to ''thisProps''
When the property childern exists in config, prevent the same reference.

