### PR TITLE
fix: reset PWA TabBar setting

### DIFF
--- a/packages/rax-pwa/package.json
+++ b/packages/rax-pwa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-pwa",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Rax pwa templates",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-pwa/src/TabBar/index.js
+++ b/packages/rax-pwa/src/TabBar/index.js
@@ -16,7 +16,7 @@ export default function TabBar(props) {
     // Have tabBar config
     typeof config === 'object' && Array.isArray(config.items)
     // Current page need show tabBar
-    && config.items.find(item => item.path === pathname);
+    && config.items.find(item => item.pagePath === pathname);
 
   const {
     backgroundColor = '#FFF',
@@ -37,7 +37,7 @@ export default function TabBar(props) {
       {showTabBar ? (
         <View style={{ ...styles.tabBar, backgroundColor }}>
           {items.map((item, index) => {
-            const selected = item.path === pathname;
+            const selected = item.pagePath === pathname;
             const itemTextColor = item.textColor || textColor;
             const itemSelectedColor = item.selectedColor || selectedColor;
             return (
@@ -46,11 +46,7 @@ export default function TabBar(props) {
                 style={styles.tabBarItem}
                 onClick={() => {
                   onClick && onClick(item);
-                  if (!item.path) {
-                    console.warn(`TabBar item ${item.name} need set path`);
-                  } else {
-                    history.push(item.path);
-                  }
+                  history.push(item.pagePath);
                 }}>
                 {selected && item.activeIcon ? (
                   <Image

--- a/packages/rax-pwa/src/__tests__/Navigation.js
+++ b/packages/rax-pwa/src/__tests__/Navigation.js
@@ -48,15 +48,15 @@ const testProps = {
       'items': [
         {
           'name': 'welcome',
-          'path': '/'
+          'pagePath': '/'
         },
         {
           'name': 'page1',
-          'path': '/page1'
+          'pagePath': '/page1'
         },
         {
           'name': 'page2',
-          'path': '/page2'
+          'pagePath': '/page2'
         }
       ]
     }

--- a/packages/rax-pwa/src/__tests__/TabBar.js
+++ b/packages/rax-pwa/src/__tests__/TabBar.js
@@ -22,15 +22,15 @@ const testProps = {
     items: [
       {
         'name': 'welcome',
-        'path': '/'
+        'pagePath': '/'
       },
       {
         'name': 'page1',
-        'path': '/page1'
+        'pagePath': '/page1'
       },
       {
         'name': 'page2',
-        'path': '/page2'
+        'pagePath': '/page2'
       }
     ]
   }


### PR DESCRIPTION
Support pagePath
```
{
  "tabbar":{
    "items": [
      "pagePath": "/"
    ]
  }
}
```