### PR TITLE
Tests for render elements in SSR

### DIFF
--- a/packages/rax-server-renderer/src/__tests__/elements.js
+++ b/packages/rax-server-renderer/src/__tests__/elements.js
@@ -430,4 +430,80 @@ describe('elements and children', () => {
       }).toWarnDev('renderToString: received an element that is not valid. (keys: render)', {withoutStack: true});
     });
   });
+
+  describe('component hierarchies', function() {
+    it('single child hierarchies of components', () => {
+      const Component = props => <div>{props.children}</div>;
+      const str = renderToString(
+        <Component>
+          <Component>
+            <Component>
+              <Component />
+            </Component>
+          </Component>
+        </Component>
+      );
+      expect(str).toBe('<div><div><div><div><!-- _ --></div></div></div></div>');
+    });
+
+    it('multi-child hierarchies of components', () => {
+      const Component = props => <div>{props.children}</div>;
+      const str = renderToString(
+        <Component>
+          <Component>
+            <Component />
+            <Component />
+          </Component>
+          <Component>
+            <Component />
+            <Component />
+          </Component>
+        </Component>
+      );
+      expect(str).toBe('<div><div><div><!-- _ --></div><div><!-- _ --></div></div><div><div><!-- _ --></div><div><!-- _ --></div></div></div>');
+    });
+
+    it('a div with a child', () => {
+      const str = renderToString(
+        <div id="parent">
+          <div id="child" />
+        </div>
+      );
+      expect(str).toBe('<div id="parent"><div id="child"></div></div>');
+    });
+
+    it('a div with multiple children', () => {
+      const str = renderToString(
+        <div id="parent">
+          <div id="child1" />
+          <div id="child2" />
+        </div>
+      );
+      expect(str).toBe('<div id="parent"><div id="child1"></div><div id="child2"></div></div>');
+    });
+
+    it('a div with multiple children separated by whitespace', () => {
+      const str = renderToString(
+        <div id="parent">
+          <div id="child1" /> <div id="child2" />
+        </div>
+      );
+      expect(str).toBe('<div id="parent"><div id="child1"></div> <div id="child2"></div></div>');
+    });
+
+    it('a div with a single child surrounded by whitespace', () => {
+      const str = renderToString(
+        <div id="parent">  <div id="child" />   </div>
+      );
+      expect(str).toBe('<div id="parent">  <div id="child"></div>   </div>');
+    });
+
+    it('a composite with multiple children', () => {
+      const Component = props => props.children;
+      const str = renderToString(
+        <Component>{['a', 'b', [undefined], [[false, 'c']]]}</Component>,
+      );
+      expect(str).toBe('ab<!-- _ --><!-- _ -->c');
+    });
+  });
 });

