### PR TITLE
feat: import platform specific extensions

### DIFF
--- a/packages/jsx2mp-cli/getWebpackConfig.js
+++ b/packages/jsx2mp-cli/getWebpackConfig.js
@@ -17,6 +17,13 @@ const FileLoader = require.resolve('jsx2mp-loader/src/file-loader');
 const BabelLoader = require.resolve('babel-loader');
 let buildStartTime;
 
+function tenantizeExtensions(tenant, extensions) {
+  return [
+    ...(tenant ? extensions.map((ext) => `.${tenant}${ext}`) : []),
+    ...extensions,
+  ];
+}
+
 function getBabelConfig() {
   return {
     presets: [
@@ -141,7 +148,7 @@ module.exports = (options = {}) => {
       ],
     },
     resolve: {
-      extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
+      extensions: tenantizeExtensions(platform, ['.js', '.jsx', '.ts', '.tsx', '.json']),
       mainFields: ['main', 'module']
     },
     externals: [

--- a/packages/jsx2mp-cli/getWebpackConfig.js
+++ b/packages/jsx2mp-cli/getWebpackConfig.js
@@ -17,9 +17,9 @@ const FileLoader = require.resolve('jsx2mp-loader/src/file-loader');
 const BabelLoader = require.resolve('babel-loader');
 let buildStartTime;
 
-function tenantizeExtensions(tenant, extensions) {
+function getPlatformExtensions(platform, extensions) {
   return [
-    ...(tenant ? extensions.map((ext) => `.${tenant}${ext}`) : []),
+    ...platform ? extensions.map((ext) => `.${platform}${ext}`) : [],
     ...extensions,
   ];
 }
@@ -148,7 +148,7 @@ module.exports = (options = {}) => {
       ],
     },
     resolve: {
-      extensions: tenantizeExtensions(platform, ['.js', '.jsx', '.ts', '.tsx', '.json']),
+      extensions: getPlatformExtensions(platform, ['.js', '.jsx', '.ts', '.tsx', '.json']),
       mainFields: ['main', 'module']
     },
     externals: [

--- a/packages/jsx2mp-loader/src/component-loader.js
+++ b/packages/jsx2mp-loader/src/component-loader.js
@@ -26,7 +26,7 @@ module.exports = async function componentLoader(content) {
   const sourcePath = join(rootContext, dirname(entryPath));
 
   const relativeSourcePath = relative(sourcePath, this.resourcePath);
-  const distFileWithoutExt = removeExt(join(outputPath, relativeSourcePath));
+  const distFileWithoutExt = removeExt(join(outputPath, relativeSourcePath), platform.type);
 
   const isFromConstantDir = cached(isFromTargetDirs(absoluteConstantDir));
 

--- a/packages/jsx2mp-loader/src/page-loader.js
+++ b/packages/jsx2mp-loader/src/page-loader.js
@@ -59,7 +59,7 @@ module.exports = async function pageLoader(content) {
   const pageDistDir = dirname(targetFilePath);
   if (!existsSync(pageDistDir)) mkdirpSync(pageDistDir);
 
-  const distFileWithoutExt = removeExt(join(outputPath, relativeSourcePath));
+  const distFileWithoutExt = removeExt(join(outputPath, relativeSourcePath), platform.type);
 
   const config = Object.assign(pageConfig, transformed.config);
   if (Array.isArray(transformed.dependencies)) {

--- a/packages/jsx2mp-loader/src/utils/pathHelper.js
+++ b/packages/jsx2mp-loader/src/utils/pathHelper.js
@@ -1,8 +1,9 @@
 const { extname, sep } = require('path');
 
-function removeExt(path) {
+function removeExt(path, platform) {
   const ext = extname(path);
-  return path.slice(0, path.length - ext.length);
+  const extReg = new RegExp(`${platform ? `(.${platform})?` : ''}${ext}$`.replace(/\\./g, '\\.'));
+  return path.replace(extReg, '');
 }
 
 /**


### PR DESCRIPTION
在构建跨平台应用程序时，希望重复使用尽可能多的代码，但是还是会出现代码有所不同的场景。
所以提了该PR，通过自动按平台引入特有后缀的文件，来实现平台扩展。

`阿里小程序`: .ali.js ...
`微信小程序`: .wechat.js ...
`百度`: .baidu.js ...
`头条`: .tt.js ...

扩展后缀和 [platformConfig](https://github.com/alibaba/rax/blob/master/packages/jsx2mp-cli/utils/platformConfig.js) 的key一致