### PR TITLE
fix: x-slot render

### DIFF
--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.3.25",
+  "version": "0.3.27",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/src/modules/components.js
+++ b/packages/jsx-compiler/src/modules/components.js
@@ -43,14 +43,14 @@ function transformIdentifierComponentName(path, alias, dynamicValue, parsed, opt
     let tagId;
 
     if (!node.__slotChildEl) {
-      tagId = "" + tagCount;
+      tagId = '' + tagCount;
 
       const parentsJSXList = findParentsJSXListEl(path);
       if (parentsJSXList.length > 0) {
         parentPath.node.__tagIdExpression = [];
         for (let i = parentsJSXList.length - 1; i >= 0; i--) {
           const { args } = parentsJSXList[i].node.__jsxlist;
-          const indexValue = args.length > 1 ? genExpression(args[1]) : "index";
+          const indexValue = args.length > 1 ? genExpression(args[1]) : 'index';
           parentPath.node.__tagIdExpression.push(new Expression(indexValue));
           tagId += `-{{${indexValue}}}`;
         }
@@ -72,23 +72,21 @@ function transformIdentifierComponentName(path, alias, dynamicValue, parsed, opt
       if (baseComponents.indexOf(componentTag) < 0) {
         node.attributes.push(
           t.jsxAttribute(
-            t.jsxIdentifier("__parentId"),
-            t.stringLiteral("{{__tagId}}")
+            t.jsxIdentifier('__parentId'),
+            t.stringLiteral('{{__tagId}}')
           )
         );
       }
       tagId = '{{__tagId}}-' + tagId;
     } else {
-      console.log(node.__slotChildEl.scopeName);
       tagId = createBinding(
         genExpression(
           t.memberExpression(
             t.identifier(node.__slotChildEl.scopeName.value),
-            t.identifier("__tagId")
+            t.identifier('__tagId')
           )
         )
       );
-      console.log(tagId);
     }
 
     node.attributes.push(
@@ -175,7 +173,8 @@ function transformComponents(parsed, options) {
       const { node } = path;
       if (t.isJSXIdentifier(node.name)) {
         // <View/>
-        const alias = getComponentAlias(node.name.name, imported);
+        const componentTag = node.name.name;
+        const alias = getComponentAlias(componentTag, imported);
         if (alias) {
           removeImport(ast, alias);
           const componentTag = transformIdentifierComponentName(path, alias, dynamicValue, parsed, options);
@@ -183,6 +182,17 @@ function transformComponents(parsed, options) {
             // Collect renamed component tag & path info
             componentsAlias[componentTag] = alias;
           }
+        } else if (componentTag === 'slot') {
+          transformIdentifierComponentName(
+            path,
+            {
+              name: 'slot',
+              default: true
+            },
+            dynamicValue,
+            parsed,
+            options
+          );
         }
       } else if (t.isJSXMemberExpression(node.name)) {
         // <RecyclerView.Cell /> or <Context.Provider>

--- a/packages/jsx-compiler/src/modules/jsx-plus.js
+++ b/packages/jsx-compiler/src/modules/jsx-plus.js
@@ -295,7 +295,7 @@ function transformSlotDirective(ast, adapter) {
       const { node } = path;
       if (t.isJSXNamespacedName(node.name) && t.isJSXIdentifier(node.name.namespace, { name: 'x-slot'})) {
         const slotName = node.name.name;
-        const slotScopeName = node.value || "__defaultScopeName";
+        const slotScopeName = node.value || '__defaultScopeName';
         const parentJSXOpeningEl = path.parentPath.node;
 
         if (adapter.slotScope && slotScopeName) {


### PR DESCRIPTION
当 `x-slot` 模板被容器循环渲染的时候，模板本身在编译时不知道自己被循环，导致 `tagId` 重复，从而渲染异常