### PR TITLE
fix(jsx2mp): functional component properties bind

### DIFF
--- a/packages/jsx2mp-runtime/src/bridge.js
+++ b/packages/jsx2mp-runtime/src/bridge.js
@@ -138,11 +138,16 @@ function createProxyMethods(events) {
 }
 
 function createAnonymousClass(render) {
-  return class extends Component {
+  const Klass = class extends Component {
     render(props) {
       return render.call(this, props);
     }
   };
+  // Set functional component properties to the Klass
+  Object.keys(render).forEach(key => {
+    Klass[key] = render[key];
+  });
+  return Klass;
 }
 
 /**

--- a/packages/jsx2mp-runtime/src/bridge.js
+++ b/packages/jsx2mp-runtime/src/bridge.js
@@ -67,9 +67,10 @@ function getPageCycles(Klass) {
 function getComponentCycles(Klass) {
   return getNativeComponentLifecycle({
     mount: function() {
-      const { instanceId, props } = generateBaseOptions(this, Klass.defaultProps);
+      const { instanceId, props } = generateBaseOptions(this, Klass.defaultProps, Klass.__highestLevelProps);
       this.instance = new Klass(props);
-      this.instance.defaultProps = Klass.defaultProps;
+      this.instance.defaultProps = Klass.defaultProps || {};
+      this.instance.__highestLevelProps = Klass.__highestLevelProps;
       this.instance.instanceId = instanceId;
       this.instance.type = Klass;
       this.instance._internal = this;

--- a/packages/jsx2mp-runtime/src/router.js
+++ b/packages/jsx2mp-runtime/src/router.js
@@ -34,17 +34,19 @@ export function __updateRouterMap(appConfig) {
 /**
  * With router decorator.
  * Inject history and location.
- * @param Klass
+ * @param Component
  */
-export function withRouter(Klass) {
-  if (Klass) Klass.props = Klass.props || {};
+export function withRouter(Component) {
+  if (!Component.defaultProps) {
+    Component.defaultProps = {};
+  }
   const history = getMiniAppHistory();
-  Object.assign(Klass.props, {
+  Object.assign(Component.defaultProps, {
     history: history,
     location: history.location,
   });
 
-  return Klass;
+  return Component;
 }
 
 /**

--- a/packages/jsx2mp-runtime/src/router.js
+++ b/packages/jsx2mp-runtime/src/router.js
@@ -37,11 +37,11 @@ export function __updateRouterMap(appConfig) {
  * @param Component
  */
 export function withRouter(Component) {
-  if (!Component.defaultProps) {
-    Component.defaultProps = {};
+  if (!Component.__highestLevelProps) {
+    Component.__highestLevelProps = {};
   }
   const history = getMiniAppHistory();
-  Object.assign(Component.defaultProps, {
+  Object.assign(Component.__highestLevelProps, {
     history: history,
     location: history.location,
   });

--- a/packages/jsx2mp-runtime/src/updater.js
+++ b/packages/jsx2mp-runtime/src/updater.js
@@ -50,6 +50,7 @@ export function updateChildProps(trigger, instanceId, nextUpdateProps) {
         },
         targetComponent.props,
         nextUpdateProps,
+        targetComponent.__highestLevelProps
       );
       if (targetComponent.__mounted) {
         targetComponent.nextProps = nextPropsMap[instanceId] = nextProps;


### PR DESCRIPTION
1. Fix `withRouter` bind `history`/`location` to `props`
```jsx
import { createElement } from "rax";
import View from "rax-view";
import Text from "rax-text";
import { withRouter } from 'rax-app';

function SubView(props) {
  return (
    <View>
      <Text>test</Text>
    </View>
  );
}

export default withRouter(SubView)
```
2. Fix component property bind, like `Component.defaultProps = {}`