### PR TITLE
fix: loop component instance id

### DIFF
--- a/packages/jsx-compiler/src/modules/__tests__/element.js
+++ b/packages/jsx-compiler/src/modules/__tests__/element.js
@@ -25,7 +25,9 @@ describe('Transform JSXElement', () => {
     it('identifier', () => {
       const sourceCode = '<View foo={bar}>{ bar }</View>';
       const ast = parseExpression(sourceCode);
-      const { dynamicValues } = _transform(ast, null, null, sourceCode);
+      const { dynamicValues } = _transform({
+        templateAST: ast
+      }, null, null, sourceCode);
       const code = genInlineCode(ast).code;
       expect(code).toEqual('<View foo="{{_d0}}">{{ _d0 }}</View>');
       expect(genDynamicAttrs(dynamicValues)).toEqual('{ _d0: bar }');
@@ -44,7 +46,9 @@ describe('Transform JSXElement', () => {
         >{false}{'string'}{8}{}{undefined}{null}{/a-z/}</View>
       `;
       const ast = parseExpression(sourceCode);
-      const { dynamicValues } = _transform(ast, null, null, sourceCode);
+      const { dynamicValues } = _transform({
+        templateAST: ast
+      }, null, null, sourceCode);
 
       expect(genInlineCode(ast).code).toEqual('<View bool="{{true}}" str=\'string\' num="{{8}}" nil="{{null}}" regexp="{{_d0}}" tpl="hello world {{_d1}}">string8{{ _d0 }}</View>');
 
@@ -79,7 +83,9 @@ describe('Transform JSXElement', () => {
         />
       `;
       const ast = parseExpression(sourceCode);
-      const { dynamicValues, dynamicEvents } = _transform(ast, null, null, sourceCode);
+      const { dynamicValues, dynamicEvents } = _transform({
+        templateAST: ast
+      }, null, null, sourceCode);
 
       expect(genDynamicAttrs(dynamicValues)).toEqual('{ _d0: this.props.foo, _d1: this.state.bar, _d2: foo, _d3: fn(), _d4: foo.method(), _d5: a, _d6: a() ? 1 : 2, _d7: ~a, _d8: b, _d9: c, _d10: new Foo(), _d11: delete foo.bar, _d12: typeof aaa, _d13: { ...{ a: 1 } } }');
 
@@ -90,14 +96,18 @@ describe('Transform JSXElement', () => {
 
     it('unsupported', () => {
       expect(() => {
-        _transform(parseExpression('<View assign={a = 1} />'));
+        _transform({
+          templateAST: parseExpression('<View assign={a = 1} />')
+        });
       }).toThrowError();
     });
 
     it('should handle MemberExpression', () => {
       const sourceCode = '<View>{a.b.c}</View>';
       const ast = parseExpression(sourceCode);
-      const { dynamicValues } = _transform(ast, null, null, sourceCode);
+      const { dynamicValues } = _transform({
+        templateAST: ast
+      }, null, null, sourceCode);
       expect(genInlineCode(ast).code).toEqual('<View>{{ _d0.b.c }}</View>');
       expect(genDynamicAttrs(dynamicValues)).toEqual('{ _d0: a }');
     });
@@ -105,7 +115,9 @@ describe('Transform JSXElement', () => {
     it('should handle nested MemberExpression', () => {
       const sourceCode = '<View>{a ? a.b[c.d] : 1}</View>';
       const ast = parseExpression(sourceCode);
-      const { dynamicValues } = _transform(ast, null, null, sourceCode);
+      const { dynamicValues } = _transform({
+        templateAST: ast
+      }, null, null, sourceCode);
       expect(genInlineCode(ast).code).toEqual('<View>{{ _d0 ? _d0.b[_d1.d] : 1 }}</View>');
       expect(genDynamicAttrs(dynamicValues)).toEqual('{ _d0: a, _d1: c }');
     });
@@ -121,7 +133,9 @@ describe('Transform JSXElement', () => {
       /**
        * { _e0: this.handleClick }
        */
-      const { dynamicEvents } = _transform(ast);
+      const { dynamicEvents } = _transform({
+        templateAST: ast
+      });
       expect(genDynamicAttrs(dynamicEvents)).toEqual('{ _e0: this.handleClick }');
       expect(genInlineCode(ast).code).toEqual('<View onClick="_e0" />');
     });
@@ -132,7 +146,9 @@ describe('Transform JSXElement', () => {
           onClick={props.onClick}
         />
       `);
-      const { dynamicEvents } = _transform(ast);
+      const { dynamicEvents } = _transform({
+        templateAST: ast
+      });
 
       expect(genInlineCode(ast).code).toEqual('<View onClick="_e0" />');
       expect(genDynamicAttrs(dynamicEvents)).toEqual('{ _e0: props.onClick }');
@@ -145,7 +161,9 @@ describe('Transform JSXElement', () => {
           onKeyPress={this.handleClick.bind(this, 'hello')}
         />
       `);
-      const { dynamicEvents } = _transform(ast);
+      const { dynamicEvents } = _transform({
+        templateAST: ast
+      });
 
       expect(genInlineCode(ast).code).toEqual('<View onClick="_e0" onKeyPress="_e1" data-e0-arg-context="this" data-e0-arg-0="{{ a: 1 }}" data-e1-arg-context="this" data-e1-arg-0="{{\'hello\'}}" />');
       expect(genDynamicAttrs(dynamicEvents)).toEqual('{ _e0: onClick, _e1: this.handleClick }');
@@ -161,7 +179,9 @@ describe('Transform JSXElement', () => {
           p.node.__transformed = true;
         }
       });
-      const { dynamicValues } = _transform(ast, null, null, sourceCode);
+      const { dynamicValues } = _transform({
+        templateAST: ast
+      }, null, null, sourceCode);
       expect(genDynamicAttrs(dynamicValues)).toEqual('{}');
     });
   });
@@ -169,7 +189,9 @@ describe('Transform JSXElement', () => {
   describe('element', () => {
     it('should handle identifier', () => {
       const ast = parseExpression('<View>{foo}</View>');
-      const { dynamicValues } = _transform(ast);
+      const { dynamicValues } = _transform({
+        templateAST: ast
+      });
       const code = genInlineCode(ast).code;
       expect(code).toEqual('<View>{{ _d0 }}</View>');
       expect(genDynamicAttrs(dynamicValues)).toEqual('{ _d0: foo }');
@@ -188,7 +210,9 @@ describe('Transform JSXElement', () => {
         </View>
       `;
       const ast = parseExpression(sourceCode);
-      const { dynamicValues } = _transform(ast, null, null, sourceCode);
+      const { dynamicValues } = _transform({
+        templateAST: ast
+      }, null, null, sourceCode);
 
       expect(genInlineCode(ast).code).toEqual(`<View>
           string
@@ -224,7 +248,9 @@ describe('Transform JSXElement', () => {
         {{...{ a: 1 }}}
       </View>`;
       const ast = parseExpression(sourceCode);
-      const { dynamicValues } = _transform(ast, null, null, sourceCode);
+      const { dynamicValues } = _transform({
+        templateAST: ast
+      }, null, null, sourceCode);
 
       expect(genInlineCode(ast).code).toEqual(`<View>
         {{ _d0 }}
@@ -253,7 +279,9 @@ describe('Transform JSXElement', () => {
     it('should handle text', () => {
       const sourceCode = '<Text style={styles.name}>{data && data.itemTitle ? data.itemTitle : \'\'}</Text>';
       const ast = parseExpression(sourceCode);
-      const { dynamicValues } = _transform(ast, null, adapter, sourceCode);
+      const { dynamicValues } = _transform({
+        templateAST: ast
+      }, null, adapter, sourceCode);
       expect(genInlineCode(ast).code).toEqual('<Text style="{{_d0.name}}">{{ _d1 && _d1.itemTitle ? _d1.itemTitle : \'\' }}</Text>');
       expect(genDynamicAttrs(dynamicValues)).toEqual('{ _d0: styles, _d1: data }');
     });
@@ -261,14 +289,18 @@ describe('Transform JSXElement', () => {
     it('should collect object expression', () => {
       const sourceCode = '<Image style={{...styles.avator, ...styles[\`\${rank}Avator\`]}} source={{ uri: avator }}></Image>';
       const ast = parseExpression(sourceCode);
-      const { dynamicValues } = _transform(ast, null, adapter, sourceCode);
+      const { dynamicValues } = _transform({
+        templateAST: ast
+      }, null, adapter, sourceCode);
       expect(genInlineCode(ast).code).toEqual('<Image style="{{_d0}}" source="{{ uri: _d1 }}"></Image>');
       expect(genDynamicAttrs(dynamicValues)).toEqual('{ _d0: { ...styles.avator, ...styles[`${rank}Avator`] }, _d1: avator }');
     });
 
     it('unsupported', () => {
       expect(() => {
-        _transform(parseExpression('<View>{a = 1}</View>'));
+        _transform({
+          templateAST: parseExpression('<View>{a = 1}</View>')
+        });
       }).toThrowError();
     });
   });

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -13,22 +13,26 @@ const ATTR = Symbol('attribute');
 const ELE = Symbol('element');
 const isDirectiveAttr = attr => /^(a:|wx:|x-)/.test(attr);
 const isEventHandlerAttr = propKey => /^on[A-Z]/.test(propKey);
+const BINDING_REG = /{{|}}/g;
 
 /**
  * 1. Normalize jsxExpressionContainer to binding var.
  * 2. Collect dynamicValue (dependent identifiers)
  * 3. Normalize function bounds.
- * @param ast
+ * @param parsed
  * @param scope
  * @param adapter
  * @param sourceCode
  */
 function transformTemplate(
-  ast,
+  {
+    templateAST: ast,
+    componentDependentProps = {},
+    dynamicValue
+  },
   scope = null,
   adapter,
   sourceCode,
-  componentDependentProps = {},
 ) {
   const dynamicValues = new DynamicBinding('_d');
   const dynamicEvents = new DynamicBinding('_e');
@@ -40,25 +44,12 @@ function transformTemplate(
       : ELE; // <View>{xxx}</View>
     let { expression } = node;
     let attributeName = null;
-    const jsxEl =
-      type === ATTR ? path.findParent(p => p.isJSXElement()).node : null;
-
     let isDirective;
 
     if (type === ATTR) {
       attributeName = parentPath.node.name.name;
       isDirective = isDirectiveAttr(attributeName);
-      if (
-        !isDirective &&
-        jsxEl.__tagId &&
-        !compiledComponents[jsxEl.openingElement.name.name]
-      ) {
-        componentDependentProps[jsxEl.__tagId].props =
-          componentDependentProps[jsxEl.__tagId].props || {};
-        componentDependentProps[jsxEl.__tagId].props[
-          attributeName
-        ] = expression;
-      }
+      collectComponentDependentProps(parentPath, expression, componentDependentProps);
     } else {
       isDirective = isDirectiveAttr(attributeName);
     }
@@ -448,6 +439,13 @@ function transformTemplate(
   }
 
   traverse(ast, {
+    JSXAttribute(path) {
+      const originalAttrValue = path.node.value;
+      if (t.isStringLiteral(originalAttrValue)) {
+        const attrValue = dynamicValue[originalAttrValue.value.replace(BINDING_REG, '')] || originalAttrValue.value;
+        collectComponentDependentProps(path, attrValue, componentDependentProps);
+      }
+    },
     JSXExpressionContainer: handleJSXExpressionContainer,
     JSXOpeningElement: {
       exit(path) {
@@ -696,6 +694,27 @@ function checkMemberHasThis(expression) {
   return hasThisExpression;
 }
 
+/**
+ * JSXAttribute path
+ * */
+function collectComponentDependentProps(path, attrValue, componentDependentProps) {
+  const { node } = path;
+  const attrName = node.name.name;
+  const jsxEl = path.findParent(p => p.isJSXElement()).node;
+  const isDirective = isDirectiveAttr(attrName);
+  if (
+    !isDirective
+    && attrValue.type
+    && jsxEl.__tagId
+  ) {
+    componentDependentProps[jsxEl.__tagId].props =
+      componentDependentProps[jsxEl.__tagId].props || {};
+    componentDependentProps[jsxEl.__tagId].props[
+      attrName
+    ] = attrValue;
+  }
+}
+
 // _e0 -> e0
 function formatEventName(name) {
   return name.replace('_', '');
@@ -705,11 +724,10 @@ module.exports = {
   parse(parsed, code, options) {
     if (parsed.renderFunctionPath) {
       const { dynamicValues, dynamicEvents } = transformTemplate(
-        parsed.templateAST,
+        parsed,
         null,
         options.adapter,
-        code,
-        parsed.componentDependentProps,
+        code
       );
 
       const dynamicValue = dynamicValues.reduce((prev, curr, vals) => {

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -442,7 +442,7 @@ function transformTemplate(
     JSXAttribute(path) {
       const originalAttrValue = path.node.value;
       if (t.isStringLiteral(originalAttrValue)) {
-        const attrValue = dynamicValue[originalAttrValue.value.replace(BINDING_REG, '')] || originalAttrValue.value;
+        const attrValue = dynamicValue && dynamicValue[originalAttrValue.value.replace(BINDING_REG, '')] || originalAttrValue.value;
         collectComponentDependentProps(path, attrValue, componentDependentProps);
       }
     },

--- a/packages/jsx2mp-runtime/src/bridge.js
+++ b/packages/jsx2mp-runtime/src/bridge.js
@@ -61,14 +61,13 @@ function getPageCycles(Klass) {
 function getComponentCycles(Klass) {
   return getComponentLifecycle({
     mount: function() {
-      const props = Object.assign({}, this[PROPS], getComponentProps(this[PROPS].__tagId));
+      const instanceId = this[PROPS].__parentId !== undefined ?
+        `${this[PROPS].__parentId}-${this[PROPS].__tagId}` : this[PROPS].__tagId;
+
+      const props = Object.assign({}, this[PROPS], getComponentProps(instanceId));
       this.instance = new Klass(props);
       this.instance.type = Klass;
-
-      if (this[PROPS].hasOwnProperty('__tagId')) {
-        const componentId = this[PROPS].__tagId;
-        setComponentInstance(componentId, this.instance);
-      }
+      setComponentInstance(instanceId, this.instance);
 
       if (GET_DERIVED_STATE_FROM_PROPS in Klass) {
         this.instance['__' + GET_DERIVED_STATE_FROM_PROPS] = Klass[GET_DERIVED_STATE_FROM_PROPS];

--- a/packages/jsx2mp-runtime/src/component.js
+++ b/packages/jsx2mp-runtime/src/component.js
@@ -97,7 +97,7 @@ export default class Component {
   }
 
   _updateChildProps(instanceId, props) {
-    const chlidInstanceId = this.props.__parentId ? this.props.__parentId + '-' + instanceId : instanceId;
+    const chlidInstanceId = this.props.__tagId !== undefined ? this.props.__tagId + '-' + instanceId : instanceId;
     updateChildProps(this, chlidInstanceId, props);
   }
 
@@ -255,7 +255,8 @@ export default class Component {
     this._internal.instance = null;
     this._internal = null;
     this.__mounted = false;
-    removeComponentProps(this.props.__tagId);
+    removeComponentProps(this.props.__parentId !== undefined ?
+      `${this.props.__parentId}-${this.props.__tagId}` : this.props.__tagId);
   }
 
   /**
@@ -320,7 +321,8 @@ export default class Component {
   _setInternal(internal) {
     this._internal = internal;
     const props = internal[PROPS];
-    this.props = Object.assign({}, props, getComponentProps(props.__tagId));
+    const instanceId = props.__parentId !== undefined ? `${props.__parentId}-${props.__tagId}` : props.__tagId;
+    this.props = Object.assign({}, internal[PROPS], getComponentProps(instanceId));
     if (!this.state) this.state = {};
     Object.assign(this.state, internal.data);
   }

--- a/packages/jsx2mp-runtime/src/updater.js
+++ b/packages/jsx2mp-runtime/src/updater.js
@@ -2,7 +2,7 @@ import nextTick from './nextTick';
 import { enqueueRender } from './enqueueRender';
 
 const propsMap = {
-  // tagId -> props
+  // instanceId -> props
 };
 const componentIntances = {};
 
@@ -17,14 +17,14 @@ export function setComponentInstance(instanceId, instance) {
   }
 }
 
-export function getComponentProps(tagId) {
-  if (propsMap.hasOwnProperty(tagId)) return propsMap[tagId];
+export function getComponentProps(instanceId) {
+  if (propsMap.hasOwnProperty(instanceId)) return propsMap[instanceId];
   else return null;
 }
 
-export function removeComponentProps(tagId) {
-  if (propsMap.hasOwnProperty(tagId)) {
-    delete propsMap[tagId];
+export function removeComponentProps(instanceId) {
+  if (propsMap.hasOwnProperty(instanceId)) {
+    delete propsMap[instanceId];
   }
 }
 
@@ -34,7 +34,10 @@ export function updateChildProps(trigger, instanceId, nextProps) {
     // Create a new object reference.
     if (targetComponent) {
       propsMap[instanceId] = Object.assign(
-        {},
+        {
+          __parentId: trigger.props.__tagId,
+          __tagId: instanceId
+        },
         targetComponent.props,
         nextProps,
       );


### PR DESCRIPTION
1. 修复属性值为字符串时，子组件无法正常更新 props 的问题
2. 修复循环渲染组件，二级子组件实例 id 一样，props 错乱的问题
