### PR TITLE
feat: 支持 x-for 里函数 filter 功能

### DIFF
--- a/packages/jsx-compiler/src/modules/__tests__/jsx-plus.js
+++ b/packages/jsx-compiler/src/modules/__tests__/jsx-plus.js
@@ -12,15 +12,16 @@ describe('Directives', () => {
   describe('list', () => {
     it('simple', () => {
       const code = `
-      <View x-for={val in array}>{val}</View>
+      <View x-for={val in array} data-item={parse(val)}>{val}</View>
     `;
       const ast = parseExpression(code);
       _transformList(ast, code, adapter);
       expect(genExpression(ast))
-        .toEqual(`<View a:for={array.map((val, index) => {
+        .toEqual(`<View data-item={parse(val)} a:for={array.map((val, index) => {
   return {
     val: val,
-    index: index
+    index: index,
+    _f0: parse(val)
   };
 })} a:for-item="val" a:for-index="index">{val}</View>`);
     });

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -279,8 +279,12 @@ function transformTemplate(
 
       // <tag foo={fn()} /> => <tag foo="{{_d0}} /> _d0 = fn();
       // <tag>{fn()}</tag> => <tag>{{ _d0 }}</tag> _d0 = fn();
+      // <tag x-for={item in items}>{fn(item)}</tag> => <tag a:for={item in items}>{{ item.item._f0 }}</tag> item.item._f0 = fn();
       case 'CallExpression':
-        if (type === ATTR) {
+        if (expression.__listItemFilter) {
+          const { item, filter } = expression.__listItemFilter;
+          path.replaceWith(t.stringLiteral(createBinding(`${item}.${item}.${filter}`)));
+        } else if (type === ATTR) {
           if (
             isEventHandler &&
             t.isMemberExpression(expression.callee) &&


### PR DESCRIPTION
支持 `x-for` 里对 `item/index` 相关的函数处理，兼容 `x-class`

```jsx
<View x-for={items} data-item={setDataset(item)}>
  <Text x-class={{ selected: selected === index }}>{parse(item)}</Text>
</View>
```

处理结果见下：

![image](https://user-images.githubusercontent.com/471003/68852171-53812600-0712-11ea-9cfd-fe30da736513.png)
![image](https://user-images.githubusercontent.com/471003/68852177-567c1680-0712-11ea-9da2-00513320804e.png)
![image](https://user-images.githubusercontent.com/471003/68852184-5aa83400-0712-11ea-9ddf-2c498ae0d818.png)
