### PR TITLE
fix: setNativeProps has not eventRegistry in web

### DIFF
--- a/packages/rax-set-native-props/package.json
+++ b/packages/rax-set-native-props/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-set-native-props",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Rax setNativeProps",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-set-native-props/src/index.js
+++ b/packages/rax-set-native-props/src/index.js
@@ -46,13 +46,9 @@ function setStyles(node, styles) {
 
 function addEventListener(node, eventName, eventHandler, props) {
   if (isWeb) {
-    if (this.eventRegistry[eventName]) {
-      return this.eventRegistry[eventName](ADD_EVENT, node, eventName, eventHandler, props);
-    } else {
-      return node.addEventListener(eventName, eventHandler);
-    }
+    return node.addEventListener(eventName, eventHandler);
   } else if (isWeex) {
-    shared.Host.driver.addEventListener(node, eventName, eventHandler, props);
+    return shared.Host.driver.addEventListener(node, eventName, eventHandler, props);
   }
 }
 


### PR DESCRIPTION
`this.eventRegistry` 是以前 driver 里的代码，现在在 web 下报错了