### PR TITLE
fix: override json file while compile jsx to miniapp

### DIFF
--- a/packages/jsx2mp-loader/src/app-loader.js
+++ b/packages/jsx2mp-loader/src/app-loader.js
@@ -88,6 +88,7 @@ module.exports = async function appLoader(content) {
     outputPath: {
       code: join(outputPath, 'app.js'),
       json: join(outputPath, 'app.json'),
+      srcJson: join(sourcePath, 'app.json'),
       css: join(outputPath, 'app' + platform.extension.css),
       config: join(outputPath, 'app.config.js')
     },

--- a/packages/jsx2mp-loader/src/component-loader.js
+++ b/packages/jsx2mp-loader/src/component-loader.js
@@ -26,6 +26,7 @@ module.exports = async function componentLoader(content) {
   const sourcePath = join(rootContext, dirname(entryPath));
 
   const relativeSourcePath = relative(sourcePath, this.resourcePath);
+  const srcFileWithoutExt = removeExt(join(sourcePath, relativeSourcePath));
   const distFileWithoutExt = removeExt(join(outputPath, relativeSourcePath));
 
   const isFromConstantDir = cached(isFromTargetDirs(absoluteConstantDir));
@@ -94,6 +95,7 @@ module.exports = async function componentLoader(content) {
     outputPath: {
       code: distFileWithoutExt + '.js',
       json: distFileWithoutExt + '.json',
+      srcJson: srcFileWithoutExt + '.json',
       css: distFileWithoutExt + platform.extension.css,
       template: distFileWithoutExt + platform.extension.xml,
       assets: outputPath

--- a/packages/jsx2mp-loader/src/output.js
+++ b/packages/jsx2mp-loader/src/output.js
@@ -88,6 +88,9 @@ function output(content, raw, options) {
   // Write file
   writeFileSync(outputPath.code, code);
   if (json) {
+    if (existsSync(outputPath.srcJson)) {
+      json = Object.assign(require(outputPath.srcJson), json);
+    }
     writeJSONSync(outputPath.json, json, { spaces: 2});
   }
   if (template) {

--- a/packages/jsx2mp-loader/src/page-loader.js
+++ b/packages/jsx2mp-loader/src/page-loader.js
@@ -59,6 +59,7 @@ module.exports = async function pageLoader(content) {
   const pageDistDir = dirname(targetFilePath);
   if (!existsSync(pageDistDir)) mkdirpSync(pageDistDir);
 
+  const srcFileWithoutExt = removeExt(join(sourcePath, relativeSourcePath));
   const distFileWithoutExt = removeExt(join(outputPath, relativeSourcePath));
 
   const config = Object.assign({}, transformed.config);
@@ -95,6 +96,7 @@ module.exports = async function pageLoader(content) {
     outputPath: {
       code: distFileWithoutExt + '.js',
       json: distFileWithoutExt + '.json',
+      srcJson: srcFileWithoutExt + '.json',
       css: distFileWithoutExt + platform.extension.css,
       template: distFileWithoutExt + platform.extension.xml,
       assets: outputPath


### PR DESCRIPTION
当项目里有 `app.json` 或者  `page/component` 的 `index.json`，编译后会将之覆盖掉，导致小程序一些配置无法生效，比如 `defaultTitle/optionMenu ` 等等

将直接覆盖改成合并的操作
