### PR TITLE
fix(driver-universal): import driver-miniapp by mistake

### DIFF
--- a/packages/driver-universal/package.json
+++ b/packages/driver-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "driver-universal",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Driver for Universal App.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/driver-universal/src/index.js
+++ b/packages/driver-universal/src/index.js
@@ -1,6 +1,6 @@
 import { isWeex, isWeb, isKraken, isMiniApp, isWeChatMiniProgram } from 'universal-env';
 import createDOMDriver from './dom';
-import * as MiniAppDriver from 'driver-miniapp';
+import MiniAppDriver from 'driver-miniapp';
 import * as WeexDriver from 'driver-weex';
 import createKrakenDriver from 'driver-kraken';
 


### PR DESCRIPTION
Since driver-miniapp use `export default` to export, driver-universal should import it correspondingly.