### PR TITLE
fix: setStyle does not update with `rpx`, in Weex

### DIFF
--- a/packages/driver-universal/README.md
+++ b/packages/driver-universal/README.md
@@ -32,5 +32,5 @@ render(<Example />, null, {
 | driver | append unit to relevant styles | 'rpx' translate | Compatible with flex | Compatible with event |
 | ------ | ------------------------------ | --------------- | -------------------- | --------------------- |
 | driver-dom | Append 'px' | Translate to 'vw' | Do nothing | Do nothing  |
-| driver-weex | Append 'px' that relative to the width of the screen. | Translate to 'px' that relative to the width of the screen. | Do nothing | Do nothing |
-| driver-universal | Append 'rpx' | Do nothing | Support parsing array like display: ["-webkit-box", "-webkit-flex", "flex"] | Support input doubleclick |
+| driver-weex | Use 'px' that relative to the width of the screen. |  Do nothing | Do nothing | Do nothing |
+| driver-universal | Append 'rpx' | Use 'px' that relative to the width of the screen, In weex | Support parsing array like display: ["-webkit-box", "-webkit-flex", "flex"] | Support input doubleclick |

--- a/packages/driver-universal/package.json
+++ b/packages/driver-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "driver-universal",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Driver for Universal App.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/driver-universal/src/weex.js
+++ b/packages/driver-universal/src/weex.js
@@ -23,7 +23,7 @@ const driver = Object.assign({}, DriverWeex, {
       // translate 'rpx' to px
       style[prop] = convertUnit(style[prop], prop);
     }
-    node.setStyles(style);
+    DriverWeex.setStyle(node, style);
   }
 });
 

--- a/packages/driver-universal/src/weex.js
+++ b/packages/driver-universal/src/weex.js
@@ -6,7 +6,7 @@ const driver = Object.assign({}, DriverWeex, {
     // Turn off batched updates
     document.open();
     // Init rem unit
-    setRpx( 1 );
+    setRpx(1);
   },
   createElement(type, props = {}) {
     const style = {};
@@ -18,6 +18,13 @@ const driver = Object.assign({}, DriverWeex, {
     }
     return DriverWeex.createElement(type, Object.assign({}, props, { style }));
   },
+  setStyle(node, style) {
+    for (let prop in style) {
+      // translate 'rpx' to px
+      style[prop] = convertUnit(style[prop], prop);
+    }
+    node.setStyles(style);
+  }
 });
 
 export default driver;


### PR DESCRIPTION
The following code, click the button, the height of the View will be changed by state update. However, it does not work properly under Weex.
Fixed a bug that `driver-universal` always remained，setStyle does not update with rpx.

```jsx
import { createElement, render, useState } from 'rax';
import DriverUniversal from 'driver-universal';
import * as DriverWeex from 'driver-weex';
import Text from 'rax-text';
import View from 'rax-view';

function App() {
  const [flag, setFlag] = useState(true);

  const style1 = {
    width: '300rpx',
    height: '500rpx',
    backgroundColor: 'green',
    overflow: 'visible',
  };
  const style2 = {
    width: '300rpx',
    height: '200rpx',
    backgroundColor: 'green',
    overflow: 'hidden',
  };

  return (
    <View>
      <View
        style={{ height: '100rpx', width: '100rpx', backgroundColor: 'yellow' }}
        onClick={() => setFlag(!flag)}>
        <Text>点击切换</Text>
      </View>
      <View style={{ height: '500rpx', width: '500rpx' }}></View>

      <View style={flag ? style1 : style2}>
        <View style={{ width: '200rpx', height: '400rpx', backgroundColor: 'red' }}>1</View>
      </View>
    </View>
  );
}

render(<App />, null, { driver: DriverUniversal });
```
