### PR TITLE
fix: update object data in component2

### DIFF
--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "main": "src/index.js",

--- a/packages/jsx2mp-runtime/package.json
+++ b/packages/jsx2mp-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-runtime",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Runtime for jsx2mp.",
   "miniprogram": {
     "ali": "dist/jsx2mp-runtime.ali.esm.js",

--- a/packages/jsx2mp-runtime/src/component.js
+++ b/packages/jsx2mp-runtime/src/component.js
@@ -341,7 +341,11 @@ export default class Component {
           useSpliceData[key] = [this.state[key].length, 0].concat(data[key].slice(this.state[key].length));
         } else {
           if (diffData(this.state[key], data[key])) {
-            useSetData[key] = data[key];
+            if (data[key].constructor.name === 'Object') {
+              useSetData[key] = Object.assign({}, this.state[key], data[key]);
+            } else {
+              useSetData[key] = data[key];
+            }
           }
         }
       }

--- a/packages/jsx2mp-runtime/src/component.js
+++ b/packages/jsx2mp-runtime/src/component.js
@@ -341,7 +341,7 @@ export default class Component {
           useSpliceData[key] = [this.state[key].length, 0].concat(data[key].slice(this.state[key].length));
         } else {
           if (diffData(this.state[key], data[key])) {
-            if (data[key].constructor.name === 'Object') {
+            if (Object.prototype.toString.call(data[key]) === '[object Object]') {
               useSetData[key] = Object.assign({}, this.state[key], data[key]);
             } else {
               useSetData[key] = data[key];


### PR DESCRIPTION
在支付宝小程序 component2 的模式下，更新一个对象的时候，小程序底层框架没有做数据合并，从而导致更新其中某一个 key 的时候，其它 key 变成 `undefined`