--- a/packages/rax-server-renderer/src/__tests__/elements.js
+++ b/packages/rax-server-renderer/src/__tests__/elements.js
@@ -610,7 +610,7 @@ describe('elements and children', () => {
       let EmptyComponent = {};
       expect(() => {
         renderToString(<EmptyComponent />);
-      }).toThrowError('renderToString: received an element that is not valid. (keys: type,key,ref,props,_owner)', {withoutStack: true});
+      }).toWarnDev('renderToString: received an element that is not valid. (keys: type,key,ref,props,_owner)', {withoutStack: true});
     });
 
     it('throw error when rendering null', () => {

--- a/packages/rax-server-renderer/src/__tests__/elements.js
+++ b/packages/rax-server-renderer/src/__tests__/elements.js
@@ -1,0 +1,369 @@
+/* @jsx createElement */
+
+import {createElement, createContext, Component, Fragment} from 'rax';
+import {renderToString} from '../index';
+
+describe('elements and children', () => {
+  describe('text children', function() {
+    it('a div with text', () => {
+      const str = renderToString(
+        <div>Text</div>
+      );
+      expect(str).toBe('<div>Text</div>');
+    });
+
+    it('a div with text with flanking whitespace', () => {
+      const str = renderToString(
+        <div>  Text </div>
+      );
+      expect(str).toBe('<div>  Text </div>');
+    });
+
+    it('a div with an empty text child', () => {
+      const str = renderToString(
+        <div>{''}</div>
+      );
+      expect(str).toBe('<div></div>');
+    });
+
+    it('a div with multiple empty text children', () => {
+      const str = renderToString(
+        <div>
+          {''}
+          {''}
+          {''}
+        </div>
+      );
+      expect(str).toBe('<div></div>');
+    });
+
+    it('a div with multiple whitespace children', () => {
+      const str = renderToString(
+        <div>
+          {' '}
+          {' '}
+          {' '}
+        </div>
+      );
+      expect(str).toBe('<div>   </div>');
+    });
+
+    it('a div with text sibling to a node', () => {
+      const str = renderToString(
+        <div>
+          Text<span>More Text</span>
+        </div>
+      );
+      expect(str).toBe('<div>Text<span>More Text</span></div>');
+    });
+
+    it('a non-standard element with text', () => {
+      const str = renderToString(
+        <nonstandard>
+          Text
+        </nonstandard>
+      );
+      expect(str).toBe('<nonstandard>Text</nonstandard>');
+    });
+
+    it('a custom element with text', () => {
+      const str = renderToString(
+        <custom-element>
+          Text
+        </custom-element>
+      );
+      expect(str).toBe('<custom-element>Text</custom-element>');
+    });
+
+    it('a leading blank child with a text sibling', () => {
+      const str = renderToString(<div>{''}foo</div>);
+      expect(str).toBe('<div>foo</div>');
+    });
+
+    it('a leading blank child with a text sibling', () => {
+      const str = renderToString(<div>{''}foo</div>);
+      expect(str).toBe('<div>foo</div>');
+    });
+
+    it('a trailing blank child with a text sibling', () => {
+      const str = renderToString(<div>foo{''}</div>);
+      expect(str).toBe('<div>foo</div>');
+    });
+
+    it('an element with two text children', () => {
+      const str = renderToString(
+        <div>
+          {'foo'}
+          {'bar'}
+        </div>
+      );
+      expect(str).toBe('<div>foobar</div>');
+    });
+
+    it('a component returning text node between two text nodes', () => {
+      const B = () => 'b';
+      const str = renderToString(
+        <div>
+          {'a'}
+          <B />
+          {'c'}
+        </div>
+      );
+      expect(str).toBe('<div>abc</div>');
+    });
+
+    it('a tree with sibling host and text nodes', () => {
+      class X extends Component {
+        render() {
+          return [null, [<Y key="1" />], false];
+        }
+      }
+
+      function Y() {
+        return [<Z key="1" />, ['c']];
+      }
+
+      function Z() {
+        return null;
+      }
+
+      const str = renderToString(
+        <div>
+          {[['a'], 'b']}
+          <div>
+            <X key="1" />
+            d
+          </div>
+          e
+        </div>,
+      );
+      expect(str).toBe('<div>ab<div><!-- _ --><!-- _ -->c<!-- _ -->d</div>e</div>');
+    });
+  });
+
+  describe('number children', function() {
+    it('a number as single child', () => {
+      const str = renderToString(
+        <div>{3}</div>
+      );
+      expect(str).toBe('<div>3</div>');
+    });
+
+    it('zero as single child', () => {
+      const str = renderToString(
+        <div>{0}</div>
+      );
+      expect(str).toBe('<div>0</div>');
+    });
+
+    it('an element with number and text children', () => {
+      const str = renderToString(
+        <div>
+          {'foo'}
+          {40}
+        </div>
+      );
+      expect(str).toBe('<div>foo40</div>');
+    });
+  });
+
+  describe('null, false, and undefined children', function() {
+    it('render null single child as blank', () => {
+      const str = renderToString(
+        <div>{null}</div>
+      );
+      expect(str).toBe('<div><!-- _ --></div>');
+    });
+
+    it('render false single child as blank', () => {
+      const str = renderToString(
+        <div>{false}</div>
+      );
+      expect(str).toBe('<div><!-- _ --></div>');
+    });
+
+    it('render undefined single child as blank', () => {
+      const str = renderToString(
+        <div>{undefined}</div>
+      );
+      expect(str).toBe('<div><!-- _ --></div>');
+    });
+
+    it('render a null component children as empty', () => {
+      const NullComponent = () => null;
+      const str = renderToString(
+        <div><NullComponent /></div>
+      );
+      expect(str).toBe('<div><!-- _ --></div>');
+    });
+
+    it('render null children as blank', () => {
+      const str = renderToString(
+        <div>{null}foo</div>
+      );
+      expect(str).toBe('<div><!-- _ -->foo</div>');
+    });
+
+    it('render false children as blank', () => {
+      const str = renderToString(
+        <div>{false}foo</div>
+      );
+      expect(str).toBe('<div><!-- _ -->foo</div>');
+    });
+
+    it('render null and false children together as blank', () => {
+      const str = renderToString(
+        <div>
+          {false}
+          {null}foo{null}
+          {false}
+        </div>
+      );
+      expect(str).toBe('<div><!-- _ --><!-- _ -->foo<!-- _ --><!-- _ --></div>');
+    });
+
+    it('render only null and false children as blank', () => {
+      const str = renderToString(
+        <div>
+          {false}
+          {null}
+          {null}
+          {false}
+        </div>
+      );
+      expect(str).toBe('<div><!-- _ --><!-- _ --><!-- _ --><!-- _ --></div>');
+    });
+  });
+
+  describe('elements with implicit namespaces', function() {
+    it('an svg element', () => {
+      const str = renderToString(
+        <svg />
+      );
+      expect(str).toBe('<svg></svg>');
+    });
+
+    it('svg child element with an attribute', () => {
+      const str = renderToString(
+        <svg viewBox="0 0 0 0" />
+      );
+      expect(str).toBe('<svg viewBox="0 0 0 0"></svg>');
+    });
+
+    it('svg child element with a namespace attribute', () => {
+      const str = renderToString(
+        <svg>
+          <image xlinkHref="http://i.imgur.com/w7GCRPb.png" />
+        </svg>
+      );
+      expect(str).toBe('<svg><image xlinkHref="http://i.imgur.com/w7GCRPb.png"></image></svg>');
+    });
+
+    it('svg child element with a badly cased alias', () => {
+      const str = renderToString(
+        <svg>
+          <image xlinkhref="http://i.imgur.com/w7GCRPb.png" />
+        </svg>
+      );
+      expect(str).toBe('<svg><image xlinkhref="http://i.imgur.com/w7GCRPb.png"></image></svg>');
+    });
+
+    it('svg element with a tabIndex attribute', () => {
+      const str = renderToString(<svg tabIndex="1" />);
+      expect(str).toBe('<svg tabIndex="1"></svg>');
+    });
+
+    it('svg element with a badly cased tabIndex attribute', () => {
+      const str = renderToString(<svg tabindex="1" />);
+      expect(str).toBe('<svg tabindex="1"></svg>');
+    });
+
+    it('svg element with a mixed case name', () => {
+      const str = renderToString(
+        <svg>
+          <filter>
+            <feMorphology />
+          </filter>
+        </svg>
+      );
+      expect(str).toBe('<svg><filter><feMorphology></feMorphology></filter></svg>');
+    });
+
+    it('a math element', () => {
+      const str = renderToString(<math />);
+      expect(str).toBe('<math></math>');
+    });
+  });
+
+  it('an img', () => {
+    const str = renderToString(<img />);
+    expect(str).toBe('<img>');
+  });
+
+  it('a button', () => {
+    const str = renderToString(<button />);
+    expect(str).toBe('<button></button>');
+  });
+
+  describe('elements with implicit namespaces', function() {
+    it('a div with dangerouslySetInnerHTML number', () => {
+      const str = renderToString(
+        <div>
+          <span dangerouslySetInnerHTML={{__html: 0}} />
+        </div>
+      );
+      expect(str).toBe('<div><span>0</span></div>');
+    });
+
+    it('a div with dangerouslySetInnerHTML boolean', () => {
+      const str = renderToString(
+        <div>
+          <span dangerouslySetInnerHTML={{__html: false}} />
+        </div>
+      );
+      expect(str).toBe('<div><span>false</span></div>');
+    });
+
+    it('a div with dangerouslySetInnerHTML text string', () => {
+      const str = renderToString(
+        <div>
+          <span dangerouslySetInnerHTML={{__html: 'hello'}} />
+        </div>
+      );
+      expect(str).toBe('<div><span>hello</span></div>');
+    });
+
+    it('a div with dangerouslySetInnerHTML element string', () => {
+      const str = renderToString(
+        <div dangerouslySetInnerHTML={{__html: "<span id='child'/>"}} />
+      );
+      expect(str).toBe("<div><span id='child'/></div>");
+    });
+
+    it('a div with dangerouslySetInnerHTML object', () => {
+      const obj = {
+        toString() {
+          return "<span id='child'/>";
+        },
+      };
+      const str = renderToString(
+        <div dangerouslySetInnerHTML={{__html: obj}} />
+      );
+      expect(str).toBe("<div><span id='child'/></div>");
+    });
+
+    it('a div with dangerouslySetInnerHTML set to null', () => {
+      const str = renderToString(
+        <div dangerouslySetInnerHTML={{__html: null}} />
+      );
+      expect(str).toBe('<div></div>');
+    });
+
+    it('a div with dangerouslySetInnerHTML set to undefined', () => {
+      const str = renderToString(
+        <div dangerouslySetInnerHTML={{__html: undefined}} />
+      );
+      expect(str).toBe('<div></div>');
+    });
+  });
+});

--- a/packages/rax-server-renderer/src/__tests__/elements.js
+++ b/packages/rax-server-renderer/src/__tests__/elements.js
@@ -525,4 +525,30 @@ describe('elements and children', () => {
       expect(str).toBe('<div>&lt;span&gt;Text1&amp;quot;&lt;/span&gt;&lt;span&gt;Text2&amp;quot;&lt;/span&gt;</div>');
     });
   });
