### PR TITLE
feat(jsx2mp): support more class component usage

### DIFF
--- a/packages/jsx-compiler/src/modules/code.js
+++ b/packages/jsx-compiler/src/modules/code.js
@@ -8,6 +8,7 @@ const traverse = require('../utils/traverseNodePath');
 const { isNpmModule, isWeexModule } = require('../utils/checkModule');
 const { getNpmName, normalizeFileName, addRelativePathPrefix } = require('../utils/pathHelper');
 const { BINDING_REG } = require('../utils/checkAttr');
+const genExpression = require('../codegen/genExpression');
 
 const RAX_PACKAGE = 'rax';
 const SUPER_COMPONENT = 'Component';
@@ -81,8 +82,7 @@ module.exports = {
       let { id, body } = exportComponentPath.node;
       if (!id) {
         // Check fn is anonymous
-        if (exportComponentPath.isArrowFunctionExpression()
-          && exportComponentPath.parentPath.isVariableDeclarator()) {
+        if (exportComponentPath.parentPath.isVariableDeclarator()) {
           id = exportComponentPath.parent.id;
         } else {
           id = t.identifier(SAFT_DEFAULT_NAME);
@@ -98,14 +98,12 @@ module.exports = {
         }
       } else if (isClassComponent(exportComponentPath)) {
         userDefineType = 'class';
-
-        const { decorators } = exportComponentPath.node;
-        // @NOTE: Remove superClass due to useless of Component base class.
-        if (replacer) {
-          replacer.replaceWith(
-            t.classDeclaration(id, t.identifier(SAFE_SUPER_COMPONENT), body, decorators)
-          );
+        if (id.name === SAFT_DEFAULT_NAME) {
+          // Suport export default class extends Component {}
+          exportComponentPath.node.id = id;
         }
+        // Replace Component use __component__
+        renameComponentClassDeclaration(ast);
       }
       replacer.insertAfter(t.variableDeclaration('let', [
         t.variableDeclarator(
@@ -215,6 +213,19 @@ function renameCoreModule(ast, runtimePath) {
       const source = path.get('source');
       if (source.isStringLiteral() && isAppRuntime(source.node.value)) {
         source.replaceWith(t.stringLiteral(runtimePath));
+      }
+    }
+  });
+}
+
+function renameComponentClassDeclaration(ast) {
+  traverse(ast, {
+    ClassDeclaration(path) {
+      const superClassPath = path.get('superClass');
+      if (superClassPath && t.isIdentifier(superClassPath.node, {
+        name: SUPER_COMPONENT
+      })) {
+        superClassPath.replaceWith(t.identifier(SAFE_SUPER_COMPONENT));
       }
     }
   });
@@ -408,7 +419,7 @@ function removeDefaultImports(ast) {
       if (/Expression$/.test(declaration.type)) {
         path.replaceWith(t.assignmentExpression('=', t.identifier(EXPORTED_DEF), declaration));
       } else {
-        path.remove();
+        path.replaceWith(declaration);
       }
     },
   });

--- a/packages/jsx-compiler/src/modules/code.js
+++ b/packages/jsx-compiler/src/modules/code.js
@@ -8,7 +8,6 @@ const traverse = require('../utils/traverseNodePath');
 const { isNpmModule, isWeexModule } = require('../utils/checkModule');
 const { getNpmName, normalizeFileName, addRelativePathPrefix } = require('../utils/pathHelper');
 const { BINDING_REG } = require('../utils/checkAttr');
-const genExpression = require('../codegen/genExpression');
 
 const RAX_PACKAGE = 'rax';
 const SUPER_COMPONENT = 'Component';

--- a/packages/jsx-compiler/src/modules/template.js
+++ b/packages/jsx-compiler/src/modules/template.js
@@ -69,7 +69,6 @@ module.exports = {
  */
 function getRenderMethodPath(path) {
   let renderMethodPath = null;
-
   traverse(path, {
     /**
      * Example:

--- a/packages/jsx-compiler/src/utils/__tests__/isClassComponent.js
+++ b/packages/jsx-compiler/src/utils/__tests__/isClassComponent.js
@@ -8,7 +8,7 @@ describe('isClassComponent', () => {
       import { createElement, Component } from 'rax';
       import View from 'rax-view';
       import './index.css';
-      
+
       export default class extends Component {
         render() {
           return (
@@ -41,7 +41,7 @@ describe('isClassComponent', () => {
     `;
 
     const defaultExportedPath = getDefaultExportedPath(parseCode(code));
-    expect(isClassComponent(defaultExportedPath)).toBeFalsy();
+    expect(isClassComponent(defaultExportedPath)).toBeTruthy();
   });
 
   it('#4', () => {

--- a/packages/jsx-compiler/src/utils/isClassComponent.js
+++ b/packages/jsx-compiler/src/utils/isClassComponent.js
@@ -10,7 +10,7 @@ const RAX_COMPONENT = 'Component';
  *  1. class xxx extends *.Component {}
  *  2. class xxx extends Component {}
  */
-module.exports = function isClassComponent(path, flag) {
+module.exports = function isClassComponent(path) {
   if (!path) return false;
 
   const { node, scope } = path;

--- a/packages/jsx2mp-runtime/src/bridge.js
+++ b/packages/jsx2mp-runtime/src/bridge.js
@@ -231,7 +231,7 @@ export function createComponent(definition, options = {}) {
 }
 
 function isClassComponent(Klass) {
-  return Klass.prototype.__proto__ === Component.prototype;
+  return Klass.prototype instanceof Component;
 }
 
 const DATASET_KEBAB_ARG_REG = /data-\w+\d+-arg-\d+/;


### PR DESCRIPTION
1. 支持 class component 的继承用法，即 `class A extends Component {}; export default class Home extends A {}`
2. 支持导出一个匿名的 class component，即 `export default class extends Component`
3. 支持通过赋值的方式定义一个 class  component，即 `const Home = class extends Component{}; export default Home;`