### PR TITLE
fix: object pattern rest element error

### DIFF
--- a/packages/jsx-compiler/src/modules/__tests__/condition.js
+++ b/packages/jsx-compiler/src/modules/__tests__/condition.js
@@ -116,7 +116,8 @@ describe('Transform condition', () => {
 
 describe('Transiform condition render function', () => {
   it('basic case', () => {
-    const ast = parseExpression(`(function render() {
+    const ast = parseExpression(`(function render(props) {
+        let { a, b, ...c } = props;
         let vdom;
         if (a > 0) {
           vdom = <view>case 1</view>
@@ -132,7 +133,12 @@ describe('Transiform condition render function', () => {
 
     const tmpVars = _transformRenderFunction(ast, adapter);
     expect(genExpression(tmpVars.vdom.value)).toEqual('<block><block a:if="{{a > 0}}"><view>case 1</view></block><block a:else><view>case 1.1</view></block><block a:if="{{a > 1}}"><view>case 2</view></block></block>');
-    expect(genExpression(ast)).toEqual(`function render() {
+    expect(genExpression(ast)).toEqual(`function render(props) {
+  let {
+    a,
+    b,
+    ...c
+  } = props;
   let vdom;
   return vdom;
 }`);

--- a/packages/jsx-compiler/src/modules/condition.js
+++ b/packages/jsx-compiler/src/modules/condition.js
@@ -28,7 +28,10 @@ function transformRenderFunction(ast, adapter) {
             case 'ObjectPattern':
               if (Array.isArray(id.properties)) {
                 id.properties.forEach(objProperty => {
-                  templateVariables[objProperty.value.name] = {
+                  templateVariables[t.isRestElement(objProperty) ?
+                    objProperty.argument.name :
+                    objProperty.value.name
+                  ] = {
                     source: t.isMemberExpression(init)
                       ? init.property.name
                       : init.name,


### PR DESCRIPTION
以下场景编译会报错：

```jsx
function App(props) {
  const { a, b, ...c } = props;
}
```

![image](https://user-images.githubusercontent.com/471003/68914916-20cf4000-079b-11ea-9ebc-8b391be396ab.png)
