### PR TITLE
feat: rax-app support custom driver

### DIFF
--- a/packages/rax-app/package.json
+++ b/packages/rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-app",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Rax application framework for univesal app.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/rax-app/src/index.js
+++ b/packages/rax-app/src/index.js
@@ -1,10 +1,11 @@
 import { withRouter } from 'rax-use-router';
 import { useAppLaunch } from './app';
 import { usePageHide, usePageShow } from './page';
-import runApp from './runApp';
+import runApp, { setDriver } from './runApp';
 
 export {
   runApp,
+  setDriver,
   withRouter,
   useAppLaunch,
   usePageHide,

--- a/packages/rax-app/src/index.js
+++ b/packages/rax-app/src/index.js
@@ -1,11 +1,10 @@
 import { withRouter } from 'rax-use-router';
 import { useAppLaunch } from './app';
 import { usePageHide, usePageShow } from './page';
-import runApp, { setDriver } from './runApp';
+import runApp from './runApp';
 
 export {
   runApp,
-  setDriver,
   withRouter,
   useAppLaunch,
   usePageHide,

--- a/packages/rax-app/src/runApp.js
+++ b/packages/rax-app/src/runApp.js
@@ -19,10 +19,6 @@ export function getHistory() {
   return history;
 }
 
-export function setDriver(customDriver) {
-  driver = customDriver;
-}
-
 function App(props) {
   const { appConfig, history, routes, pageProps, InitialComponent } = props;
   const { component } = useRouter(() => ({ history, routes, InitialComponent }));
@@ -95,6 +91,11 @@ export default function runApp(appConfig, pageProps = {}) {
   }
   launched = true;
   const { hydrate = false, routes, shell } = appConfig;
+
+  // Set custom driver
+  if (typeof appConfig.driver !== 'undefined') {
+    driver = appConfig.driver;
+  }
 
   if (isWeex) {
     history = createMemoryHistory();

--- a/packages/rax-app/src/runApp.js
+++ b/packages/rax-app/src/runApp.js
@@ -12,10 +12,15 @@ const SHELL_DATA = 'shellData';
 
 let history;
 let launched = false;
+let driver = UniversalDriver;
 const initialDataFromSSR = global[INITIAL_DATA_FROM_SSR];
 
 export function getHistory() {
   return history;
+}
+
+export function setDriver(customDriver) {
+  driver = customDriver;
 }
 
 function App(props) {
@@ -131,7 +136,7 @@ export default function runApp(appConfig, pageProps = {}) {
       return render(
         appInstance,
         rootEl,
-        { driver: UniversalDriver, hydrate }
+        { driver, hydrate }
       );
     })
     .catch((err) => {


### PR DESCRIPTION
 rax-app support custom driver. RunApp default driver is `driver-universal`.

```jsx
import { runApp } from 'rax-app';
import appConfig from './app.json';
import * as DriverDOM from 'driver-dom';

appConfig.driver = DriverDOM;
runApp(appConfig);
```