### PR TITLE
fix: require function traverse

### DIFF
--- a/packages/jsx-compiler/src/modules/__tests__/function.js
+++ b/packages/jsx-compiler/src/modules/__tests__/function.js
@@ -22,4 +22,26 @@ describe('Transform function', () => {
   }
 }`);
   });
+  it('should remove weex module in another function', () => {
+    const code = `
+        export default function Index() {
+          useEffect(() => {
+            if (isWeex) {
+              const dom = require('@weex-module/dom');
+              console.log(dom);
+            }
+          });
+        }
+      `;
+    const ast = parseCode(code);
+    _transformFunction(ast);
+    expect(genExpression(ast)).toEqual(`export default function Index() {
+  useEffect(() => {
+    if (isWeex) {
+      const dom = null;
+      console.log(dom);
+    }
+  });
+}`);
+  });
 });

--- a/packages/jsx-compiler/src/modules/function.js
+++ b/packages/jsx-compiler/src/modules/function.js
@@ -15,7 +15,6 @@ function transformFunction(ast) {
           path.replaceWith(t.nullLiteral());
         }
       }
-      path.stop();
     }
   });
 }


### PR DESCRIPTION
Fix require weex-module not be removed in another function body.