### PR TITLE
Feat(jsx2mp): list render

### DIFF
--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.3.30",
+  "version": "0.3.31",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.3.31-1",
+  "version": "0.3.31",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.3.31",
+  "version": "0.3.31-1",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/src/modules/__tests__/jsx-plus.js
+++ b/packages/jsx-compiler/src/modules/__tests__/jsx-plus.js
@@ -10,6 +10,7 @@ const genExpression = require('../../codegen/genExpression');
 const adapter = require('../../adapter').ali;
 
 let count = 0;
+let id = 0;
 
 describe('Directives', () => {
   describe('list', () => {
@@ -179,17 +180,18 @@ describe('Directives', () => {
       expect(genExpression(ast)).toEqual(`<View>
         <block a:for={data.map((item, ${index}) => {
     this._registerRefs([{
-      "name": "0" + "${index}",
+      "name": "${id}" + "${index}",
       "method": refs[${index}]
     }]);
 
     return {
       item: item,
       ${index}: ${index},
-      _d0: "0" + "${index}"
+      _d0: "${id}" + "${index}"
     };
   })} a:for-item="item" a:for-index="${index}"><View ref="{{item._d0}}">test</View></block>
       </View>`);
+      id++;
     });
   });
 
@@ -209,16 +211,16 @@ describe('Directives', () => {
         <block a:for={data.map((item, ${index1}) => {
     return {
       item: { ...item,
-        list: item.list.map((item, index1) => {
+        list: item.list.map((item, ${index2}) => {
           this._registerRefs([{
-            "name": "0" + "${index2}",
+            "name": "${id}" + "${index2}",
             "method": refs[${index2}]
           }]);
 
           return {
             item: item,
             ${index2}: ${index2},
-            _d0: "0" + "${index2}"
+            _d0: "${id}" + "${index2}"
           };
         })
       },
@@ -228,5 +230,6 @@ describe('Directives', () => {
             <block a:for={item.list} a:for-item="item" a:for-index="${index2}"><View ref="{{item._d0}}">test</View></block>
         </View></block>
       </View>`);
+    id++;
   });
 });

--- a/packages/jsx-compiler/src/modules/__tests__/jsx-plus.js
+++ b/packages/jsx-compiler/src/modules/__tests__/jsx-plus.js
@@ -146,7 +146,7 @@ describe('Directives', () => {
         <View className="home" x-class={classNames}></View>
       `);
       _transformClass(ast, adapter);
-      expect(genExpression(ast)).toEqual('<View className={"home" + " " + __classnames__(classNames)}></View>');
+      expect(genExpression(ast)).toEqual('<View className={`home${" "}${__classnames__(classNames)}`}></View>');
     });
   });
 

--- a/packages/jsx-compiler/src/modules/__tests__/jsx-plus.js
+++ b/packages/jsx-compiler/src/modules/__tests__/jsx-plus.js
@@ -165,4 +165,68 @@ describe('Directives', () => {
       expect(genExpression(ast)).toEqual('<View slot="item" slot-scope="__defaultScopeName">{props.text}</View>');
     });
   });
+
+  describe('ref', () => {
+    it('should transform ref in x-for', () => {
+      const code = `<View>
+        <View x-for={(item, index) in data} ref={refs[index]}>test</View>
+      </View>`;
+      const ast = parseExpression(code);
+      _transformList({
+        templateAST: ast
+      }, code, adapter);
+      const index = 'index' + count++;
+      expect(genExpression(ast)).toEqual(`<View>
+        <block a:for={data.map((item, ${index}) => {
+    this._registerRefs([{
+      "name": "0" + "${index}",
+      "method": refs[${index}]
+    }]);
+
+    return {
+      item: item,
+      ${index}: ${index},
+      _d0: "0" + "${index}"
+    };
+  })} a:for-item="item" a:for-index="${index}"><View ref="{{item._d0}}">test</View></block>
+      </View>`);
+    });
+  });
+
+  it('should transform ref in nested x-for', () => {
+    const code = `<View>
+        <View x-for={(item, index) in data}>
+            <View x-for={(item, idx) in item.list} ref={refs[idx]}>test</View>
+        </View>
+      </View>`;
+    const ast = parseExpression(code);
+    _transformList({
+      templateAST: ast
+    }, code, adapter);
+    const index1 = 'index' + count++;
+    const index2 = 'index' + count++;
+    expect(genExpression(ast)).toEqual(`<View>
+        <block a:for={data.map((item, ${index1}) => {
+    return {
+      item: { ...item,
+        list: item.list.map((item, index1) => {
+          this._registerRefs([{
+            "name": "0" + "${index2}",
+            "method": refs[${index2}]
+          }]);
+
+          return {
+            item: item,
+            ${index2}: ${index2},
+            _d0: "0" + "${index2}"
+          };
+        })
+      },
+      ${index1}: ${index1}
+    };
+  })} a:for-item="item" a:for-index="${index1}"><View>
+            <block a:for={item.list} a:for-item="item" a:for-index="${index2}"><View ref="{{item._d0}}">test</View></block>
+        </View></block>
+      </View>`);
+  });
 });

--- a/packages/jsx-compiler/src/modules/__tests__/list.js
+++ b/packages/jsx-compiler/src/modules/__tests__/list.js
@@ -61,10 +61,9 @@ describe('Transform list', () => {
       ${index}: ${index},
       _d0: {
         uri: item.picUrl
-      },
-      _d1: resizeMode
+      }
     };
-  })} a:for-item="item" a:for-index="${index}"><View>{item.title}<image source="{{item._d0}}" resizeMode="{{item._d1}}" /></View></block></View>`);
+  })} a:for-item="item" a:for-index="${index}"><View>{item.title}<image source="{{item._d0}}" resizeMode={resizeMode} /></View></block></View>`);
   });
 
   it('list elements', () => {
@@ -212,5 +211,25 @@ describe('Transform list', () => {
       ${index}: ${index}
     };
   })} a:for-item="item" a:for-index="${index}"><Text>test</Text></block></View>`);
+  });
+
+  it('use expression in map fn', () => {
+    const code = `<View>{[1,2,3].map((item, index) => {
+      const a = index * 2 + 10;
+      return <Text>{a}</Text>;
+    })}</View>`;
+    const ast = parseExpression(code);
+    _transformList({
+      templateAST: ast
+    }, code, adapter);
+    const index = 'index' + count++;
+    expect(genCode(ast).code).toEqual(`<View><block a:for={[1, 2, 3].map((item, ${index}) => {
+    const a = ${index} * 2 + 10;
+    return {
+      item: item,
+      ${index}: ${index},
+      a: a
+    };
+  })} a:for-item="item" a:for-index="${index}"><Text>{a}</Text></block></View>`);
   });
 });

--- a/packages/jsx-compiler/src/modules/code.js
+++ b/packages/jsx-compiler/src/modules/code.js
@@ -7,6 +7,7 @@ const isFunctionComponent = require('../utils/isFunctionComponent');
 const traverse = require('../utils/traverseNodePath');
 const { isNpmModule, isWeexModule } = require('../utils/checkModule');
 const { getNpmName, normalizeFileName, addRelativePathPrefix } = require('../utils/pathHelper');
+const { BINDING_REG } = require('../utils/checkAttr');
 
 const RAX_PACKAGE = 'rax';
 const SUPER_COMPONENT = 'Component';
@@ -527,7 +528,10 @@ function addRegisterRefs(refs, renderFunctionPath) {
   const stringRefs = [];
   refs.map(ref => {
     if (t.isStringLiteral(ref.method)) {
-      stringRefs.push(ref);
+      // Exclude expressions that have already been processed
+      if (!BINDING_REG.test(ref.method.value)) {
+        stringRefs.push(ref);
+      }
     } else if (t.isIdentifier(ref.method) && !renderFunctionPath.scope.hasBinding(ref.name.value)) {
       stringRefs.push(ref);
     } else {

--- a/packages/jsx-compiler/src/modules/condition.js
+++ b/packages/jsx-compiler/src/modules/condition.js
@@ -4,7 +4,6 @@ const createJSX = require('../utils/createJSX');
 const CodeError = require('../utils/CodeError');
 const chalk = require('chalk');
 const handleValidIdentifier = require('../utils/handleValidIdentifier');
-const genExpression = require('../codegen/genExpression');
 
 const TEMPLATE_AST = 'templateAST';
 const RENDER_FN_PATH = 'renderFunctionPath';

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -734,6 +734,14 @@ function collectComponentDependentProps(path, attrValue, attrPath, componentDepe
     && attrValue.type
     && jsxEl.__tagId
   ) {
+    // Replace list render replaced node
+    traverse(attrPath, {
+      StringLiteral(innerPath) {
+        if (BINDING_REG.test(innerPath.node.value)) {
+          attrValue = innerPath.node.__originalExpression;
+        }
+      }
+    });
     if (attrPath) {
       attrValue = parseExpression('(' + attrPath.toString() + ')'); // deep clone
     }

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -280,12 +280,8 @@ function transformTemplate(
 
       // <tag foo={fn()} /> => <tag foo="{{_d0}} /> _d0 = fn();
       // <tag>{fn()}</tag> => <tag>{{ _d0 }}</tag> _d0 = fn();
-      // <tag x-for={item in items}>{fn(item)}</tag> => <tag a:for={item in items}>{{ item._f0 }}</tag> item._f0 = fn();
       case 'CallExpression':
-        if (expression.__listItemFilter) {
-          const { item, filter } = expression.__listItemFilter;
-          path.replaceWith(t.stringLiteral(createBinding(`${item}.${filter}`)));
-        } else if (type === ATTR) {
+        if (type === ATTR) {
           if (isEventHandler) {
             const isBindCallExpression = t.isMemberExpression(expression.callee) &&
             t.isIdentifier(expression.callee.property, { name: 'bind' });

--- a/packages/jsx-compiler/src/modules/jsx-plus.js
+++ b/packages/jsx-compiler/src/modules/jsx-plus.js
@@ -4,7 +4,7 @@ const traverse = require('../utils/traverseNodePath');
 const CodeError = require('../utils/CodeError');
 const createJSX = require('../utils/createJSX');
 const findIndex = require('../utils/findIndex');
-const getListIndex = require('../utils/getListIndex');
+const createListIndex = require('../utils/createListIndex');
 const handleParentListReturn = require('../utils/handleParentListReturn');
 const handleValidIdentifier = require('../utils/handleValidIdentifier');
 const handleListStyle = require('../utils/handleListStyle');
@@ -190,7 +190,7 @@ function transformDirectiveList(parsed, code, adapter) {
         // original index identifier
         let originalIndex;
         // create new index identifier
-        const forIndex = getListIndex();
+        const forIndex = createListIndex();
         if (t.isBinaryExpression(expression, { operator: 'in' })) {
           // x-for={(item, index) in value}
           const { left, right } = expression;
@@ -351,7 +351,7 @@ function transformListJSXElement(parsed, path, code, adapter) {
             parsed.useCreateStyle = useCreateStyle;
           }
           // Handle props
-          handleListProps(innerPath, args[0], originalIndex, args[1].name, properties, dynamicValue);
+          handleListProps(innerPath, args[0], originalIndex, args[1].name, properties, dynamicValue, code);
         }
       }
     });

--- a/packages/jsx-compiler/src/modules/jsx-plus.js
+++ b/packages/jsx-compiler/src/modules/jsx-plus.js
@@ -136,13 +136,14 @@ function transformDirectiveClass(ast, parsed) {
           const replaceNode = replaced ? node.value : callExp;
           if (classNameAttribute) {
             if (t.isJSXExpressionContainer(classNameAttribute.value)) {
-              // className={'container-el'}
+              // ClassName is {'container-el'} => className={`${'container-el'}${' '}${x-class-value}`}
               classNameAttribute.value =
                 t.jsxExpressionContainer(t.templateLiteral(
                   [createHolderTemplateEl(), createHolderTemplateEl(),
                     createHolderTemplateEl(), createHolderTemplateEl()],
                   [classNameAttribute.value.expression, spaceNode, replaceNode]));
             } else {
+              // ClassName is "container-el" => className={`container-el ${x-class-value}`}
               const prevVal = t.isStringLiteral(classNameAttribute.value) ? classNameAttribute.value.value : '';
               classNameAttribute.value =
                 t.jsxExpressionContainer(t.templateLiteral(

--- a/packages/jsx-compiler/src/modules/list.js
+++ b/packages/jsx-compiler/src/modules/list.js
@@ -101,9 +101,7 @@ function transformMapMethod(path, parsed, code, adapter) {
 
                 if (isIndex) {
                   // Use renamed index instead of original value
-                  if (originalIndex === innerNode.name) {
-                    innerNode.name = renamedIndex.name;
-                  }
+                  innerNode.name = renamedIndex.name;
                 }
 
                 if (isScope) {
@@ -149,9 +147,7 @@ function transformMapMethod(path, parsed, code, adapter) {
             handleValidIdentifier(innerPath, () => {
               if (innerNode.name === forIndex.name) {
                 // Use renamed index instead of original value
-                if (originalIndex === innerNode.name) {
-                  innerNode.name = renamedIndex.name;
-                }
+                innerNode.name = renamedIndex.name;
               }
             });
           }

--- a/packages/jsx-compiler/src/modules/list.js
+++ b/packages/jsx-compiler/src/modules/list.js
@@ -4,7 +4,7 @@ const getReturnElementPath = require('../utils/getReturnElementPath');
 const createJSX = require('../utils/createJSX');
 const genExpression = require('../codegen/genExpression');
 const findIndex = require('../utils/findIndex');
-const getListIndex = require('../utils/getListIndex');
+const createListIndex = require('../utils/createListIndex');
 const handleParentListReturn = require('../utils/handleParentListReturn');
 const DynamicBinding = require('../utils/DynamicBinding');
 const handleValidIdentifier = require('../utils/handleValidIdentifier');
@@ -45,7 +45,7 @@ function transformMapMethod(path, parsed, code, adapter) {
           params[0] = t.identifier('item');
         }
         // Create increasing new index identifier
-        const renamedIndex = getListIndex();
+        const renamedIndex = createListIndex();
 
         // record original index identifier
         if (params[1]) {
@@ -136,7 +136,7 @@ function transformMapMethod(path, parsed, code, adapter) {
                 parsed.useCreateStyle = useCreateStyle;
               }
               // Handle props
-              handleListProps(innerPath, forItem, originalIndex, renamedIndex.name, properties, dynamicValue);
+              handleListProps(innerPath, forItem, originalIndex, renamedIndex.name, properties, dynamicValue, code);
             }
           }
         });

--- a/packages/jsx-compiler/src/utils/createIncrement.js
+++ b/packages/jsx-compiler/src/utils/createIncrement.js
@@ -1,0 +1,5 @@
+let id = 0;
+
+module.exports = function() {
+  return String(id++);
+};

--- a/packages/jsx-compiler/src/utils/createListIndex.js
+++ b/packages/jsx-compiler/src/utils/createListIndex.js
@@ -2,7 +2,6 @@ const t = require('@babel/types');
 
 let listIndexCount = 0;
 
-
 // Create increasing index node
 module.exports = function() {
   return t.identifier('index' + listIndexCount++);

--- a/packages/jsx-compiler/src/utils/handleList.js
+++ b/packages/jsx-compiler/src/utils/handleList.js
@@ -77,7 +77,7 @@ module.exports = function(
 
 /**
  * @param {Node} loopFnBody - current loop function body
- * @param {Node} propertyValue - the node which shoudl be
+ * @param {Node} propertyValue - the node which should be
  * inserted into current list return properties
  * @param {NodePath} attrValuePath - the attr value path
  */

--- a/packages/jsx-compiler/src/utils/handleList.js
+++ b/packages/jsx-compiler/src/utils/handleList.js
@@ -4,21 +4,25 @@ const genExpression = require('../codegen/genExpression');
 const handleValidIdentifier = require('./handleValidIdentifier');
 const getListItem = require('./getListItem');
 const findIndex = require('./findIndex');
+const createIncrement = require('./createIncrement');
 
 /**
  * @param {NodePath} containerPath - container node path
- * @param {NodePath} path - jsx attribute path
+ * @param {Node} valueNode - property's value
+ * @param {NodePath} attrPath - jsx attribute path
  * @param {Node} forItem - for item node
  * @param {string} originalIndex - original for index name
  * @param {string} renamedIndex - renamed index name
  * @param {Array} properties - map return properties
  * @param {object} dynamicBinding - dynamic style generator
- * @param {Node} valueNode - property's value
- * @return {boolean} useCreateStyle
  * */
-module.exports = function(containerPath, path, forItem, originalIndex, renamedIndex, properties, dynamicBinding, valueNode) {
-  const { node } = path;
-  const valuePath = path.get('value');
+module.exports = function(
+  containerPath, valueNode, attrPath, forItem,
+  originalIndex, renamedIndex, properties, dynamicBinding) {
+  const { node } = attrPath;
+  // Check attribute name wheather is ref
+  const isRef = node.name.name === 'ref';
+  const attrValuePath = attrPath.get('value');
   // Rename index node in expression
   const indexNodeVisitor = {
     Identifier(innerPath) {
@@ -29,12 +33,23 @@ module.exports = function(containerPath, path, forItem, originalIndex, renamedIn
       });
     }
   };
-  valuePath.traverse(indexNodeVisitor);
+  attrValuePath.traverse(indexNodeVisitor);
   if (containerPath) {
     containerPath.traverse(indexNodeVisitor);
   }
   // Avoid replace normal expression
-  if (getListItem(valuePath, true)) {
+  const listItem = getListItem(attrValuePath, true);
+  if (listItem) {
+    const listInfo = listItem.__listItem;
+    let propertyValue = valueNode;
+    // Handle current loop ref, attr name is ref and the list item is in current list
+    if (isRef && listInfo.item === forItem.name) {
+      const parentList = listInfo.parentList;
+      const { loopFnBody } = parentList;
+      propertyValue = t.binaryExpression('+',
+        t.stringLiteral(createIncrement()), t.stringLiteral(renamedIndex));
+      handleRef(loopFnBody, propertyValue, attrValuePath);
+    }
     const name = dynamicBinding.add({
       expression: node.value.expression
     });
@@ -44,7 +59,7 @@ module.exports = function(containerPath, path, forItem, originalIndex, renamedIn
       if (addedNodeIndex > -1) {
         properties.splice(addedNodeIndex, 1);
       }
-      properties.push(t.objectProperty(t.identifier(name), valueNode));
+      properties.push(t.objectProperty(t.identifier(name), propertyValue));
     }
     const replaceNode = t.stringLiteral(
       createBinding(genExpression(t.memberExpression(forItem, t.identifier(name))))
@@ -54,8 +69,27 @@ module.exports = function(containerPath, path, forItem, originalIndex, renamedIn
     node.value = replaceNode;
     // Record current properties info
     replaceNode.__properties = {
-      properties,
+      value: properties,
       index: properties.length - 1
     };
   }
 };
+
+/**
+ * @param {Node} loopFnBody - current loop function body
+ * @param {Node} propertyValue - the node which shoudl be
+ * inserted into current list return properties
+ * @param {NodePath} attrValuePath - the attr value path
+ */
+function handleRef(loopFnBody, propertyValue, attrValuePath) {
+  const registerRefsMethods = t.memberExpression(
+    t.thisExpression(),
+    t.identifier('_registerRefs')
+  );
+  loopFnBody.body.unshift(t.expressionStatement(t.callExpression(registerRefsMethods, [
+    t.arrayExpression([
+      t.objectExpression([t.objectProperty(t.stringLiteral('name'), propertyValue),
+        t.objectProperty(t.stringLiteral('method'), attrValuePath.node.expression)])
+    ])
+  ])));
+}

--- a/packages/jsx-compiler/src/utils/handleListProps.js
+++ b/packages/jsx-compiler/src/utils/handleListProps.js
@@ -14,10 +14,7 @@ module.exports = function(...args) {
   const path = args[0];
   const { node } = path;
   const attrName = node.name.name;
-  if (attrName !== 'style'
-    && !isEventHandlerAttr(attrName)
-    && !isDirectiveAttr(attrName)
-  ) {
+  if (attrName !== 'style' && attrName !== 'x-for') {
     if (t.isJSXExpressionContainer(node.value)) {
       handleList(null, ...args, node.value.expression);
     } else if (t.isStringLiteral(node.value)) {

--- a/packages/jsx-compiler/src/utils/handleListProps.js
+++ b/packages/jsx-compiler/src/utils/handleListProps.js
@@ -9,6 +9,7 @@ const handleList = require('./handleList');
  * @param {string} renamedIndex - renamed index name
  * @param {Array} properties - map return properties
  * @param {object} dynamicBinding - dynamic style generator
+ * @param {string} code - original code
  * */
 module.exports = function(...args) {
   const path = args[0];
@@ -16,13 +17,13 @@ module.exports = function(...args) {
   const attrName = node.name.name;
   if (attrName !== 'style' && attrName !== 'x-for' && !isEventHandlerAttr(attrName)) {
     if (t.isJSXExpressionContainer(node.value)) {
-      handleList(null, ...args, node.value.expression);
+      handleList(null, node.value.expression, ...args);
     } else if (t.isStringLiteral(node.value)) {
       // override prev level list value
       if (BINDING_REG.test(node.value.value) && node.value.__originalExpression) {
-        node.value.__properties.properties.splice(node.value.__properties.index, 1);
+        node.value.__properties.value.splice(node.value.__properties.index, 1);
         node.value = t.jsxExpressionContainer(node.value.__originalExpression);
-        handleList(null, ...args, node.value.expression);
+        handleList(null, node.value.expression, ...args);
       }
     }
   }

--- a/packages/jsx-compiler/src/utils/handleListProps.js
+++ b/packages/jsx-compiler/src/utils/handleListProps.js
@@ -1,5 +1,5 @@
 const t = require('@babel/types');
-const { isDirectiveAttr, isEventHandlerAttr, BINDING_REG } = require('./checkAttr');
+const { isEventHandlerAttr, BINDING_REG } = require('./checkAttr');
 const handleList = require('./handleList');
 
 /**
@@ -14,7 +14,7 @@ module.exports = function(...args) {
   const path = args[0];
   const { node } = path;
   const attrName = node.name.name;
-  if (attrName !== 'style' && attrName !== 'x-for') {
+  if (attrName !== 'style' && attrName !== 'x-for' && !isEventHandlerAttr(attrName)) {
     if (t.isJSXExpressionContainer(node.value)) {
       handleList(null, ...args, node.value.expression);
     } else if (t.isStringLiteral(node.value)) {

--- a/packages/jsx-compiler/src/utils/handleListStyle.js
+++ b/packages/jsx-compiler/src/utils/handleListStyle.js
@@ -31,7 +31,7 @@ module.exports = function(mapFnBodyPath, ...args) {
       }
     }
     useCreateStyle = true;
-    handleList(mapFnBodyPath, t.callExpression(t.identifier('__create_style__'), [node.value.expression]), ...args.splice(0, 6));
+    handleList(mapFnBodyPath, t.callExpression(t.identifier('__create_style__'), [node.value.expression]), ...args);
   }
   return useCreateStyle;
 };

--- a/packages/jsx-compiler/src/utils/handleListStyle.js
+++ b/packages/jsx-compiler/src/utils/handleListStyle.js
@@ -23,7 +23,7 @@ module.exports = function(mapFnBodyPath, ...args) {
   })) {
     if (!t.isJSXExpressionContainer(node.value)) {
       if (node.value.__originalExpression) {
-        node.value.__properties.properties.splice(node.value.__properties.index, 1);
+        node.value.__properties.value.splice(node.value.__properties.index, 1);
         node.value = t.jsxExpressionContainer(node.value.__originalExpression);
       } else {
         throw new CodeError(code, node.value, node.loc,
@@ -31,7 +31,7 @@ module.exports = function(mapFnBodyPath, ...args) {
       }
     }
     useCreateStyle = true;
-    handleList(mapFnBodyPath, ...args.splice(0, 6), t.callExpression(t.identifier('__create_style__'), [node.value.expression]));
+    handleList(mapFnBodyPath, t.callExpression(t.identifier('__create_style__'), [node.value.expression]), ...args.splice(0, 6));
   }
   return useCreateStyle;
 };

--- a/packages/jsx-compiler/src/utils/handleParentListReturn.js
+++ b/packages/jsx-compiler/src/utils/handleParentListReturn.js
@@ -26,7 +26,7 @@ module.exports = function(mapCallExpression, forNode, code) {
         if (t.isIdentifier(forNode.object)) {
           forItem.value = t.objectExpression([
             t.spreadElement(forItem.value),
-            t.objectProperty(forItem.value, mapCallExpression)
+            t.objectProperty(forNode.property, mapCallExpression)
           ]);
         } else if (t.isCallExpression(forNode)) {
           // handle list.filter().map()
@@ -35,7 +35,7 @@ module.exports = function(mapCallExpression, forNode, code) {
           }
           forItem.value = t.objectExpression([
             t.spreadElement(forItem.value),
-            t.objectProperty(forItem.value, mapCallExpression)
+            t.objectProperty(forNode.property, mapCallExpression)
           ]);
           forNode = listItem;
         } else {

--- a/packages/jsx2mp-runtime/src/component.js
+++ b/packages/jsx2mp-runtime/src/component.js
@@ -98,7 +98,9 @@ export default class Component {
   }
 
   _registerRefs(refs) {
-    this.refs = {};
+    if (!this.refs) {
+      this.refs = {};
+    }
     refs.forEach(({name, method}) => {
       if (!method) {
         const target = {

--- a/packages/jsx2mp-runtime/src/component.js
+++ b/packages/jsx2mp-runtime/src/component.js
@@ -24,6 +24,7 @@ export default class Component {
   constructor(props) {
     this.state = {};
     this.props = props;
+    this.refs = {};
 
     this.__dependencies = {}; // for context
 
@@ -98,9 +99,6 @@ export default class Component {
   }
 
   _registerRefs(refs) {
-    if (!this.refs) {
-      this.refs = {};
-    }
     refs.forEach(({name, method}) => {
       if (!method) {
         const target = {


### PR DESCRIPTION
- 支持在 `map` 函数中定义的表达式里使用循环产生的临时变量 `item`/ `index`
- 支持 `x-for` 和 `x-if` 混合使用的场景下，`x-if` 的判断条件中包含循环产生的临时变量
- 支持在循环中使用 `ref` 的功能
- 修复层级循环时动态绑定的数据赋值出错的问题，如：
```jsx
<Fragment x-for={(item, index) in data} x-if={item}>
      <Text x-for={(benefitItem, index) in item.b} />
</Fragment>
``` 
`map` 中 `return` 出来的值应该是：
```js
item: {
  ...item,
  b: item.b.map(() => {});
}
```