### PR TITLE
fix: jsx2mp-loader-babel-config

### DIFF
--- a/packages/jsx2mp-cli/getWebpackConfig.js
+++ b/packages/jsx2mp-cli/getWebpackConfig.js
@@ -21,7 +21,7 @@ function getBabelConfig() {
   return {
     presets: [
       require.resolve('@babel/preset-env'),
-      ['@babel/preset-react', {
+      [require.resolve('@babel/preset-react'), {
         'throwIfNamespace': false
       }]
     ],


### PR DESCRIPTION
`presets` 里直接写 `@babel/preset-react`，`babel-loader` 会到当前项目目录下查找 `@babel/preset-react`，当构建逻辑不在项目里的话，会出现找不到的错误

```
- build
  - node_modules
    - @babel/preset-react
  - cli.js
- project
  - src
  - package.json
```
