### PR TITLE
fix: jsx2mp-compiler parse namespace import error

### DIFF
--- a/packages/jsx-compiler/src/modules/__tests__/components.js
+++ b/packages/jsx-compiler/src/modules/__tests__/components.js
@@ -41,6 +41,6 @@ describe('Transform components', () => {
     expect(genCode(ast).code).toEqual(`<rax-view>
         <c-a94616 __parentId="{{__tagId}}" __tagId="0" />
       </rax-view>`);
-    expect(componentsAlias).toEqual({'c-a94616': {'default': true, 'from': '../components/CustomEl', 'isCustomEl': true, 'local': 'CustomEl', 'name': 'c-a94616'}});
+    expect(componentsAlias).toEqual({'c-a94616': {'default': true, 'namespace': false, 'from': '../components/CustomEl', 'isCustomEl': true, 'local': 'CustomEl', 'name': 'c-a94616'}});
   });
 });

--- a/packages/jsx-compiler/src/parser/__tests__/importedAndExported.js
+++ b/packages/jsx-compiler/src/parser/__tests__/importedAndExported.js
@@ -4,18 +4,22 @@ describe('Parse imported', () => {
   it('should parse default imported', () => {
     expect(getImported(parseCode(`
       import Hello from './Hello';
+      import * as Env from 'universal-env';
       import Rax, { Component } from 'rax';
     `))).toEqual({
-      './Hello': [{ default: true, isCustomEl: true, local: 'Hello', name: 'c-702789' }],
+      './Hello': [{ default: true, namespace: false, isCustomEl: true, local: 'Hello', name: 'c-702789' }],
+      'universal-env': [{ default: false, namespace: true, isCustomEl: false, local: 'Env', name: 'universal-env' }],
       rax: [
         {
           default: true,
+          namespace: false,
           isCustomEl: false,
           local: 'Rax',
           name: 'rax',
         },
         {
           default: false,
+          namespace: false,
           isCustomEl: false,
           importFrom: 'Component',
           local: 'Component',

--- a/packages/jsx-compiler/src/parser/index.js
+++ b/packages/jsx-compiler/src/parser/index.js
@@ -36,8 +36,8 @@ function getImported(ast) {
 
       path.node.specifiers.forEach((specifier) => {
         const local = specifier.local.name;
-        const ret = { local, default: t.isImportDefaultSpecifier(specifier) };
-        if (ret.default === false) {
+        const ret = { local, default: t.isImportDefaultSpecifier(specifier), namespace: t.isImportNamespaceSpecifier(specifier) };
+        if (ret.default === false && ret.namespace === false) {
           ret.importFrom = specifier.imported.name;
         }
 


### PR DESCRIPTION
Fix jsx2pm compile error `import * as Env from 'universal-env'`

![image](https://user-images.githubusercontent.com/471003/68757169-6fb79100-0646-11ea-8be3-9b1968741d8d.png)
