### PR TITLE
Fix alive page useEffect triggered by history

### DIFF
--- a/packages/rax-pwa/package.json
+++ b/packages/rax-pwa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-pwa",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Rax pwa templates",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-pwa/src/Navigation/index.js
+++ b/packages/rax-pwa/src/Navigation/index.js
@@ -47,9 +47,6 @@ export default function Navigation(props) {
 
   const isAlivePage = currentPage.keepAlive;
   useEffect(() => {
-    history.listen(() => {
-      _updatePageTrigger(Date.now());
-    });
     // Use display control alive page, need get alive page list.
     routes.forEach((route) => {
       if (route.keepAlive) {


### PR DESCRIPTION
Fix alive page history change to a common page, useEffect method will be called.

```jsx
import { createElement, useEffect } from 'rax';
export default function Home(props) {
  useEffect(() => {
    // called when history change to the page not alive. Like page1
  }, []);
  return (
    ....
  );
}
```
Example app.json
```json
// app.json
{
  "routes": [
    {
      "path": "/",
      "keepAlive": true,
      "source": "pages/Home/index"
    },
    {
      "path": "/page1",
      "source": "pages/Page1/index"
    }
  ]
}
```