### PR TITLE
chore(rax-children): aviod effect

### DIFF
--- a/packages/rax-children/package.json
+++ b/packages/rax-children/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-children",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Rax Children",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-children/src/index.js
+++ b/packages/rax-children/src/index.js
@@ -1,9 +1,8 @@
 import { shared } from 'rax';
 
-const { flattenChildren } = shared;
-
 function convertChildrenToArray(children) {
   // flatten children
+  const { flattenChildren } = shared;
   children = flattenChildren(children, []);
   return Array.isArray(children) ? children : [].concat(children);
 }


### PR DESCRIPTION
直接的解构用法，存在副作用。在小程序编译时方案中，没有 `shared`，从而导致报错。