### PR TITLE
fix: jsx2mp template ast analyze

### DIFF
--- a/packages/jsx-compiler/src/modules/code.js
+++ b/packages/jsx-compiler/src/modules/code.js
@@ -76,7 +76,7 @@ module.exports = {
       const replacer = getReplacer(exportComponentPath);
       let { id, body } = exportComponentPath.node;
       if (!id) {
-        // Check fn is anonymity
+        // Check fn is anonymous
         if (exportComponentPath.isArrowFunctionExpression()
           && exportComponentPath.parentPath.isVariableDeclarator()) {
           id = exportComponentPath.parent.id;

--- a/packages/jsx-compiler/src/modules/template.js
+++ b/packages/jsx-compiler/src/modules/template.js
@@ -8,6 +8,8 @@ const genExpression = require('../codegen/genExpression');
 const createJSX = require('../utils/createJSX');
 const createBinding = require('../utils/createBinding');
 const findIndex = require('../utils/findIndex');
+const getExportComponentPath = require('../utils/getExportComponentPath');
+const getProgramPath = require('../utils/getProgramPath');
 
 const TEMPLATE_AST = 'templateAST';
 const RENDER_FN_PATH = 'renderFunctionPath';
@@ -17,13 +19,13 @@ const RENDER_FN_PATH = 'renderFunctionPath';
  */
 module.exports = {
   parse(parsed, code, options) {
-    const { defaultExportedPath } = parsed;
+    const { defaultExportedPath, ast } = parsed;
     if (!defaultExportedPath) return;
-
-    const renderFnPath = isFunctionComponent(defaultExportedPath)
-      ? defaultExportedPath
-      : isClassComponent(defaultExportedPath)
-        ? getRenderMethodPath(defaultExportedPath)
+    const exportComponentPath = parsed.exportComponentPath = getExportComponentPath(defaultExportedPath, getProgramPath(ast), code);
+    const renderFnPath = isFunctionComponent(exportComponentPath)
+      ? exportComponentPath
+      : isClassComponent(exportComponentPath)
+        ? getRenderMethodPath(exportComponentPath)
         : undefined;
     if (!renderFnPath) return;
 

--- a/packages/jsx-compiler/src/utils/getExportComponentPath.js
+++ b/packages/jsx-compiler/src/utils/getExportComponentPath.js
@@ -1,0 +1,36 @@
+const t = require('@babel/types');
+const CodeError = require('../utils/CodeError');
+
+/**
+ * @param export default path
+ * @param program path
+ * @param source code
+ * @return should be replaced path
+ * */
+module.exports = function(defaultExportedPath, programPath, code) {
+  const exportedNodeType = defaultExportedPath.node.type;
+  if (['ClassExpression', 'ClassDeclaration', 'FunctionDeclaration',
+    'ArrowFunctionExpression', 'FunctionExpression' ].includes(exportedNodeType)) {
+    return defaultExportedPath;
+  }
+  if (exportedNodeType === 'CallExpression') {
+    let exportComponentPath = defaultExportedPath;
+    // Only first param is component
+    const componentNode = defaultExportedPath.get('arguments')[0].node;
+    if (programPath.scope.hasBinding(componentNode.name)) {
+      programPath.traverse({
+        Declaration(path) {
+          const { node } = path;
+          if (node.id && t.isIdentifier(node.id, {
+            name: componentNode.name
+          })) {
+            exportComponentPath = path;
+          }
+        }
+      });
+    } else {
+      throw new CodeError(code, componentNode, componentNode.loc, 'Exported component is undefined');
+    }
+    return exportComponentPath;
+  }
+};


### PR DESCRIPTION
1. Support use anonymous fn as component
```jsx
const Todo = () => {
  return <View></View>
}

export default Todo;
```
2. Fix wrapper fn, like `handleComponent(Todo)`
```jsx
class Todo extends Component {
  render() {
      console.log(this.x);
      return <View>Todo</View>;
  }
}

function handleComponent(Com) {
  Com.prototype.x = 1;
  return Com;
}

export default handleComponent(Todo);
```