### PR TITLE
feat: rax-set-native-props convert rpx to 'vw' in web.

### DIFF
--- a/packages/rax-set-native-props/package.json
+++ b/packages/rax-set-native-props/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "universal-env": "^1.0.0",
-    "style-unit": "^2.0.0",
-    "rax": "^1.0.0"
+    "style-unit": "^2.0.0"
   }
 }

--- a/packages/rax-set-native-props/package.json
+++ b/packages/rax-set-native-props/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-set-native-props",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Rax setNativeProps",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "universal-env": "^1.0.0",
-    "style-unit": "^1.0.0",
+    "style-unit": "^2.0.0",
     "rax": "^1.0.0"
   }
 }

--- a/packages/style-unit/README.md
+++ b/packages/style-unit/README.md
@@ -1,3 +1,57 @@
 # style-unit
 
-> style-unit
+> Unit conversion for calculating dimensional css attributes, especially for rpx.
+
+## API
+
+convertUnit(value, prop, platform);
+
+| Property | Type          | Required | Description                                                  |
+| -------- | ------------- | -------- | ------------------------------------------------------------ |
+| value    | string/number | true     |                                                              |
+| prop     | string        | true     |                                                              |
+| platform | string        | false    | Different platforms have different rpx conversion. Details are as follows. |
+
+## Web 
+
+In Web, Calculate rpx to vw (relative to viewport width 750). 
+
+750rpx -> 100vw
+
+### setViewportWidth
+
+You can use `setViewportWidth` method update viewport width
+
+setViewportWidth(1500);
+
+750rpx -> 50vw
+
+
+## Weex 
+
+In Web, Calculate rpx to px (viewport width is 750). 
+
+750rpx -> 750px
+
+### setRpx
+
+You can use `setRpx` method update coefficient of 750
+
+setRpx(1500 / 750)
+
+750rpx -> 1500px
+
+## MiniApp
+
+rpx (responsive pixel): Adaptable to the screen width in MiniApp. The specified screen width is 750 rpx. If the screen width on iPhone6 is 375 px (750 physical pixels), then 750 rpx = 375 px = 750 physical pixels, i.e. 1 rpx = 0.5 px = 1 physical pixel.
+
+## Node.js
+
+Use Weex result:
+```
+convertUnit('500rpx', 'width', 'weex')
+```
+Use Web result:
+```
+convertUnit('500rpx', 'width', 'web')
+```

--- a/packages/style-unit/package.json
+++ b/packages/style-unit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-unit",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "style-unit",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
@@ -14,5 +14,8 @@
   "bugs": {
     "url": "https://github.com/alibaba/rax/issues"
   },
-  "homepage": "https://github.com/alibaba/rax#readme"
+  "homepage": "https://github.com/alibaba/rax#readme",
+  "dependencies": {
+    "universal-env": "^2.0.0"
+  }
 }

--- a/packages/style-unit/src/__tests__/style-unit.js
+++ b/packages/style-unit/src/__tests__/style-unit.js
@@ -1,0 +1,23 @@
+import { convertUnit, setRpx, setViewportWidth } from '..';
+
+
+describe('style-unit', () => {
+  describe('rpx convertUnit', () => {
+    // Weex
+    setRpx(414 / 750);
+    it('should calculate rpx to px in Weex', () => {
+      expect(convertUnit('500rpx', 'width', 'weex')).toEqual('276px');
+    });
+
+    // Web
+    setViewportWidth(375);
+    it('should calculate rpx to vw in Web', () => {
+      expect(convertUnit('375rpx', 'width', 'web')).toEqual('100vw');
+    });
+
+    // MiniApp
+    it('should not calculate rpx in MiniApp', () => {
+      expect(convertUnit('375rpx', 'width', 'miniApp')).toEqual('375rpx');
+    });
+  });
+});

