### PR TITLE
fix: use rax-devtools hooks instead of react devtools hooks

### DIFF
--- a/packages/rax/src/devtools/index.js
+++ b/packages/rax/src/devtools/index.js
@@ -40,9 +40,9 @@ const renderer = {
   monitor: null
 };
 
-/* global __REACT_DEVTOOLS_GLOBAL_HOOK__ */
+/* global __RAX_DEVTOOLS_GLOBAL_HOOK__ */
 if (
-  typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined' &&
-  typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.inject === 'function') {
-  __REACT_DEVTOOLS_GLOBAL_HOOK__.inject(renderer);
+  typeof __RAX_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined' &&
+  typeof __RAX_DEVTOOLS_GLOBAL_HOOK__.inject === 'function') {
+  __RAX_DEVTOOLS_GLOBAL_HOOK__.inject(renderer);
 }


### PR DESCRIPTION
Rax 未来将会会通过`__RAX_DEVTOOLS_GLOBAL_HOOK__`这个全局变量来启用调试工具。

这样就可以避免和已有的react devtools发生冲突，毕竟rax已经无法和最新的react devtools v4.x版本兼容了。

我们基于react devtools v3.x版本开发出了[rax devtools](https://github.com/raxjs/rax-devtools)，功能目前和React Devtools v3.x 版本一样，不过未来会持续维护以保证与Rax相互兼容。

修改后的插件现在正在发布到Chrome商店的路上，估计审核还需要一定时间，审核通过之后就可以直接在商店搜索`Rax Developer Tools`来安装了