+
+  describe('carriage return and null character', function() {
+    it('an element with one text child with special characters', () => {
+      const str = renderToString(
+        <div>{'foo\rbar\r\nbaz\nqux\u0000'}</div>
+      );
+      expect(str).toBe('<div>foo\rbar\r\nbaz\nqux\u0000</div>');
+    });
+
+    it('an element with two text children with special characters', () => {
+      const str = renderToString(
+        <div>
+          {'foo\rbar'}
+          {'\r\nbaz\nqux\u0000'}
+        </div>
+      );
+      expect(str).toBe('<div>foo\rbar\r\nbaz\nqux\u0000</div>');
+    });
+
+    it('an element with an attribute value with special characters', () => {
+      const str = renderToString(
+        <a title={'foo\rbar\r\nbaz\nqux\u0000'} />
+      );
+      expect(str).toBe('<a title="foo\rbar\r\nbaz\nqux\u0000"></a>');
+    });
+  });
 });

--- a/packages/rax-server-renderer/src/__tests__/elements.js
+++ b/packages/rax-server-renderer/src/__tests__/elements.js
@@ -427,7 +427,7 @@ describe('elements and children', () => {
       };
       expect(() => {
         renderToString(<FactoryComponent />);
-      }).toWarnDev('renderToString: received an element that is not valid. (keys: render)', {withoutStack: true});
+      }).toWarnDev('Invalid element type, expected types: Element instance, string, boolean, array, null, undefined. (found: object with keys {render})', {withoutStack: true});
     });
   });
 
