### PR TITLE
fix: remove root el detect at DOM tree

### DIFF
--- a/packages/rax-app/package.json
+++ b/packages/rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-app",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Rax application framework for univesal app.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/rax-app/src/runApp.js
+++ b/packages/rax-app/src/runApp.js
@@ -131,7 +131,6 @@ export default function runApp(appConfig, pageProps = {}) {
       emit('launch');
 
       let rootEl = isWeex || isKraken ? null : document.getElementById('root');
-      if (isWeb && rootEl === null) throw new Error('Error: Can not find #root element, please check which exists in DOM.');
 
       // Async render.
       return render(

--- a/packages/rax-app/src/runApp.js
+++ b/packages/rax-app/src/runApp.js
@@ -131,7 +131,7 @@ export default function runApp(appConfig, pageProps = {}) {
       emit('launch');
 
       let rootEl = isWeex || isKraken ? null : document.getElementById('root');
-
+      if (isWeb && rootEl === null) console.warn('Error: Can not find #root element, please check which exists in DOM.');
       // Async render.
       return render(
         appInstance,


### PR DESCRIPTION
For root not exists, rax will fallback to document.body automatically.

