### PR TITLE
fix: nested loop render

### DIFF
--- a/packages/jsx-compiler/src/modules/__tests__/jsx-plus.js
+++ b/packages/jsx-compiler/src/modules/__tests__/jsx-plus.js
@@ -45,16 +45,16 @@ describe('Directives', () => {
         .toEqual(`<View>
         <block a:for={array.map((item, index) => {
     return {
-      item: item.map((item2, index) => {
+      item: item.map((item2, index0) => {
         return {
           item2: item2,
-          index: index
+          index0: index0
         };
       }),
       index: index
     };
   })} a:for-item="item" a:for-index="index"><View>
-          <block a:for={item} a:for-item="item2" a:for-index="index"><View>{item2}
+          <block a:for={item} a:for-item="item2" a:for-index="index0"><View>{item2}
         </View></block>
       </View></block>
 </View>`);

--- a/packages/jsx-compiler/src/modules/components.js
+++ b/packages/jsx-compiler/src/modules/components.js
@@ -41,10 +41,16 @@ function transformIdentifierComponentName(path, alias, dynamicValue, parsed, opt
     let tagId = '' + tagCount++;
 
     if (parentJSXListEl) {
-      const { args } = parentJSXListEl.node.__jsxlist;
+      const { args, parentList } = parentJSXListEl.node.__jsxlist;
       const indexValue = args.length > 1 ? genExpression(args[1]) : 'index';
-      parentPath.node.__tagIdExpression = [tagId, new Expression(indexValue)];
-      tagId += '-{{' + indexValue + '}}';
+      if (parentList) {
+        const parentListIndexValue = parentList.args[1].name;
+        parentPath.node.__tagIdExpression = [tagId, parentListIndexValue, new Expression(indexValue)];
+        tagId += `-{{${parentListIndexValue}}}-{{${indexValue}}}`;
+      } else {
+        parentPath.node.__tagIdExpression = [tagId, new Expression(indexValue)];
+        tagId += `-{{${indexValue}}}`;
+      }
     }
     parentPath.node.__tagId = tagId;
     componentDependentProps[tagId] = componentDependentProps[tagId] || {};

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -628,6 +628,9 @@ function transformIdentifier(expression, dynamicBinding, isDirective) {
     itemNode.__listItem = {
       jsxplus: expression.__listItem.jsxplus,
     };
+    if (expression.name === expression.__listItem.originalIndex) {
+      expression.name = expression.__listItem.index;
+    }
     replaceNode = t.memberExpression(itemNode, expression);
   } else {
     const name = dynamicBinding.add({


### PR DESCRIPTION
```jsx
<View>
  <View
    x-for={(item1, index) in list}
    style={{
      width: "100rpx"
    }}
  >
    <View x-for={(v, index) in item1}>
      out: {index}
      <Test val={v} />
    </View>
  </View>
</View>
```
compiled to

```jsx
<block a:for="{{_d0}}" a:for-item="item1" a:for-index="index">
  <view style="{{_s0}}" class="__rax-view">
    <block a:for="{{item1.item1}}" a:for-item="v" a:for-index="index0">
      <view class="__rax-view">
      out: {{ v.index0 }}
      <c-89edce val="{{v.v}}" __parentId="{{__tagId}}" __tagId="5-{{index}}-{{index0}}" />
      </view>
    </block>
  </view>
</block>
```
