### PR TITLE
refactor(jsx2mp): native event bind

### DIFF
--- a/packages/jsx2mp-runtime/package.json
+++ b/packages/jsx2mp-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-runtime",
-  "version": "0.3.23",
+  "version": "0.4.0",
   "description": "Runtime for jsx2mp.",
   "miniprogram": {
     "ali": "dist/jsx2mp-runtime.ali.esm.js",

--- a/packages/jsx2mp-runtime/src/adapter/getNativeEventBindTarget.js
+++ b/packages/jsx2mp-runtime/src/adapter/getNativeEventBindTarget.js
@@ -1,10 +1,10 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { isMiniApp } from 'universal-env';
 
-export default function(Klass) {
+export default function(Klass, isShareAppMessage) {
   // For alibaba miniapp
   if (isMiniApp) {
-    return Klass.__config.events;
+    return isShareAppMessage ? Klass.__config : Klass.__config.events;
   } else {
     return Klass.__config;
   }

--- a/packages/jsx2mp-runtime/src/adapter/getNativeEventBindTarget.js
+++ b/packages/jsx2mp-runtime/src/adapter/getNativeEventBindTarget.js
@@ -1,10 +1,10 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { isMiniApp } from 'universal-env';
 
-export default function(Klass, isShareAppMessage) {
+export default function(Klass, returnConfig) {
   // For alibaba miniapp
   if (isMiniApp) {
-    return isShareAppMessage ? Klass.__config : Klass.__config.events;
+    return returnConfig ? Klass.__config : Klass.__config.events;
   } else {
     return Klass.__config;
   }

--- a/packages/jsx2mp-runtime/src/adapter/getNativeEventBindTarget.js
+++ b/packages/jsx2mp-runtime/src/adapter/getNativeEventBindTarget.js
@@ -1,10 +1,10 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { isMiniApp } from 'universal-env';
 
-export default function(Klass, returnConfig) {
+export default function(Klass, shouldReturnConfig) {
   // For alibaba miniapp
   if (isMiniApp) {
-    return returnConfig ? Klass.__config : Klass.__config.events;
+    return shouldReturnConfig ? Klass.__config : Klass.__config.events;
   } else {
     return Klass.__config;
   }

--- a/packages/jsx2mp-runtime/src/component.js
+++ b/packages/jsx2mp-runtime/src/component.js
@@ -240,7 +240,7 @@ export default class Component {
       if (isFunction(hook.destory)) hook.destory();
     });
     // Clean up page cycle callbacks
-    this.__proto__.__nativeEventQueue = {};
+    this.__proto__.__nativeEventMap = {};
     this._internal.instance = null;
     this._internal = null;
     this.__mounted = false;

--- a/packages/jsx2mp-runtime/src/component.js
+++ b/packages/jsx2mp-runtime/src/component.js
@@ -11,12 +11,6 @@ import {
   RENDER,
   ON_SHOW,
   ON_HIDE,
-  ON_PAGE_SCROLL,
-  ON_REACH_BOTTOM,
-  ON_PULL_DOWN_REFRESH,
-  ON_SHARE_APP_MESSAGE,
-  ON_TAB_ITEM_TAP,
-  ON_TITLE_CLICK,
   COMPONENT_DID_MOUNT,
   COMPONENT_DID_UPDATE,
   COMPONENT_WILL_MOUNT,
@@ -245,6 +239,8 @@ export default class Component {
     this.hooks.forEach(hook => {
       if (isFunction(hook.destory)) hook.destory();
     });
+    // Clean up page cycle callbacks
+    this.__proto__.__nativeEventQueue = {};
     this._internal.instance = null;
     this._internal = null;
     this.__mounted = false;
@@ -258,7 +254,6 @@ export default class Component {
    * @private
    */
   _trigger(cycle, ...args) {
-    let ret;
     const pageId = this.instanceId;
 
     switch (cycle) {
@@ -270,11 +265,6 @@ export default class Component {
       case COMPONENT_WILL_UNMOUNT:
       case ON_SHOW:
       case ON_HIDE:
-      case ON_PAGE_SCROLL:
-      case ON_REACH_BOTTOM:
-      case ON_TAB_ITEM_TAP:
-      case ON_TITLE_CLICK:
-      case ON_PULL_DOWN_REFRESH:
         if (isFunction(this[cycle])) this[cycle](...args);
         if (this._cycles.hasOwnProperty(cycle)) {
           this._cycles[cycle].forEach(fn => fn(...args));
@@ -295,17 +285,7 @@ export default class Component {
 
         this.render(this.props = nextProps, this.state = nextState);
         break;
-
-      case ON_SHARE_APP_MESSAGE:
-        if (isFunction(this[cycle])) ret = this[cycle](...args);
-        if (pageCycles[pageId] && pageCycles[pageId][cycle]) {
-          // There will be one callback fn for shareAppMessage at most
-          const fn = pageCycles[pageId][cycle][0];
-          ret = fn(...args);
-        }
-        break;
     }
-    return ret;
   }
 
   /**

--- a/packages/jsx2mp-runtime/src/cycles.js
+++ b/packages/jsx2mp-runtime/src/cycles.js
@@ -7,13 +7,6 @@ export const COMPONENT_WILL_RECEIVE_PROPS = 'componentWillReceiveProps';
 export const COMPONENT_WILL_UPDATE = 'componentWillUpdate';
 export const COMPONENT_DID_UPDATE = 'componentDidUpdate';
 
-// Page only
-export const ON_PAGE_SCROLL = 'onPageScroll';
-export const ON_REACH_BOTTOM = 'onReachBottom';
-export const ON_PULL_DOWN_REFRESH = 'onPullDownRefresh';
-export const ON_TAB_ITEM_TAP = 'onTabItemTap';
-export const ON_TITLE_CLICK = 'onTitleClick';
-
 // App only
 export const ON_LAUNCH = 'launch';
 export const ON_ERROR = 'onError';

--- a/packages/jsx2mp-runtime/src/hooks.js
+++ b/packages/jsx2mp-runtime/src/hooks.js
@@ -262,11 +262,3 @@ export function useReducer(reducer, initialArg, init) {
   queue.actions.length = 0;
   return hooks[hookID];
 }
-
-export function useHistory() {
-  return history;
-}
-
-export function useLocation() {
-  return history.location;
-}

--- a/packages/jsx2mp-runtime/src/index.js
+++ b/packages/jsx2mp-runtime/src/index.js
@@ -1,24 +1,13 @@
 import { runApp, createComponent, createPage } from './bridge';
-import { useAppEffect, useAppLaunch, useAppShow, useAppHide, useAppShare, useAppError } from './app';
-import {
-  usePageEffect,
-  usePageShow,
-  usePageHide,
-  usePagePullDownRefresh,
-  usePageReachBottom,
-  usePageScroll,
-  useShareAppMessage,
-  usePageShare,
-  useTabItemTap,
-  useTitleClick
-} from './page';
+import { useAppLaunch, useAppShow, useAppHide, useAppShare, useAppError } from './app';
+import { usePageShow, usePageHide} from './page';
 import { withRouter } from './router';
 import Component from './component';
 import createStyle from './createStyle';
 import createContext from './createContext';
 import classnames from './classnames';
 import createRef from './createRef';
-import { addNativeEventListener, registerNativeEventListeners } from './nativeEventListener';
+import { addNativeEventListener, removeNativeEventListener, registerNativeEventListeners } from './nativeEventListener';
 
 export {
   runApp,
@@ -40,23 +29,13 @@ export {
 
   usePageShow,
   usePageHide,
-  usePagePullDownRefresh,
-  usePageReachBottom,
-  usePageScroll,
-  useShareAppMessage,
-  usePageShare,
-  useTabItemTap,
-  useTitleClick,
-
-  // Compatible old version of cycles.
-  useAppEffect,
-  usePageEffect,
 
   // Router
   withRouter,
 
   // Native events
   addNativeEventListener,
+  removeNativeEventListener,
   registerNativeEventListeners
 };
 

--- a/packages/jsx2mp-runtime/src/nativeEventListener.js
+++ b/packages/jsx2mp-runtime/src/nativeEventListener.js
@@ -4,8 +4,8 @@ import getNativeEventBindTarget from './adapter/getNativeEventBindTarget';
 import { ON_SHARE_APP_MESSAGE } from './cycles';
 
 export function registerEventsInConfig(Klass, events = []) {
-  if (!Klass.prototype.__nativeEventQueue) {
-    Klass.prototype.__nativeEventQueue = {};
+  if (!Klass.prototype.__nativeEventMap) {
+    Klass.prototype.__nativeEventMap = {};
   }
   events.forEach(eventName => {
     const shouldReturnConfig = eventName !== ON_SHARE_APP_MESSAGE;
@@ -13,8 +13,8 @@ export function registerEventsInConfig(Klass, events = []) {
     eventBindTarget[eventName] = function(...args) {
       // onShareAppMessage need receive callback execute return
       let ret;
-      if (Klass.prototype.__nativeEventQueue[eventName]) {
-        Klass.prototype.__nativeEventQueue[eventName].forEach(callback => ret = callback(...args));
+      if (Klass.prototype.__nativeEventMap[eventName]) {
+        Klass.prototype.__nativeEventMap[eventName].forEach(callback => ret = callback(...args));
       }
       return ret;
     };
@@ -28,16 +28,16 @@ export function registerNativeEventListeners(component, events) {
 
 export function addNativeEventListener(eventName, callback) {
   const pageInstance = getPageInstance();
-  if (!pageInstance.__proto__.__nativeEventQueue[eventName]) {
-    pageInstance.__proto__.__nativeEventQueue[eventName] = [];
+  if (!pageInstance.__proto__.__nativeEventMap[eventName]) {
+    pageInstance.__proto__.__nativeEventMap[eventName] = [];
   }
-  pageInstance.__proto__.__nativeEventQueue[eventName].push(callback);
+  pageInstance.__proto__.__nativeEventMap[eventName].push(callback);
 }
 
 export function removeNativeEventListener(eventName, callback) {
   const pageInstance = getPageInstance();
-  if (pageInstance.__proto__.__nativeEventQueue[eventName]) {
-    pageInstance.__proto__.__nativeEventQueue[eventName] = pageInstance.__proto__.__nativeEventQueue[eventName].filter(fn => fn !== callback);
+  if (pageInstance.__proto__.__nativeEventMap[eventName]) {
+    pageInstance.__proto__.__nativeEventMap[eventName] = pageInstance.__proto__.__nativeEventMap[eventName].filter(fn => fn !== callback);
   }
 }
 

--- a/packages/jsx2mp-runtime/src/nativeEventListener.js
+++ b/packages/jsx2mp-runtime/src/nativeEventListener.js
@@ -8,8 +8,8 @@ export function registerEventsInConfig(Klass, events = []) {
     Klass.prototype.__nativeEventQueue = {};
   }
   events.forEach(eventName => {
-    const isShareAppMessage = eventName === ON_SHARE_APP_MESSAGE;
-    const eventBindTarget = getNativeEventBindTarget(Klass, isShareAppMessage);
+    const returnConfig = eventName !== ON_SHARE_APP_MESSAGE;
+    const eventBindTarget = getNativeEventBindTarget(Klass, returnConfig);
     eventBindTarget[eventName] = function(...args) {
       // onShareAppMessage need receive callback execute return
       let ret;

--- a/packages/jsx2mp-runtime/src/nativeEventListener.js
+++ b/packages/jsx2mp-runtime/src/nativeEventListener.js
@@ -8,8 +8,8 @@ export function registerEventsInConfig(Klass, events = []) {
     Klass.prototype.__nativeEventQueue = {};
   }
   events.forEach(eventName => {
-    const returnConfig = eventName !== ON_SHARE_APP_MESSAGE;
-    const eventBindTarget = getNativeEventBindTarget(Klass, returnConfig);
+    const shouldReturnConfig = eventName !== ON_SHARE_APP_MESSAGE;
+    const eventBindTarget = getNativeEventBindTarget(Klass, shouldReturnConfig);
     eventBindTarget[eventName] = function(...args) {
       // onShareAppMessage need receive callback execute return
       let ret;

--- a/packages/jsx2mp-runtime/src/nativeEventListener.js
+++ b/packages/jsx2mp-runtime/src/nativeEventListener.js
@@ -1,29 +1,48 @@
 import { getMiniAppHistory } from './history';
-import { getPageInstance } from './pageInstanceMap';
+import { getPageInstanceById } from './pageInstanceMap';
 import getNativeEventBindTarget from './adapter/getNativeEventBindTarget';
+import { ON_SHARE_APP_MESSAGE } from './cycles';
 
 export function registerEventsInConfig(Klass, events = []) {
-  const eventBindTarget = getNativeEventBindTarget(Klass);
   if (!Klass.prototype.__nativeEventQueue) {
     Klass.prototype.__nativeEventQueue = {};
   }
   events.forEach(eventName => {
+    const isShareAppMessage = eventName === ON_SHARE_APP_MESSAGE;
+    const eventBindTarget = getNativeEventBindTarget(Klass, isShareAppMessage);
     eventBindTarget[eventName] = function(...args) {
-      Klass.prototype.__nativeEventQueue[eventName].forEach(callback => callback(...args));
+      // onShareAppMessage need receive callback execute return
+      let ret;
+      if (Klass.prototype.__nativeEventQueue[eventName]) {
+        Klass.prototype.__nativeEventQueue[eventName].forEach(callback => ret = callback(...args));
+      }
+      return ret;
     };
   });
 }
 
 export function registerNativeEventListeners(component, events) {
   component.__nativeEvents = events;
+  return component;
 }
 
 export function addNativeEventListener(eventName, callback) {
-  const history = getMiniAppHistory();
-  const pageId = history.location._pageId;
-  const pageInstance = getPageInstance(pageId);
+  const pageInstance = getPageInstance();
   if (!pageInstance.__proto__.__nativeEventQueue[eventName]) {
     pageInstance.__proto__.__nativeEventQueue[eventName] = [];
   }
   pageInstance.__proto__.__nativeEventQueue[eventName].push(callback);
+}
+
+export function removeNativeEventListener(eventName, callback) {
+  const pageInstance = getPageInstance();
+  if (pageInstance.__proto__.__nativeEventQueue[eventName]) {
+    pageInstance.__proto__.__nativeEventQueue[eventName] = pageInstance.__proto__.__nativeEventQueue[eventName].filter(fn => fn !== callback);
+  }
+}
+
+function getPageInstance() {
+  const history = getMiniAppHistory();
+  const pageId = history.location._pageId;
+  return getPageInstanceById(pageId);
 }

--- a/packages/jsx2mp-runtime/src/page.js
+++ b/packages/jsx2mp-runtime/src/page.js
@@ -2,16 +2,10 @@ import isFunction from './isFunction';
 import {
   ON_SHOW,
   ON_HIDE,
-  ON_PAGE_SCROLL,
-  ON_SHARE_APP_MESSAGE,
-  ON_REACH_BOTTOM,
-  ON_PULL_DOWN_REFRESH,
-  ON_TAB_ITEM_TAP,
-  ON_TITLE_CLICK
 } from './cycles';
 import { useEffect } from './hooks';
 import { getMiniAppHistory } from './history';
-import { getPageInstance } from './pageInstanceMap';
+import { getPageInstanceById } from './pageInstanceMap';
 
 const history = getMiniAppHistory();
 
@@ -22,12 +16,6 @@ export function usePageEffect(cycle, callback) {
     switch (cycle) {
       case ON_SHOW:
       case ON_HIDE:
-      case ON_PAGE_SCROLL:
-      case ON_SHARE_APP_MESSAGE:
-      case ON_REACH_BOTTOM:
-      case ON_PULL_DOWN_REFRESH:
-      case ON_TAB_ITEM_TAP:
-      case ON_TITLE_CLICK:
         const pageId = history && history.location._pageId;
         useEffect(() => {
           if (!cycles[pageId]) {
@@ -36,14 +24,10 @@ export function usePageEffect(cycle, callback) {
           if (!cycles[pageId][cycle]) {
             cycles[pageId][cycle] = [];
           }
-          if (cycle === ON_SHARE_APP_MESSAGE && cycles[pageId][cycle].length > 1) {
-            console.warn('useShareAppMessage can only receive one callback function.');
-          } else {
-            cycles[pageId][cycle].push(callback);
-          }
+          cycles[pageId][cycle].push(callback);
 
           // Define page instance life cycle when the cycle is used
-          const pageInstance = getPageInstance(pageId);
+          const pageInstance = getPageInstanceById(pageId);
           if (!pageInstance._internal[cycle]) {
             pageInstance._internal[cycle] = (e) => {
               return pageInstance._trigger(cycle, e);
@@ -63,33 +47,4 @@ export function usePageShow(callback) {
 
 export function usePageHide(callback) {
   return usePageEffect(ON_HIDE, callback);
-}
-
-export function usePageScroll(callback) {
-  return usePageEffect(ON_PAGE_SCROLL, callback);
-}
-
-export function useShareAppMessage(callback) {
-  console.warn('useShareAppMessage() will be deprecated soon, please use usePageShare() instead.');
-  return usePageEffect(ON_SHARE_APP_MESSAGE, callback);
-}
-
-export function usePageShare(callback) {
-  return usePageEffect(ON_SHARE_APP_MESSAGE, callback);
-}
-
-export function usePageReachBottom(callback) {
-  return usePageEffect(ON_REACH_BOTTOM, callback);
-}
-
-export function usePagePullDownRefresh(callback) {
-  return usePageEffect(ON_PULL_DOWN_REFRESH, callback);
-}
-
-export function useTabItemTap(callback) {
-  return usePageEffect(ON_TAB_ITEM_TAP, callback);
-}
-
-export function useTitleClick(callback) {
-  return usePageEffect(ON_TITLE_CLICK, callback);
 }

--- a/packages/jsx2mp-runtime/src/pageInstanceMap.js
+++ b/packages/jsx2mp-runtime/src/pageInstanceMap.js
@@ -8,7 +8,7 @@ export function setPageInstance(pageInstance) {
 }
 
 
-export function getPageInstance(pageId) {
+export function getPageInstanceById(pageId) {
   if (pageInstanceMap.hasOwnProperty(pageId)) {
     return pageInstanceMap[pageId];
   }


### PR DESCRIPTION
小程序原生生命周期 break change:

- 移除在 class component 上注册监听
- 移除大量小程序专属的 hooks，如 usePageAppShare, useLocation
- 支持通过 `addNativeEventListener` `removeNativeEventListener` 等更加灵活的处理原生事件