@@ -579,7 +579,7 @@ describe('elements and children', () => {
         renderToString(
           <ObjectComponent />
         );
-      }).toWarnDev('renderToString: received an element that is not valid. (keys: x)', {withoutStack: true});
+      }).toWarnDev('Invalid element type, expected types: Element instance, string, boolean, array, null, undefined. (found: object with keys {x})', {withoutStack: true});
     });
 
     it('throw error when rendering a class returning an object', () => {
@@ -593,7 +593,7 @@ describe('elements and children', () => {
         renderToString(
           <ObjectComponent />
         );
-      }).toWarnDev('renderToString: received an element that is not valid. (keys: x)', {withoutStack: true});
+      }).toWarnDev('Invalid element type, expected types: Element instance, string, boolean, array, null, undefined. (found: object with keys {x})', {withoutStack: true});
     });
 
     it('throw error when rendering top-level object', () => {
@@ -601,7 +601,7 @@ describe('elements and children', () => {
         renderToString({
           x: 123
         });
-      }).toWarnDev('renderToString: received an element that is not valid. (keys: x)', {withoutStack: true});
+      }).toWarnDev('Invalid element type, expected types: Element instance, string, boolean, array, null, undefined. (found: object with keys {x})', {withoutStack: true});
     });
   });
 
