### PR TITLE
ci: In node 12 env, eslint is not found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: node_js
 
 before_install:
   - npm i -g npm@6
+  - npm i eslint -g
 
 node_js:
   - "8"
@@ -16,7 +17,7 @@ script:
   - npm run lint:nofix
   - npm run test
 
-jobs: 
+jobs:
   include:
     - stage: bench
       addons:


### PR DESCRIPTION
In node 12, eslint is not found:
![image](https://user-images.githubusercontent.com/14757289/68996755-46626380-08d9-11ea-8bcc-61fe58b90dd1.png)
