### PR TITLE
chore: add parameter control rpx to vw

### DIFF
--- a/packages/driver-dom/package.json
+++ b/packages/driver-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "driver-dom",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "DOM driver for Rax",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/driver-dom/src/__tests__/css-custom-properties.js
+++ b/packages/driver-dom/src/__tests__/css-custom-properties.js
@@ -1,5 +1,5 @@
 import { createElement, render } from 'rax';
-import * as DriverDOM from '../../';
+import * as DriverDOM from '../';
 
 describe('Support CSS custom properties', () => {
   let container;

--- a/packages/driver-dom/src/__tests__/css-unit-operations.js
+++ b/packages/driver-dom/src/__tests__/css-unit-operations.js
@@ -1,5 +1,5 @@
 import { createElement, render } from 'rax';
-import * as DriverDOM from '../../';
+import * as DriverDOM from '../';
 
 describe('CSSPropertyOperations', () => {
   let container;

--- a/packages/driver-dom/src/__tests__/event-listener.js
+++ b/packages/driver-dom/src/__tests__/event-listener.js
@@ -1,5 +1,5 @@
 import { createElement, render } from 'rax';
-import * as DriverDOM from '../../';
+import * as DriverDOM from '../';
 
 describe('EventListener', () => {
   let container;

--- a/packages/driver-dom/src/__tests__/node-operations.js
+++ b/packages/driver-dom/src/__tests__/node-operations.js
@@ -1,5 +1,5 @@
 import { createElement, Fragment, render, useState } from 'rax';
-import * as DriverDOM from '../../';
+import * as DriverDOM from '../';
 
 describe('NodeOperations', () => {
   let container;

--- a/packages/driver-dom/src/__tests__/svg.js
+++ b/packages/driver-dom/src/__tests__/svg.js
@@ -1,5 +1,5 @@
 import { createElement, render } from 'rax';
-import * as DriverDOM from '../../';
+import * as DriverDOM from '../';
 
 describe('svg', () => {
   let container;

--- a/packages/driver-dom/src/index.js
+++ b/packages/driver-dom/src/index.js
@@ -346,10 +346,14 @@ export function setStyle(node, style, __shouldConvertUnitlessToRpx, __shouldTran
     const value = style[prop];
     let convertedValue;
     if (typeof value === 'number' && isDimensionalProp(prop)) {
-      convertedValue = value + __shouldConvertUnitlessToRpx ? 'rpx' : 'px';
-
-      if (__shouldTransformRpx) {
-        convertedValue = convertUnit(convertedValue);
+      if (__shouldConvertUnitlessToRpx) {
+        convertedValue = value + 'rpx';
+        if (__shouldTransformRpx) {
+          // Transfrom rpx to vw
+          convertedValue = convertUnit(convertedValue);
+        }
+      } else {
+        convertedValue = value + 'px';
       }
     } else {
       convertedValue = __shouldTransformRpx ? convertUnit(value) : value;

--- a/packages/driver-dom/src/index.js
+++ b/packages/driver-dom/src/index.js
@@ -183,9 +183,9 @@ function findHydrationChild(parent) {
  * @param {object} props elemement properties
  * @param {object} component component instance
  * @param {boolean} __shouldConvertUnitlessToRpx should add unit when missing
- * @param {boolean} __shouldTransformRpx should transfrom rpx to vw
+ * @param {boolean} __shouldConvertRpxToVw should transfrom rpx to vw
  */
-export function createElement(type, props, component, __shouldConvertUnitlessToRpx, __shouldTransformRpx = true) {
+export function createElement(type, props, component, __shouldConvertUnitlessToRpx, __shouldConvertRpxToVw = true) {
   const parent = component._parent;
   isSVGMode = type === 'svg' || parent && parent.namespaceURI === SVG_NS;
   let node;
@@ -254,7 +254,7 @@ export function createElement(type, props, component, __shouldConvertUnitlessToR
 
     if (value != null) {
       if (prop === STYLE) {
-        setStyle(node, value, __shouldConvertUnitlessToRpx, __shouldTransformRpx);
+        setStyle(node, value, __shouldConvertUnitlessToRpx, __shouldConvertRpxToVw);
       } else if (isEventProp(prop)) {
         addEventListener(node, prop.slice(2).toLowerCase(), value, component);
       } else {
@@ -352,17 +352,16 @@ export function setAttribute(node, propKey, propValue) {
  * @param {object} node target node
  * @param {object} style target node style value
  * @param {boolean} __shouldConvertUnitlessToRpx
- * @param {boolean} __shouldConvertUnitlessToRpx should add unit when missing
- * @param {boolean} __shouldTransformRpx should transfrom rpx to vw
+ * @param {boolean} __shouldConvertRpxToVw should transfrom rpx to vw
  */
-export function setStyle(node, style, __shouldConvertUnitlessToRpx, __shouldTransformRpx = true) {
+export function setStyle(node, style, __shouldConvertUnitlessToRpx, __shouldConvertRpxToVw = true) {
   for (let prop in style) {
     const value = style[prop];
     let convertedValue;
     if (typeof value === 'number' && isDimensionalProp(prop)) {
       if (__shouldConvertUnitlessToRpx) {
         convertedValue = value + 'rpx';
-        if (__shouldTransformRpx) {
+        if (__shouldConvertRpxToVw) {
           // Transfrom rpx to vw
           convertedValue = convertUnit(convertedValue);
         }
@@ -370,7 +369,7 @@ export function setStyle(node, style, __shouldConvertUnitlessToRpx, __shouldTran
         convertedValue = value + 'px';
       }
     } else {
-      convertedValue = __shouldTransformRpx ? convertUnit(value) : value;
+      convertedValue = __shouldConvertRpxToVw ? convertUnit(value) : value;
     }
 
     // Support CSS custom properties (variables) like { --main-color: "black" }

--- a/packages/driver-dom/src/index.js
+++ b/packages/driver-dom/src/index.js
@@ -178,6 +178,13 @@ function findHydrationChild(parent) {
   return parent.childNodes[parent[HYDRATION_INDEX]++];
 }
 
+/**
+ * @param {string} type node type
+ * @param {object} props elemement properties
+ * @param {object} component component instance
+ * @param {boolean} __shouldConvertUnitlessToRpx should add unit when missing
+ * @param {boolean} __shouldTransformRpx should transfrom rpx to vw
+ */
 export function createElement(type, props, component, __shouldConvertUnitlessToRpx, __shouldTransformRpx = true) {
   const parent = component._parent;
   isSVGMode = type === 'svg' || parent && parent.namespaceURI === SVG_NS;
@@ -341,6 +348,13 @@ export function setAttribute(node, propKey, propValue) {
   }
 }
 
+/**
+ * @param {object} node target node
+ * @param {object} style target node style value
+ * @param {boolean} __shouldConvertUnitlessToRpx
+ * @param {boolean} __shouldConvertUnitlessToRpx should add unit when missing
+ * @param {boolean} __shouldTransformRpx should transfrom rpx to vw
+ */
 export function setStyle(node, style, __shouldConvertUnitlessToRpx, __shouldTransformRpx = true) {
   for (let prop in style) {
     const value = style[prop];

--- a/packages/driver-dom/src/index.js
+++ b/packages/driver-dom/src/index.js
@@ -178,7 +178,7 @@ function findHydrationChild(parent) {
   return parent.childNodes[parent[HYDRATION_INDEX]++];
 }
 
-export function createElement(type, props, component, __shouldConvertUnitlessToRpx) {
+export function createElement(type, props, component, __shouldConvertUnitlessToRpx, __shouldTransformRpx = true) {
   const parent = component._parent;
   isSVGMode = type === 'svg' || parent && parent.namespaceURI === SVG_NS;
   let node;
@@ -247,7 +247,7 @@ export function createElement(type, props, component, __shouldConvertUnitlessToR
 
     if (value != null) {
       if (prop === STYLE) {
-        setStyle(node, value, __shouldConvertUnitlessToRpx);
+        setStyle(node, value, __shouldConvertUnitlessToRpx, __shouldTransformRpx);
       } else if (isEventProp(prop)) {
         addEventListener(node, prop.slice(2).toLowerCase(), value, component);
       } else {
@@ -341,14 +341,18 @@ export function setAttribute(node, propKey, propValue) {
   }
 }
 
-export function setStyle(node, style, __shouldConvertUnitlessToRpx) {
+export function setStyle(node, style, __shouldConvertUnitlessToRpx, __shouldTransformRpx = true) {
   for (let prop in style) {
     const value = style[prop];
     let convertedValue;
     if (typeof value === 'number' && isDimensionalProp(prop)) {
-      convertedValue = __shouldConvertUnitlessToRpx ? convertUnit(value + 'rpx') : value + 'px';
+      convertedValue = value + __shouldConvertUnitlessToRpx ? 'rpx' : 'px';
+
+      if (__shouldTransformRpx) {
+        convertedValue = convertUnit(convertedValue);
+      }
     } else {
-      convertedValue = convertUnit(value);
+      convertedValue = __shouldTransformRpx ? convertUnit(value) : value;
     }
 
     // Support CSS custom properties (variables) like { --main-color: "black" }

--- a/packages/driver-miniapp/package.json
+++ b/packages/driver-miniapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "driver-miniapp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MiniApp (runtime) driver for Rax",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/driver-miniapp/src/index.js
+++ b/packages/driver-miniapp/src/index.js
@@ -3,9 +3,9 @@ import * as DriverDOM from 'driver-dom';
 // Convert Unitless To Rpx defaultly
 export default Object.assign({}, DriverDOM, {
   createElement(type, props, component) {
-    return DriverDOM.createElement(type, props, component, true);
+    return DriverDOM.createElement(type, props, component, true, false);
   },
   setStyle(node, style) {
-    return DriverDOM.setStyle(node, style, true);
+    return DriverDOM.setStyle(node, style, true, false);
   }
 });


### PR DESCRIPTION
Add `__shouldTransformRpx` to avoid `rpx2vw` 