@@ -610,7 +610,7 @@ describe('elements and children', () => {
       let EmptyComponent = {};
       expect(() => {
         renderToString(<EmptyComponent />);
-      }).toWarnDev('renderToString: received an element that is not valid. (keys: type,key,ref,props,_owner)', {withoutStack: true});
+      }).toWarnDev('Invalid element type, expected types: Element instance, string, boolean, array, null, undefined. (found: object with keys {type,key,ref,props,_owner})', {withoutStack: true});
     });
 
     it('throw error when rendering null', () => {

--- a/packages/rax-server-renderer/src/__tests__/elements.js
+++ b/packages/rax-server-renderer/src/__tests__/elements.js
@@ -375,4 +375,27 @@ describe('elements and children', () => {
       expect(str).toBe('<div></div>');
     });
   });
+
+  describe('newline-eating elements', function() {
+    it('a newline-eating tag with content not starting with \\n', () => {
+      const str = renderToString(
+        <pre>Hello</pre>
+      );
+      expect(str).toBe('<pre>Hello</pre>');
+    });
+
+    it('a newline-eating tag with content starting with \\n', () => {
+      const str = renderToString(
+        <pre>{'\nHello'}</pre>
+      );
+      expect(str).toBe('<pre>\nHello</pre>');
+    });
+
+    it('a normal tag with content starting with \\n', () => {
+      const str = renderToString(
+        <div>{'\nHello'}</div>
+      );
+      expect(str).toBe('<div>\nHello</div>');
+    });
+  });
 });

--- a/packages/rax-server-renderer/src/__tests__/elements.js
+++ b/packages/rax-server-renderer/src/__tests__/elements.js
@@ -417,7 +417,7 @@ describe('elements and children', () => {
       expect(str).toBe('<div>foo</div>');
     });
 
