### PR TITLE
[WIP]refactor(jsx2mp): use addNativeEventListener instead of register by property

### DIFF
--- a/packages/jsx2mp-runtime/package.json
+++ b/packages/jsx2mp-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-runtime",
-  "version": "0.3.23",
+  "version": "0.4.0",
   "description": "Runtime for jsx2mp.",
   "miniprogram": {
     "ali": "dist/jsx2mp-runtime.ali.esm.js",

--- a/packages/jsx2mp-runtime/src/bridge.js
+++ b/packages/jsx2mp-runtime/src/bridge.js
@@ -9,7 +9,7 @@ import { __updateRouterMap } from './router';
 import getId from './getId';
 import { setPageInstance } from './pageInstanceMap';
 import { registerEventsInConfig } from './nativeEventListener';
-import nextTick from "./nextTick";
+import nextTick from './nextTick';
 
 const GET_DERIVED_STATE_FROM_PROPS = 'getDerivedStateFromProps';
 let _appConfig;

--- a/packages/jsx2mp-runtime/src/bridge.js
+++ b/packages/jsx2mp-runtime/src/bridge.js
@@ -9,6 +9,7 @@ import { __updateRouterMap } from './router';
 import getId from './getId';
 import { setPageInstance } from './pageInstanceMap';
 import { registerEventsInConfig } from './nativeEventListener';
+import nextTick from "./nextTick";
 
 const GET_DERIVED_STATE_FROM_PROPS = 'getDerivedStateFromProps';
 let _appConfig;

--- a/packages/jsx2mp-runtime/src/nativeEventListener.js
+++ b/packages/jsx2mp-runtime/src/nativeEventListener.js
@@ -9,7 +9,9 @@ export function registerEventsInConfig(Klass, events = []) {
   }
   events.forEach(eventName => {
     eventBindTarget[eventName] = function(...args) {
-      Klass.prototype.__nativeEventQueue[eventName].forEach(callback => callback(...args));
+      if (Klass.prototype.__nativeEventQueue[eventName]) {
+        Klass.prototype.__nativeEventQueue[eventName].forEach(callback => callback(...args));
+      }
     };
   });
 }


### PR DESCRIPTION
小程序原生生命周期 break change:
1. 移除在 class component 上注册监听
2. 移除大量小程序专属的 hooks，如 `usePageAppShare`
3. 支持通过 `addNativeEventListener` `removeNativeEventListener` 等更加灵活的处理原生事件
