### PR TITLE
fix(jsx2mp): class method is not a render function

### DIFF
--- a/packages/jsx-compiler/src/modules/render-function.js
+++ b/packages/jsx-compiler/src/modules/render-function.js
@@ -24,6 +24,7 @@ function transformRenderFunction(ast, renderFnPath) {
             const renderFunctionPath = renderFnParentPath.get('body').find(path => path.isClassMethod()
               && path.node.key.name === methodName);
             const returnStatementPath = getReturnElementPath(renderFunctionPath);
+            if (!returnStatementPath) return;
             const returnArgumentPath = returnStatementPath.get('argument');
             if (!renderItemFunctions.some(fn => fn.originName === methodName)) {
               if (!returnArgumentPath.isJSXElement()) {


### PR DESCRIPTION
```jsx
class Parent extends Component {
  handleClick() {
    console.log('xxxx');
  }
  render() {
    return <View onClick={() => this.handleClick()}>123</View>;
  }
}
```
![image](https://user-images.githubusercontent.com/14757289/71397726-4df3f580-2659-11ea-8071-467fd9c2df5b.png)