-    it('should throw error when render factory components', () => {
+    it('throw when rendering factory components', () => {
       const FactoryComponent = () => {
         return {
           render: function() {
@@ -504,6 +504,25 @@ describe('elements and children', () => {
         <Component>{['a', 'b', [undefined], [[false, 'c']]]}</Component>,
       );
       expect(str).toBe('ab<!-- _ --><!-- _ -->c');
+    });
+  });
+
+  describe('escaping >, <, and &', function() {
+    it('>,<, and & as single child', () => {
+      const str = renderToString(
+        <div>{'<span>Text&quot;</span>'}</div>
+      );
+      expect(str).toBe('<div>&lt;span&gt;Text&amp;quot;&lt;/span&gt;</div>');
+    });
+
+    it('>,<, and & as multiple children', () => {
+      const str = renderToString(
+        <div>
+          {'<span>Text1&quot;</span>'}
+          {'<span>Text2&quot;</span>'}
+        </div>
+      );
+      expect(str).toBe('<div>&lt;span&gt;Text1&amp;quot;&lt;/span&gt;&lt;span&gt;Text2&amp;quot;&lt;/span&gt;</div>');
     });
   });
 });

--- a/packages/rax-server-renderer/src/__tests__/elements.js
+++ b/packages/rax-server-renderer/src/__tests__/elements.js
@@ -553,7 +553,7 @@ describe('elements and children', () => {
   });
 
   describe('components that throw errors', function() {
-    it('a function returning undefined', () => {
+    it('render a function returning undefined', () => {
       const UndefinedComponent = () => undefined;
       const str = renderToString(
         <UndefinedComponent />
@@ -561,7 +561,7 @@ describe('elements and children', () => {
       expect(str).toBe('<!-- _ -->');
     });
 
-    it('a function returning undefined', () => {
+    it('render a function returning undefined', () => {
       class UndefinedComponent extends Component {
         render() {
           return undefined;
@@ -573,7 +573,7 @@ describe('elements and children', () => {
       expect(str).toBe('<!-- _ -->');
     });
 
-    it('a function returning an object', () => {
+    it('throw error when rendering a function returning an object', () => {
       const ObjectComponent = () => ({x: 123});
       expect(() => {
         renderToString(
@@ -582,7 +582,7 @@ describe('elements and children', () => {
       }).toWarnDev('renderToString: received an element that is not valid. (keys: x)', {withoutStack: true});
     });
 
-    it('a class returning an object', () => {
+    it('throw error when rendering a class returning an object', () => {
       class ObjectComponent extends Component {
         render() {
           return {x: 123};
@@ -596,12 +596,35 @@ describe('elements and children', () => {
       }).toWarnDev('renderToString: received an element that is not valid. (keys: x)', {withoutStack: true});
     });
 
-    it('top-level object', () => {
+    it('throw error when rendering top-level object', () => {
       expect(() => {
         renderToString({
           x: 123
         });
       }).toWarnDev('renderToString: received an element that is not valid. (keys: x)', {withoutStack: true});
+    });
+  });
+
+  describe('badly-typed elements', function() {
+    it('render object', () => {
+      let EmptyComponent = {};
+      expect(() => {
+        renderToString(<EmptyComponent />);
+      }).toThrowError('renderToString: received an element that is not valid. (keys: type,key,ref,props,_owner)', {withoutStack: true});
+    });
+
+    it('throw error when rendering null', () => {
+      let NullComponent = null;
+      expect(() => {
+        renderToString(<NullComponent />);
+      }).toThrowError('Invalid element type, expected a string or a class/function component but got "null"', {withoutStack: true});
+    });
+
+    it('throw error when rendering undefined', () => {
+      let UndefinedComponent = undefined;
+      expect(() => {
+        renderToString(<UndefinedComponent />);
+      }).toThrowError('Invalid element type, expected a string or a class/function component but got "undefined"', {withoutStack: true});
     });
   });
 });

--- a/packages/rax-server-renderer/src/__tests__/elements.js
+++ b/packages/rax-server-renderer/src/__tests__/elements.js
@@ -305,6 +305,15 @@ describe('elements and children', () => {
     expect(str).toBe('<button></button>');
   });
 
+  it('a noscript with children', () => {
+    const str = renderToString(
+      <noscript>
+        <div>Enable JavaScript to run this app.</div>
+      </noscript>
+    );
+    expect(str).toBe('<noscript><div>Enable JavaScript to run this app.</div></noscript>');
+  });
+
   describe('elements with implicit namespaces', function() {
     it('a div with dangerouslySetInnerHTML number', () => {
       const str = renderToString(

--- a/packages/rax-server-renderer/src/__tests__/elements.js
+++ b/packages/rax-server-renderer/src/__tests__/elements.js
@@ -2,6 +2,7 @@
 
 import {createElement, createContext, Component, Fragment} from 'rax';
 import {renderToString} from '../index';
+import { exec } from 'child_process';
 
 describe('elements and children', () => {
   describe('text children', function() {
@@ -396,6 +397,37 @@ describe('elements and children', () => {
         <div>{'\nHello'}</div>
       );
       expect(str).toBe('<div>\nHello</div>');
+    });
+  });
+
+  describe('different component implementations', function() {
+    it('stateless components', () => {
+      const FunctionComponent = () => <div>foo</div>;
+      const str = renderToString(<FunctionComponent />);
+      expect(str).toBe('<div>foo</div>');
+    });
+
+    it('ES6 class components', () => {
+      class ClassComponent extends Component {
+        render() {
+          return <div>foo</div>;
+        }
+      }
+      const str = renderToString(<ClassComponent />);
+      expect(str).toBe('<div>foo</div>');
+    });
+
+    it('should throw error when render factory components', () => {
+      const FactoryComponent = () => {
+        return {
+          render: function() {
+            return <div>foo</div>;
+          },
+        };
+      };
+      expect(() => {
+        renderToString(<FactoryComponent />);
+      }).toWarnDev('renderToString: received an element that is not valid. (keys: render)', {withoutStack: true});
     });
   });
 });

--- a/packages/rax-server-renderer/src/__tests__/elements.js
+++ b/packages/rax-server-renderer/src/__tests__/elements.js
@@ -551,4 +551,57 @@ describe('elements and children', () => {
       expect(str).toBe('<a title="foo\rbar\r\nbaz\nqux\u0000"></a>');
     });
   });
+
+  describe('components that throw errors', function() {
+    it('a function returning undefined', () => {
+      const UndefinedComponent = () => undefined;
+      const str = renderToString(
+        <UndefinedComponent />
+      );
+      expect(str).toBe('<!-- _ -->');
+    });
+
+    it('a function returning undefined', () => {
+      class UndefinedComponent extends Component {
+        render() {
+          return undefined;
+        }
+      }
+      const str = renderToString(
+        <UndefinedComponent />
+      );
+      expect(str).toBe('<!-- _ -->');
+    });
+
+    it('a function returning an object', () => {
+      const ObjectComponent = () => ({x: 123});
+      expect(() => {
+        renderToString(
+          <ObjectComponent />
+        );
+      }).toWarnDev('renderToString: received an element that is not valid. (keys: x)', {withoutStack: true});
+    });
+
+    it('a class returning an object', () => {
+      class ObjectComponent extends Component {
+        render() {
+          return {x: 123};
+        }
+      }
+
+      expect(() => {
+        renderToString(
+          <ObjectComponent />
+        );
+      }).toWarnDev('renderToString: received an element that is not valid. (keys: x)', {withoutStack: true});
+    });
+
+    it('top-level object', () => {
+      expect(() => {
+        renderToString({
+          x: 123
+        });
+      }).toWarnDev('renderToString: received an element that is not valid. (keys: x)', {withoutStack: true});
+    });
+  });
 });

--- a/packages/rax-server-renderer/src/__tests__/elements.js
+++ b/packages/rax-server-renderer/src/__tests__/elements.js
@@ -1,8 +1,7 @@
 /* @jsx createElement */
 
-import {createElement, createContext, Component, Fragment} from 'rax';
+import {createElement, Component} from 'rax';
 import {renderToString} from '../index';
-import { exec } from 'child_process';
 
 describe('elements and children', () => {
   describe('text children', function() {

--- a/packages/rax-server-renderer/src/index.js
+++ b/packages/rax-server-renderer/src/index.js
@@ -409,10 +409,16 @@ function renderElementToString(element, context, options) {
       }
 
       return html;
+    } else {
+      throwInValidElementError(element);
     }
   } else {
-    console.error(`renderToString: received an element that is not valid. (keys: ${Object.keys(element)})`);
+    throwInValidElementError(element);
   }
+}
+
+function throwInValidElementError(element) {
+  console.error(`renderToString: received an element that is not valid. (keys: ${Object.keys(element)})`);
 }
 
 export function renderToString(element, options = {}) {

--- a/packages/rax-server-renderer/src/index.js
+++ b/packages/rax-server-renderer/src/index.js
@@ -390,7 +390,7 @@ function renderElementToString(element, context, options) {
         html = html + '>';
       } else {
         html = html + '>';
-        // children may be null or undefined
+        // When child is null or undefined, it should be render as <!-- _ -->
         if (props.hasOwnProperty('children')) {
           const children = props.children;
           if (Array.isArray(children)) {
@@ -401,7 +401,7 @@ function renderElementToString(element, context, options) {
           } else {
             html = html + renderElementToString(children, context, options);
           }
-        } else if (innerHTML != null) { // innerHTML may be 0
+        } else if (innerHTML != null) { // When dangerouslySetInnerHTML is 0, it should be render as 0
           html = html + innerHTML;
         }
 

--- a/packages/rax-server-renderer/src/index.js
+++ b/packages/rax-server-renderer/src/index.js
@@ -418,7 +418,14 @@ function renderElementToString(element, context, options) {
 }
 
 function throwInValidElementError(element) {
-  console.error(`renderToString: received an element that is not valid. (keys: ${Object.keys(element)})`);
+  let typeInfo = element === undefined ? '' :
+    '(found: ' + (isPlainObject(element) ? `object with keys {${Object.keys(element)}}` : element) + ')';
+
+  console.error(`Invalid element type, expected types: Element instance, string, boolean, array, null, undefined. ${typeInfo}`);
+}
+
+function isPlainObject(obj) {
+  return EMPTY_OBJECT.toString.call(obj) === '[object Object]';
 }
 
 export function renderToString(element, options = {}) {

--- a/packages/rax-server-renderer/src/index.js
+++ b/packages/rax-server-renderer/src/index.js
@@ -428,7 +428,7 @@ function isPlainObject(obj) {
   return EMPTY_OBJECT.toString.call(obj) === '[object Object]';
 }
 
-export function renderToString(element, options = {}) {
+export function renderToString(element, options) {
   return renderElementToString(element, EMPTY_OBJECT, Object.assign({}, DEFAULT_STYLE_OPTIONS, options));
 }
 

--- a/packages/rax-server-renderer/src/index.js
+++ b/packages/rax-server-renderer/src/index.js
@@ -390,8 +390,9 @@ function renderElementToString(element, context, options) {
         html = html + '>';
       } else {
         html = html + '>';
-        var children = props.children;
-        if (children != null) {
+        // children may be null or undefined
+        if (props.hasOwnProperty('children')) {
+          const children = props.children;
           if (Array.isArray(children)) {
             for (var i = 0, l = children.length; i < l; i++) {
               var child = children[i];
@@ -400,7 +401,7 @@ function renderElementToString(element, context, options) {
           } else {
             html = html + renderElementToString(children, context, options);
           }
-        } else if (innerHTML) {
+        } else if (innerHTML != null) { // innerHTML may be 0
           html = html + innerHTML;
         }
 


### PR DESCRIPTION
1. fix render empty object

```jsx
let EmptyComponent = {};
renderToString(<EmptyComponent />);
```

before: return `undefined`
now: throw error `renderToString: received an element that is not valid.` 

2. fix: render a div with dangerouslySetInnerHTML number

```jsx
      const str = renderToString(
        <div>
          <span dangerouslySetInnerHTML={{__html: 0}} />
        </div>
      );
```
before: `<div><span></span></div>`
now: `<div><span>0</span></div>`

3. fix: render null single child

```jsx
      const str = renderToString(
        <div>{null}</div>
      );
```

before: `<div></div>`
now: `<div><!-- _ --></div>`

the result before is inconsistent with multiple children

```jsx
      const str = renderToString(
        <div>
          {null}
          {null}
        </div>
      );
```
`<div><!-- _ --><!-- _ --></div>`
