### PR TITLE
chore(jsx2mp): compatible with rax-text in wechat miniprogram

### DIFF
--- a/packages/jsx-compiler/src/adapter.js
+++ b/packages/jsx-compiler/src/adapter.js
@@ -18,6 +18,7 @@ const parserAdapters = {
       onLongPress: 'onLongTap',
       className: '__rax-view'
     },
+    compatibleText: false,
     // Need transform style & class keyword
     styleKeyword: false,
     // Need transform onClick -> bindonclick
@@ -43,6 +44,7 @@ const parserAdapters = {
       onTouchCancel: 'bindtouchcancel',
       className: '__rax-view'
     },
+    compatibleText: true,
     styleKeyword: true,
     needTransformEvent: true,
     slotScope: false

--- a/packages/jsx-compiler/src/modules/__tests__/rax-text.js
+++ b/packages/jsx-compiler/src/modules/__tests__/rax-text.js
@@ -1,0 +1,32 @@
+const { parse } = require('../rax-text');
+const { parseExpression } = require('../../parser');
+const adapter = require('../../adapter').ali;
+const wxAdapter = require('../../adapter').wechat;
+const genCode = require('../../codegen/genCode');
+
+describe('Transform rax-text', () => {
+  it('should transform rax-text children into __content props in wechat', () => {
+    const code = '<rax-text>{{_d0}}123</rax-text>';
+    const ast = parseExpression(code);
+    parse({
+      templateAST: ast
+    }, code, {
+      adapter: wxAdapter
+    });
+    expect(genCode(ast).code).toEqual(`<rax-text __content="{{ _d0 }}123">{{
+    _d0
+  }}123</rax-text>`);
+  });
+  it('should not transform rax-text children into __content props in ali', () => {
+    const code = '<rax-text>{{_d0}}123</rax-text>';
+    const ast = parseExpression(code);
+    parse({
+      templateAST: ast
+    }, code, {
+      adapter
+    });
+    expect(genCode(ast).code).toEqual(`<rax-text>{{
+    _d0
+  }}123</rax-text>`);
+  });
+});

--- a/packages/jsx-compiler/src/modules/index.js
+++ b/packages/jsx-compiler/src/modules/index.js
@@ -9,6 +9,8 @@ module.exports = [
   require('./css'),
   // Handle js code.
   require('./code'),
+  // Handle rax-text
+  require('./rax-text'),
   // Handle template attrs
   require('./element'),
   // Handle jsx attribute

--- a/packages/jsx-compiler/src/modules/rax-text.js
+++ b/packages/jsx-compiler/src/modules/rax-text.js
@@ -1,0 +1,36 @@
+const t = require('@babel/types');
+const traverse = require('../utils/traverseNodePath');
+const genExpression = require('../codegen/genExpression');
+
+function transformRaxText(ast) {
+  traverse(ast, {
+    JSXOpeningElement(path) {
+      const { node } = path;
+      const componentTagNode = node.name;
+      // For text content
+      if (componentTagNode.name === 'rax-text') {
+        node.attributes.push(
+          t.jsxAttribute(
+            t.jsxIdentifier('__content'),
+            t.stringLiteral(
+              path.parent.children.reduce((prev, next) => {
+                return prev + genExpression(next, {
+                  concise: true,
+                  comments: false,
+                });
+              }, '')
+            )
+          )
+        );
+      }
+    }
+  });
+}
+
+module.exports = {
+  parse(parsed, code, options) {
+    if (options.adapter.compatibleText) {
+      transformRaxText(parsed.templateAST);
+    }
+  }
+};


### PR DESCRIPTION
In wechat miniprogram, slot couldn't in text component.
```jsx
<Text>123</Text> => <Text __content="{{123}}">123</Text>
```