--- a/packages/style-unit/src/__tests__/style-unit.miniApp.js
+++ b/packages/style-unit/src/__tests__/style-unit.miniApp.js
@@ -1,0 +1,32 @@
+import { convertUnit, getViewportWidth, setViewportWidth } from '..';
+
+jest.mock('universal-env', () => {
+  return {
+    isMiniApp: true,
+    isWeb: false,
+    isWeex: false
+  };
+});
+
+describe('Mini-App style-unit', () => {
+  describe('convertUnit', () => {
+    it('should recognize number', () => {
+      expect(convertUnit(500, 'width')).toEqual('500');
+    });
+
+    it('should recognize number string', () => {
+      expect(convertUnit('500', 'width')).toEqual('500');
+    });
+
+    it('should recognize px', () => {
+      expect(convertUnit('276px', 'width')).toEqual('276px');
+    });
+
+    it('should recognize rem', () => {
+      expect(convertUnit('500rem', 'width')).toEqual('500rem');
+    });
+    it('should recognize rpx', () => {
+      expect(convertUnit('375rpx', 'width')).toEqual('375rpx');
+    });
+  });
+});

--- a/packages/style-unit/src/__tests__/style-unit.miniApp.js
+++ b/packages/style-unit/src/__tests__/style-unit.miniApp.js
@@ -25,8 +25,23 @@ describe('Mini-App style-unit', () => {
     it('should recognize rem', () => {
       expect(convertUnit('500rem', 'width')).toEqual('500rem');
     });
+
     it('should recognize rpx', () => {
       expect(convertUnit('375rpx', 'width')).toEqual('375rpx');
+    });
+
+    it('should recognize vh', () => {
+      expect(convertUnit('500vh', 'width')).toEqual('500vh');
+    });
+
+    it('should recognize 0', () => {
+      expect(convertUnit('0', 'width')).toEqual('0');
+      expect(convertUnit(0, 'width')).toEqual('0');
+    });
+
+    it('should recognize transform', () => {
+      expect(convertUnit('375rpx 20px 375rpx', 'margin')).toEqual('375rpx 20px 375rpx');
+      expect(convertUnit('translateX(375rpx) translateY(375rpx)', 'transform')).toEqual('translateX(375rpx) translateY(375rpx)');
     });
   });
 });

--- a/packages/style-unit/src/__tests__/style-unit.web.js
+++ b/packages/style-unit/src/__tests__/style-unit.web.js
@@ -1,0 +1,47 @@
+import { convertUnit, setDecimalPixelTransformer, getRpx, setRpx } from '..';
+
+jest.mock('universal-env', () => {
+  return {
+    isMiniApp: false,
+    isWeb: true,
+    isWeex: false
+  };
+});
+
+describe('Web style-unit', () => {
+  describe('convertUnit', () => {
+    it('should recognize number', () => {
+      expect(convertUnit(500, 'width')).toEqual('500');
+    });
+
+    it('should recognize number string', () => {
+      expect(convertUnit('500', 'width')).toEqual('500');
+    });
+
+    it('should recognize px', () => {
+      expect(convertUnit('276px', 'width')).toEqual('276px');
+    });
+
+    it('should recognize rem', () => {
+      expect(convertUnit('500rem', 'width')).toEqual('500rem');
+    });
+
+    it('should recognize rpx', () => {
+      expect(convertUnit('375rpx', 'width')).toEqual('50vw');
+    });
+
+    it('should recognize vh', () => {
+      expect(convertUnit('500vh', 'width')).toEqual('500vh');
+    });
+
+    it('should recognize 0', () => {
+      expect(convertUnit('0', 'width')).toEqual('0');
+      expect(convertUnit(0, 'width')).toEqual('0');
+    });
+
+    it('should recognize transform', () => {
+      expect(convertUnit('375rpx 20px 375rpx', 'margin')).toEqual('50vw 20px 50vw');
+      expect(convertUnit('translateX(375rpx) translateY(375rpx)', 'transform')).toEqual('translateX(50vw) translateY(50vw)');
+    });
+  });
+});

