### PR TITLE
fix: remove all import specifiers of component

### DIFF
--- a/packages/jsx-compiler/src/modules/components.js
+++ b/packages/jsx-compiler/src/modules/components.js
@@ -345,7 +345,10 @@ function removeImport(ast, alias) {
     ImportDeclaration(path) {
       const { node } = path;
       if (t.isStringLiteral(node.source) && node.source.value === alias.from) {
-        path.remove();
+        node.specifiers = (node.specifiers || []).filter(function(s) {
+          return !(s.local && s.local.name === alias.local);
+        });
+        if (!node.specifiers.length) path.remove();
       }
     },
   });

--- a/packages/jsx2mp-cli/__tests__/component.js
+++ b/packages/jsx2mp-cli/__tests__/component.js
@@ -38,7 +38,7 @@ describe('Component compiled result', () => {
 
   it('should return correct js', () => {
     expect(jsContent).toEqual(
-      '"use strict";var _jsx2mpRuntime=require("./npm/jsx2mp-runtime"),img="./assets/rax.png",a=0,b=1;function Index(){this._updateChildProps("0",{source:{uri:img},c:a&&b,d:img?a:b}),this._updateData({_d0:img,_d1:a,_d2:b}),this._updateMethods({})}var __def__=Index;Component((0,_jsx2mpRuntime.createComponent)(__def__));'
+      '"use strict";var _jsx2mpRuntime=require("./npm/jsx2mp-runtime"),_index=require("./npm/rax-view/lib/index.js"),img="./assets/rax.png",a=0,b=1;function Index(){(0,_index.custom)(),this._updateChildProps("0",{source:{uri:img},c:a&&b,d:img?a:b}),this._updateData({_d0:img,_d1:a,_d2:b}),this._updateMethods({})}var __def__=Index;Component((0,_jsx2mpRuntime.createComponent)(__def__));'
     );
   });
 

--- a/packages/jsx2mp-cli/demo/component.js
+++ b/packages/jsx2mp-cli/demo/component.js
@@ -1,5 +1,5 @@
 import { createElement } from 'rax';
-import View from 'rax-view';
+import View, { custom } from 'rax-view';
 import Image from 'rax-image';
 import img from './assets/rax.png';
 
@@ -7,6 +7,7 @@ const a = 0;
 const b = 1;
 
 export default function Index() {
+  custom();
   return (
     <View>
       Hello World!


### PR DESCRIPTION
组件转成小程序代码时，会直接将 `import` 语句直接删掉，如果还有导出其他变量的话，会导致出错，应该只删除组件相关的变量

```js
import Loading, { showLoading, hideLoading } from 'loading';
=>
import { showLoading, hideLoading } from 'loading';
```
