### PR TITLE
fix: page lifecyle

### DIFF
--- a/packages/jsx-compiler/src/modules/__tests__/element.js
+++ b/packages/jsx-compiler/src/modules/__tests__/element.js
@@ -85,7 +85,7 @@ describe('Transform JSXElement', () => {
 
       expect(genDynamicAttrs(dynamicEvents)).toEqual('{ _e0: event => { console.log(event); }, _e1: console.log, _e2: function (event) { console.log(event); } }');
 
-      expect(genInlineCode(ast).code).toEqual('<View onFn1="_e0" onFn2="_e1" onFn3="_e2" prop="{{_d0}}" state="{{_d1}}" member="{{_d2.bar.c}}" call1="{{_d3}}" call2="{{_d4}}" conditional="{{_d5 ? 1 : 2}}" conditionalComplex="{{_d6}}" compare="{{_d5 >= 1}}" math="{{_d5 - 1}}" bitwise="{{_d7}}" logical="{{_d5 || _d8}}" stringOp="{{\'a\' + _d9}}" comma="{{_d5, _d9}}" inst="{{_d10}}" delete="{{_d11}}" type="{{_d12}}" relation="{{\'a\' in _d8}}" group="{{_d5 + 1}}" spread="{{_d13}}" data-_e1-arg-0="{{event}}" />');
+      expect(genInlineCode(ast).code).toEqual('<View onFn1="_e0" onFn2="_e1" onFn3="_e2" prop="{{_d0}}" state="{{_d1}}" member="{{_d2.bar.c}}" call1="{{_d3}}" call2="{{_d4}}" conditional="{{_d5 ? 1 : 2}}" conditionalComplex="{{_d6}}" compare="{{_d5 >= 1}}" math="{{_d5 - 1}}" bitwise="{{_d7}}" logical="{{_d5 || _d8}}" stringOp="{{\'a\' + _d9}}" comma="{{_d5, _d9}}" inst="{{_d10}}" delete="{{_d11}}" type="{{_d12}}" relation="{{\'a\' in _d8}}" group="{{_d5 + 1}}" spread="{{_d13}}" data-e1-arg-0="{{event}}" />');
     });
 
     it('unsupported', () => {
@@ -147,7 +147,7 @@ describe('Transform JSXElement', () => {
       `);
       const { dynamicEvents } = _transform(ast);
 
-      expect(genInlineCode(ast).code).toEqual('<View onClick="_e0" onKeyPress="_e1" data-_e0-arg-context="this" data-_e0-arg-0="{{ a: 1 }}" data-_e1-arg-context="this" data-_e1-arg-0="{{\'hello\'}}" />');
+      expect(genInlineCode(ast).code).toEqual('<View onClick="_e0" onKeyPress="_e1" data-e0-arg-context="this" data-e0-arg-0="{{ a: 1 }}" data-e1-arg-context="this" data-e1-arg-0="{{\'hello\'}}" />');
       expect(genDynamicAttrs(dynamicEvents)).toEqual('{ _e0: onClick, _e1: this.handleClick }');
     });
 

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -230,12 +230,13 @@ function transformTemplate(
           expression: fnExpression,
           isDirective,
         });
+        const formatName = formatEventName(name);
         if (Array.isArray(args)) {
           args.forEach((arg, index) => {
             const transformedArg = transformCallExpressionArg(arg);
             attributes.push(
               t.jsxAttribute(
-                t.jsxIdentifier(`data-${name}-arg-` + index),
+                t.jsxIdentifier(`data-${formatName}-arg-` + index),
                 t.stringLiteral(
                   createBinding(
                     genExpression(transformedArg, {
@@ -302,6 +303,7 @@ function transformTemplate(
               expression: callExp.callee.object,
               isDirective,
             });
+            const formatName = formatEventName(name);
             if (Array.isArray(args)) {
               args.forEach((arg, index) => {
                 if (index === 0) {
@@ -316,7 +318,7 @@ function transformTemplate(
                     );
                   attributes.push(
                     t.jsxAttribute(
-                      t.jsxIdentifier(`data-${name}-arg-context`),
+                      t.jsxIdentifier(`data-${formatName}-arg-context`),
                       t.stringLiteral(strValue),
                     ),
                   );
@@ -324,7 +326,7 @@ function transformTemplate(
                   const transformedArg = transformCallExpressionArg(arg);
                   attributes.push(
                     t.jsxAttribute(
-                      t.jsxIdentifier(`data-${name}-arg-` + (index - 1)),
+                      t.jsxIdentifier(`data-${formatName}-arg-` + (index - 1)),
                       t.stringLiteral(
                         createBinding(
                           genExpression(transformedArg, {
@@ -692,6 +694,11 @@ function checkMemberHasThis(expression) {
     hasThisExpression = checkMemberHasThis(object);
   }
   return hasThisExpression;
+}
+
+// _e0 -> e0
+function formatEventName(name) {
+  return name.replace('_', '');
 }
 
 module.exports = {

--- a/packages/jsx2mp-runtime/src/bridge.js
+++ b/packages/jsx2mp-runtime/src/bridge.js
@@ -1,7 +1,7 @@
 /* global PROPS */
 import { cycles as appCycles } from './app';
 import Component from './component';
-import { ON_SHOW, ON_HIDE, ON_PAGE_SCROLL, ON_SHARE_APP_MESSAGE, ON_REACH_BOTTOM, ON_PULL_DOWN_REFRESH } from './cycles';
+import { ON_SHOW, ON_HIDE, ON_PAGE_SCROLL, ON_SHARE_APP_MESSAGE, ON_REACH_BOTTOM, ON_PULL_DOWN_REFRESH, ON_TAB_ITEM_TAP } from './cycles';
 import { setComponentInstance, getComponentProps } from './updater';
 import { getComponentLifecycle, getComponentBaseConfig } from '@@ADAPTER@@';
 import { createMiniAppHistory } from './history';
@@ -50,7 +50,7 @@ function getPageCycles(Klass) {
       if (this.instance.__mounted) this.instance._trigger(ON_HIDE);
     }
   };
-  [ON_PAGE_SCROLL, ON_SHARE_APP_MESSAGE, ON_REACH_BOTTOM, ON_PULL_DOWN_REFRESH].forEach((hook) => {
+  [ON_PAGE_SCROLL, ON_SHARE_APP_MESSAGE, ON_REACH_BOTTOM, ON_PULL_DOWN_REFRESH, ON_TAB_ITEM_TAP].forEach((hook) => {
     config[hook] = function(e) {
       return this.instance._trigger(hook, e);
     };
@@ -108,12 +108,13 @@ function createProxyMethods(events) {
             }
           });
         } else {
+          const formatName = formatEventName(eventName);
           Object.keys(this[PROPS]).forEach(key => {
-            if (`data-${eventName}-arg-context` === key) {
+            if (`data-${formatName}-arg-context` === key) {
               context = this[PROPS][key] === 'this' ? this.instance : this[PROPS][key];
             } else if (isDatasetKebabArg(key)) {
               // `data-arg-` length is 9.
-              const len = `data-${eventName}-arg-`.length;
+              const len = `data-${formatName}-arg-`.length;
               datasetArgs[key.slice(len)] = this[PROPS][key];
             }
           });
@@ -221,4 +222,8 @@ const DATASET_ARG_REG = /\w+?-[aA]rg?-?(\d+)/;
 
 function isDatasetArg(str) {
   return DATASET_ARG_REG.test(str);
+}
+
+function formatEventName(name) {
+  return name.replace('_', '');
 }

--- a/packages/jsx2mp-runtime/src/component.js
+++ b/packages/jsx2mp-runtime/src/component.js
@@ -15,6 +15,7 @@ import {
   ON_REACH_BOTTOM,
   ON_PULL_DOWN_REFRESH,
   ON_SHARE_APP_MESSAGE,
+  ON_TAB_ITEM_TAP,
   COMPONENT_DID_MOUNT,
   COMPONENT_DID_UPDATE,
   COMPONENT_WILL_MOUNT,
@@ -276,13 +277,19 @@ export default class Component {
       case ON_HIDE:
       case ON_PAGE_SCROLL:
       case ON_REACH_BOTTOM:
+      case ON_TAB_ITEM_TAP:
       case ON_PULL_DOWN_REFRESH:
         if (isFunction(this[cycle])) this[cycle](...args);
         if (this._cycles.hasOwnProperty(cycle)) {
           this._cycles[cycle].forEach(fn => fn(...args));
         }
-        if (pageCycles.hasOwnProperty(cycle)) {
-          pageCycles[cycle].forEach(fn => fn(...args));
+        if (this.props.location) {
+          const pathname = this.props.location.pathname;
+          if (pageCycles[pathname]) {
+            if (pageCycles[pathname][cycle]) {
+              pageCycles[pathname][cycle].forEach(fn => fn(...args));
+            }
+          }
         }
         break;
 

--- a/packages/jsx2mp-runtime/src/cycles.js
+++ b/packages/jsx2mp-runtime/src/cycles.js
@@ -11,3 +11,4 @@ export const ON_PAGE_SCROLL = 'onPageScroll';
 export const ON_SHARE_APP_MESSAGE = 'onShareAppMessage';
 export const ON_REACH_BOTTOM = 'onReachBottom';
 export const ON_PULL_DOWN_REFRESH = 'onPullDownRefresh';
+export const ON_TAB_ITEM_TAP = 'onTabItemTap';

--- a/packages/jsx2mp-runtime/src/hooks.js
+++ b/packages/jsx2mp-runtime/src/hooks.js
@@ -8,7 +8,7 @@ import { createMiniAppHistory } from './history';
 
 const history = createMiniAppHistory();
 
-function getCurrentInstance() {
+export function getCurrentInstance() {
   return Host.current;
 }
 

--- a/packages/jsx2mp-runtime/src/index.js
+++ b/packages/jsx2mp-runtime/src/index.js
@@ -1,6 +1,15 @@
 import { runApp, createPage, createComponent } from './bridge';
 import { useAppEffect, useAppLaunch } from './app';
-import { usePageEffect, usePageShow, usePageHide } from './page';
+import {
+  usePageEffect,
+  usePageShow,
+  usePageHide,
+  usePagePullDownRefresh,
+  usePageReachBottom,
+  usePageScroll,
+  useShareAppMessage,
+  useTabItemTap
+} from './page';
 import { withRouter } from './router';
 import Component from './component';
 import createStyle from './createStyle';
@@ -21,6 +30,11 @@ export {
   useAppLaunch,
   usePageShow,
   usePageHide,
+  usePagePullDownRefresh,
+  usePageReachBottom,
+  usePageScroll,
+  useShareAppMessage,
+  useTabItemTap,
 
   // Compatible old version of cycles.
   useAppEffect,

--- a/packages/jsx2mp-runtime/src/page.js
+++ b/packages/jsx2mp-runtime/src/page.js
@@ -1,18 +1,41 @@
 import isFunction from './isFunction';
-import { ON_SHOW, ON_HIDE } from './cycles';
+import {
+  ON_SHOW,
+  ON_HIDE,
+  ON_PAGE_SCROLL,
+  ON_SHARE_APP_MESSAGE,
+  ON_REACH_BOTTOM,
+  ON_PULL_DOWN_REFRESH,
+  ON_TAB_ITEM_TAP
+} from './cycles';
+import { useEffect } from './hooks';
+import { createMiniAppHistory } from './history';
 
-export const cycles = {
-  [ON_SHOW]: [],
-  [ON_HIDE]: [],
-};
+const history = createMiniAppHistory();
+
+export const cycles = {};
 
 export function usePageEffect(cycle, callback) {
   switch (cycle) {
     case ON_SHOW:
     case ON_HIDE:
-      if (isFunction(callback)) {
-        cycles[cycle].push(callback);
-      }
+    case ON_PAGE_SCROLL:
+    case ON_SHARE_APP_MESSAGE:
+    case ON_REACH_BOTTOM:
+    case ON_PULL_DOWN_REFRESH:
+    case ON_TAB_ITEM_TAP:
+      const pathname = history && history.location.pathname;
+      useEffect(() => {
+        if (isFunction(callback)) {
+          if (!cycles[pathname]) {
+            cycles[pathname] = {};
+          }
+          if (!cycles[pathname][cycle]) {
+            cycles[pathname][cycle] = [];
+          }
+          cycles[pathname][cycle].push(callback);
+        }
+      }, []);
       break;
     default:
       throw new Error('Unsupported page cycle ' + cycle);
@@ -25,4 +48,24 @@ export function usePageShow(callback) {
 
 export function usePageHide(callback) {
   return usePageEffect(ON_HIDE, callback);
+}
+
+export function usePageScroll(callback) {
+  return usePageEffect(ON_PAGE_SCROLL, callback);
+}
+
+export function useShareAppMessage(callback) {
+  return usePageEffect(ON_SHARE_APP_MESSAGE, callback);
+}
+
+export function usePageReachBottom(callback) {
+  return usePageEffect(ON_REACH_BOTTOM, callback);
+}
+
+export function usePagePullDownRefresh(callback) {
+  return usePageEffect(ON_PULL_DOWN_REFRESH, callback);
+}
+
+export function useTabItemTap(callback) {
+  return usePageEffect(ON_TAB_ITEM_TAP, callback);
 }


### PR DESCRIPTION
1. 修复页面生命周期回调被重复注册的问题
2. 增加支持: usePagePullDownRefresh, usePageReachBottom, usePageScroll,
  useShareAppMessage, useTabItemTap
3. 修复微信小程序绑定参数中存在 _ 导致 bad attribute 的问题