--- a/packages/style-unit/src/__tests__/style-unit.web.js
+++ b/packages/style-unit/src/__tests__/style-unit.web.js
@@ -1,4 +1,4 @@
-import { convertUnit, setDecimalPixelTransformer, getRpx, setRpx } from '..';
+import { convertUnit, getViewportWidth, setViewportWidth } from '..';
 
 jest.mock('universal-env', () => {
   return {
@@ -10,6 +10,7 @@ jest.mock('universal-env', () => {
 
 describe('Web style-unit', () => {
   describe('convertUnit', () => {
+    setViewportWidth(375);
     it('should recognize number', () => {
       expect(convertUnit(500, 'width')).toEqual('500');
     });
@@ -27,7 +28,7 @@ describe('Web style-unit', () => {
     });
 
     it('should recognize rpx', () => {
-      expect(convertUnit('375rpx', 'width')).toEqual('50vw');
+      expect(convertUnit('375rpx', 'width')).toEqual('100vw');
     });
 
     it('should recognize vh', () => {
@@ -40,8 +41,15 @@ describe('Web style-unit', () => {
     });
 
     it('should recognize transform', () => {
-      expect(convertUnit('375rpx 20px 375rpx', 'margin')).toEqual('50vw 20px 50vw');
-      expect(convertUnit('translateX(375rpx) translateY(375rpx)', 'transform')).toEqual('translateX(50vw) translateY(50vw)');
+      expect(convertUnit('375rpx 20px 375rpx', 'margin')).toEqual('100vw 20px 100vw');
+      expect(convertUnit('translateX(375rpx) translateY(375rpx)', 'transform')).toEqual('translateX(100vw) translateY(100vw)');
+    });
+  });
+
+  describe('exported API', () => {
+    it('get and set viewportWidth', () => {
+      setViewportWidth(500);
+      expect(getViewportWidth()).toEqual(500);
     });
   });
 });

--- a/packages/style-unit/src/__tests__/style-unit.weex.js
+++ b/packages/style-unit/src/__tests__/style-unit.weex.js
@@ -1,6 +1,14 @@
 import { convertUnit, setDecimalPixelTransformer, getRpx, setRpx } from '..';
 
-describe('style-unit', () => {
+jest.mock('universal-env', () => {
+  return {
+    isMiniApp: false,
+    isWeb: false,
+    isWeex: true
+  };
+});
+
+describe('Weex style-unit', () => {
   describe('convertUnit', () => {
     setRpx(414 / 750);
 

--- a/packages/style-unit/src/index.js
+++ b/packages/style-unit/src/index.js
@@ -1,7 +1,7 @@
-import { isWeb, isWeex, isMiniApp } from 'universal-env';
+import { isWeb, isWeex } from 'universal-env';
 
 const RPX_REG = /[-+]?\d*\.?\d+rpx/g;
-const GLOBAL_RPX_UNIT = '__rpx_coefficient__';
+const GLOBAL_RPX_COEFFICIENT = '__rpx_coefficient__';
 const GLOBAL_VIEWPORT_WIDTH = '__rpx_viewport_width__';
 const global =
   typeof window === 'object'
@@ -46,29 +46,32 @@ export function isRpx(str) {
 }
 
 /**
- * Calculate rpx to pixels: '1.2rpx' => 1.2 * rpx
+ * Calculate rpx
  * @param {String} str
  * @returns {String}
  */
 export function calcRpx(str) {
   if (isWeb) {
     // In Web convert rpx to 'vw', same as driver-dom and driver-universal
+    // '375rpx' => '50vw'
     return str.replace(RPX_REG, decimalVWTransformer);
-  } else if (isWeex || isMiniApp) {
-    // In Weex and miniApp convert rpx to 'px'
+  } else if (isWeex) {
+    // In Weex convert rpx to 'px'
+    // '375rpx' => 375 * rpx
     return str.replace(RPX_REG, decimalPixelTransformer);
   } else {
-    // Unknown platform return original value
+    // Other platform return original value, like Mini-App and WX Mini-Program ...
+    // '375rpx' => '375rpx'
     return str;
   }
 }
 
 export function getRpx() {
-  return global[GLOBAL_RPX_UNIT];
+  return global[GLOBAL_RPX_COEFFICIENT];
 }
 
 export function setRpx(rpx) {
-  global[GLOBAL_RPX_UNIT] = rpx;
+  global[GLOBAL_RPX_COEFFICIENT] = rpx;
 }
 
 export function getViewportWidth() {

--- a/packages/style-unit/src/index.js
+++ b/packages/style-unit/src/index.js
@@ -101,9 +101,10 @@ const cache = Object.create(null);
  * @return {String} Transformed value.
  */
 export function convertUnit(value, prop, platform) {
-  const cacheKey = `${prop}-${value}-${platform}`;
+  let cacheKey = `${prop}-${value}`;
   const hit = cache[cacheKey];
   if (platform) {
+    cacheKey += `-${platform}`;
     targetPlatform = platform;
   }
   if (hit) {

--- a/packages/style-unit/src/index.js
+++ b/packages/style-unit/src/index.js
@@ -1,5 +1,8 @@
+import { isWeb } from 'universal-env';
+
 const RPX_REG = /[-+]?\d*\.?\d+rpx/g;
 const GLOBAL_RPX_UNIT = '__rpx_coefficient__';
+const GLOBAL_VIEWPORT_WIDTH = '__rpx_viewport_width__';
 const global =
   typeof window === 'object'
     ? window
@@ -7,12 +10,28 @@ const global =
       ? global
       : {};
 
-// Dedault decimal transformer.
+const unitPrecision = 4;
+const toFixed = (number, precision) => {
+  const multiplier = Math.pow(10, precision + 1);
+  const wholeNumber = Math.floor(number * multiplier);
+  return Math.round(wholeNumber / 10) * 10 / multiplier;
+};
+
+
+// Dedault decimal px transformer.
 let decimalPixelTransformer = (rpx) => parseFloat(rpx) * getRpx() + 'px';
+
+// Default decimal vw transformer.
+let decimalVWTransformer = (rpx) => toFixed(parseFloat(rpx) / (getViewportWidth() / 100), unitPrecision) + 'vw';
 
 // Default 1 rpx to 1 px
 if (getRpx() === undefined) {
   setRpx(1);
+}
+
+// Set default viewport width
+if (getViewportWidth() === undefined) {
+  setViewportWidth(750);
 }
 
 /**
@@ -31,7 +50,7 @@ export function isRpx(str) {
  * @returns {String}
  */
 export function calcRpx(str) {
-  return str.replace(RPX_REG, decimalPixelTransformer);
+  return str.replace(RPX_REG, isWeb ? decimalVWTransformer : decimalPixelTransformer);
 }
 
 export function getRpx() {
@@ -40,6 +59,14 @@ export function getRpx() {
 
 export function setRpx(rpx) {
   global[GLOBAL_RPX_UNIT] = rpx;
+}
+
+export function getViewportWidth() {
+  return global[GLOBAL_VIEWPORT_WIDTH];
+}
+
+export function setViewportWidth(viewport) {
+  global[GLOBAL_VIEWPORT_WIDTH] = viewport;
 }
 
 /**

--- a/packages/style-unit/src/index.js
+++ b/packages/style-unit/src/index.js
@@ -2,13 +2,15 @@ import { isWeb, isWeex } from 'universal-env';
 
 const RPX_REG = /[-+]?\d*\.?\d+rpx/g;
 const GLOBAL_RPX_COEFFICIENT = '__rpx_coefficient__';
-const GLOBAL_VIEWPORT_WIDTH = '__rpx_viewport_width__';
+const GLOBAL_VIEWPORT_WIDTH = '__viewport_width__';
 const global =
   typeof window === 'object'
     ? window
     : typeof global === 'object'
       ? global
       : {};
+// convertUnit method targetPlatform
+let targetPlatform = isWeb ? 'web' : isWeex ? 'weex' : '';
 
 // Init toFixed method
 const unitPrecision = 4;
@@ -17,7 +19,6 @@ const toFixed = (number, precision) => {
   const wholeNumber = Math.floor(number * multiplier);
   return Math.round(wholeNumber / 10) * 10 / multiplier;
 };
-
 
 // Dedault decimal px transformer.
 let decimalPixelTransformer = (rpx) => parseFloat(rpx) * getRpx() + 'px';
@@ -51,11 +52,11 @@ export function isRpx(str) {
  * @returns {String}
  */
 export function calcRpx(str) {
-  if (isWeb) {
+  if (targetPlatform === 'web') {
     // In Web convert rpx to 'vw', same as driver-dom and driver-universal
     // '375rpx' => '50vw'
     return str.replace(RPX_REG, decimalVWTransformer);
-  } else if (isWeex) {
+  } else if (targetPlatform === 'weex') {
     // In Weex convert rpx to 'px'
     // '375rpx' => 375 * rpx
     return str.replace(RPX_REG, decimalPixelTransformer);
@@ -96,11 +97,15 @@ const cache = Object.create(null);
  * Convert rpx.
  * @param value
  * @param prop
+ * @param platform
  * @return {String} Transformed value.
  */
-export function convertUnit(value, prop) {
-  const cacheKey = `${prop}-${value}`;
+export function convertUnit(value, prop, platform) {
+  const cacheKey = `${prop}-${value}-${platform}`;
   const hit = cache[cacheKey];
+  if (platform) {
+    targetPlatform = platform;
+  }
   if (hit) {
     return hit;
   } else {

--- a/packages/style-unit/src/index.js
+++ b/packages/style-unit/src/index.js
@@ -10,6 +10,7 @@ const global =
       ? global
       : {};
 
+// Init toFixed method
 const unitPrecision = 4;
 const toFixed = (number, precision) => {
   const multiplier = Math.pow(10, precision + 1);
@@ -29,7 +30,7 @@ if (getRpx() === undefined) {
   setRpx(1);
 }
 
-// Set default viewport width
+// Viewport width, default to 750.
 if (getViewportWidth() === undefined) {
   setViewportWidth(750);
 }
@@ -50,7 +51,13 @@ export function isRpx(str) {
  * @returns {String}
  */
 export function calcRpx(str) {
-  return str.replace(RPX_REG, isWeb ? decimalVWTransformer : decimalPixelTransformer);
+  if (isWeb) {
+    // In Web convert rpx to 'vw', same as driver-dom and driver-universal
+    return str.replace(RPX_REG, decimalVWTransformer);
+  } else {
+    // In WEEX and miniApp convert rpx to 'px'
+    return str.replace(RPX_REG, decimalPixelTransformer);
+  }
 }
 
 export function getRpx() {

--- a/packages/style-unit/src/index.js
+++ b/packages/style-unit/src/index.js
@@ -1,4 +1,4 @@
-import { isWeb } from 'universal-env';
+import { isWeb, isWeex, isMiniApp } from 'universal-env';
 
 const RPX_REG = /[-+]?\d*\.?\d+rpx/g;
 const GLOBAL_RPX_UNIT = '__rpx_coefficient__';
@@ -23,7 +23,7 @@ const toFixed = (number, precision) => {
 let decimalPixelTransformer = (rpx) => parseFloat(rpx) * getRpx() + 'px';
 
 // Default decimal vw transformer.
-let decimalVWTransformer = (rpx) => toFixed(parseFloat(rpx) / (getViewportWidth() / 100), unitPrecision) + 'vw';
+const decimalVWTransformer = (rpx) => toFixed(parseFloat(rpx) / (getViewportWidth() / 100), unitPrecision) + 'vw';
 
 // Default 1 rpx to 1 px
 if (getRpx() === undefined) {
@@ -54,9 +54,12 @@ export function calcRpx(str) {
   if (isWeb) {
     // In Web convert rpx to 'vw', same as driver-dom and driver-universal
     return str.replace(RPX_REG, decimalVWTransformer);
-  } else {
-    // In WEEX and miniApp convert rpx to 'px'
+  } else if (isWeex || isMiniApp) {
+    // In Weex and miniApp convert rpx to 'px'
     return str.replace(RPX_REG, decimalPixelTransformer);
+  } else {
+    // Unknown platform return original value
+    return str;
   }
 }
 


### PR DESCRIPTION
Before: 
rax-set-native-props convert rpx to 'px' in web.

After:
rax-set-native-props convert rpx to 'vw' in web, same as driver-dom and driver-universal