### PR TITLE
fix: loop key

### DIFF
--- a/packages/jsx-compiler/src/adapter.js
+++ b/packages/jsx-compiler/src/adapter.js
@@ -23,7 +23,9 @@ const parserAdapters = {
     styleKeyword: false,
     // Need transform onClick -> bindonclick
     needTransformEvent: false,
-    slotScope: true
+    slotScope: true,
+    // Need transform key
+    needTransformKey: false
   },
   'wechat': {
     if: 'wx:if',
@@ -47,7 +49,8 @@ const parserAdapters = {
     compatibleText: true,
     styleKeyword: true,
     needTransformEvent: true,
-    slotScope: false
+    slotScope: false,
+    needTransformKey: true
   },
 };
 

--- a/packages/jsx-compiler/src/modules/__tests__/attribute.js
+++ b/packages/jsx-compiler/src/modules/__tests__/attribute.js
@@ -6,7 +6,7 @@ const wxAdapter = require('../../adapter').wechat;
 const genCode = require('../../codegen/genCode');
 
 describe('Transform JSX Attribute', () => {
-  it('should transform attribute name is key', () => {
+  it('should transform alibaba miniapp attribute name is key', () => {
     const code = '<View key={1}>test</View>';
     const ast = parseExpression(code);
     _transformAttribute(ast, code, adapter);

--- a/packages/jsx-compiler/src/modules/__tests__/jsx-plus.js
+++ b/packages/jsx-compiler/src/modules/__tests__/jsx-plus.js
@@ -27,14 +27,14 @@ describe('Directives', () => {
       const index = 'index' + count++;
       expect(genExpression(ast))
         .toEqual(`<View>
-        <block a:for={array.map((val, ${index}) => {
+        <View a:for={array.map((val, ${index}) => {
     return {
       val: val,
       ${index}: ${index}
     };
-  })} a:for-item="val" a:for-index="${index}"><View>{{
-        val.val
-      }}</View></block>
+  })} a:for-item="val" a:for-index="${index}">{{
+      val.val
+    }}</View>
       </View>`);
     });
 
@@ -54,7 +54,7 @@ describe('Directives', () => {
       const index2 = 'index' + count++;
       expect(genExpression(ast))
         .toEqual(`<View>
-        <block a:for={array.map((item, ${index1}) => {
+        <View a:for={array.map((item, ${index1}) => {
     return {
       item: item.map((item2, ${index2}) => {
         return {
@@ -64,11 +64,11 @@ describe('Directives', () => {
       }),
       ${index1}: ${index1}
     };
-  })} a:for-item="item" a:for-index="${index1}"><View>
-          <block a:for={item} a:for-item="item2" a:for-index="${index2}"><View>{{
-            item2.item2
-          }}</View></block>
-      </View></block>
+  })} a:for-item="item" a:for-index="${index1}">
+          <View a:for={item} a:for-item="item2" a:for-index="${index2}">{{
+        item2.item2
+      }}</View>
+      </View>
 </View>`);
     });
 
@@ -94,7 +94,7 @@ describe('Directives', () => {
       const index2 = 'index' + count++;
       expect(genExpression(ast))
         .toEqual(`<View className="rxpi-coupon">
-        <block key="{{row._d0}}" a:for={testList.map((row, ${index1}) => {
+        <View className="rxpi-coupon-row" key="{{row._d0}}" a:for={testList.map((row, ${index1}) => {
     return {
       row: row.map((col, ${index2}) => {
         return {
@@ -105,13 +105,13 @@ describe('Directives', () => {
       ${index1}: ${index1},
       _d0: 'test_' + ${index1}
     };
-  })} a:for-item="row" a:for-index="${index1}"><View className="rxpi-coupon-row">
-          <block a:for={row} a:for-item="col" a:for-index="${index2}"><View>
+  })} a:for-item="row" a:for-index="${index1}">
+          <View a:for={row} a:for-item="col" a:for-index="${index2}">
             <Text key="{{col.${index2}}}">{{
-              col.${index2}
-            }}</Text>
-          </View></block>
-        </View></block>
+          col.${index2}
+        }}</Text>
+          </View>
+        </View>
       </View>`);
     });
 
@@ -128,15 +128,15 @@ describe('Directives', () => {
       const index = 'index' + count++;
       expect(genExpression(ast))
         .toEqual(`<View>
-        <block a:for={array.map((val, ${index}) => {
+        <View a:for={array.map((val, ${index}) => {
     return {
       val: val,
       ${index}: ${index},
       _d0: format(val)
     };
-  })} a:for-item="val" a:for-index="${index}"><View>{{
-        val._d0
-      }}</View></block>
+  })} a:for-item="val" a:for-index="${index}">{{
+      val._d0
+    }}</View>
       </View>`);
     });
   });
@@ -206,7 +206,7 @@ describe('Directives', () => {
       }, code, adapter);
       const index = 'index' + count++;
       expect(genExpression(ast)).toEqual(`<View>
-        <block a:for={data.map((item, ${index}) => {
+        <View ref="{{item._d0}}" a:for={data.map((item, ${index}) => {
     this._registerRefs([{
       "name": "${id}" + "${index}",
       "method": refs[${index}]
@@ -217,7 +217,7 @@ describe('Directives', () => {
       ${index}: ${index},
       _d0: "${id}" + "${index}"
     };
-  })} a:for-item="item" a:for-index="${index}"><View ref="{{item._d0}}">test</View></block>
+  })} a:for-item="item" a:for-index="${index}">test</View>
       </View>`);
       id++;
     });
@@ -236,7 +236,7 @@ describe('Directives', () => {
     const index1 = 'index' + count++;
     const index2 = 'index' + count++;
     expect(genExpression(ast)).toEqual(`<View>
-        <block a:for={data.map((item, ${index1}) => {
+        <View a:for={data.map((item, ${index1}) => {
     return {
       item: { ...item,
         list: item.list.map((item, ${index2}) => {
@@ -254,9 +254,9 @@ describe('Directives', () => {
       },
       ${index1}: ${index1}
     };
-  })} a:for-item="item" a:for-index="${index1}"><View>
-            <block a:for={item.list} a:for-item="item" a:for-index="${index2}"><View ref="{{item._d0}}">test</View></block>
-        </View></block>
+  })} a:for-item="item" a:for-index="${index1}">
+            <View ref="{{item._d0}}" a:for={item.list} a:for-item="item" a:for-index="${index2}">test</View>
+        </View>
       </View>`);
     id++;
   });

--- a/packages/jsx-compiler/src/modules/attribute.js
+++ b/packages/jsx-compiler/src/modules/attribute.js
@@ -15,6 +15,16 @@ function transformAttribute(ast, code, adapter) {
       switch (attrName) {
         case 'key':
           node.name.name = adapter.key;
+          if (adapter.needTransformKey && node.value.__originalExpression) {
+            // In wechat miniprogram, key should be a string
+            const originalExpression = node.value.__originalExpression;
+            if (t.isIdentifier(originalExpression)) {
+              node.value = t.stringLiteral(originalExpression.name);
+            } else if (t.isMemberExpression(originalExpression)) {
+              const propertyName = originalExpression.property.name;
+              node.value = t.isStringLiteral(propertyName) ? propertyName : t.stringLiteral(propertyName);
+            }
+          }
           break;
         case 'className':
           if (!adapter.styleKeyword) {

--- a/packages/jsx-compiler/src/modules/jsx-plus.js
+++ b/packages/jsx-compiler/src/modules/jsx-plus.js
@@ -10,6 +10,7 @@ const handleValidIdentifier = require('../utils/handleValidIdentifier');
 const handleListStyle = require('../utils/handleListStyle');
 const handleListProps = require('../utils/handleListProps');
 const handleListJSXExpressionContainer = require('../utils/handleListJSXExpressionContainer');
+const genExpression = require('../codegen/genExpression');
 
 const directiveIf = 'x-if';
 const directiveElseif = 'x-elseif';
@@ -348,8 +349,9 @@ function transformListJSXElement(parsed, path, code, adapter) {
       },
       JSXExpressionContainer: {
         exit(innerPath) {
-          if (!innerPath.findParent(p => p.isJSXAttribute()) && !transformedContainerMap[innerPath.node.expression]) {
-            transformedContainerMap[innerPath.node.expression] = true;
+          const epxressionCode = genExpression(innerPath.node.expression);
+          if (!innerPath.findParent(p => p.isJSXAttribute()) && !transformedContainerMap[epxressionCode]) {
+            transformedContainerMap[epxressionCode] = true;
             handleListJSXExpressionContainer(innerPath, args[0], originalIndex, args[1].name, properties, dynamicValue);
           }
         }

--- a/packages/jsx-compiler/src/modules/list.js
+++ b/packages/jsx-compiler/src/modules/list.js
@@ -137,8 +137,9 @@ function transformMapMethod(path, parsed, code, adapter) {
           },
           JSXExpressionContainer: {
             exit(innerPath) {
-              if (!innerPath.findParent(p => p.isJSXAttribute()) && !transformedContainerMap[innerPath.node.expression]) {
-                transformedContainerMap[innerPath.node.expression] = true;
+              const epxressionCode = genExpression(innerPath.node.expression);
+              if (!innerPath.findParent(p => p.isJSXAttribute()) && !transformedContainerMap[epxressionCode]) {
+                transformedContainerMap[epxressionCode] = true;
                 handleListJSXExpressionContainer(innerPath, forItem, originalIndex, renamedIndex.name, properties, dynamicValue);
               }
             }

--- a/packages/jsx-compiler/src/modules/list.js
+++ b/packages/jsx-compiler/src/modules/list.js
@@ -95,7 +95,7 @@ function transformMapMethod(path, parsed, code, adapter) {
               const isScope = returnElPath.scope.hasBinding(innerNode.name);
               const isItem = innerNode.name === forItem.name;
               // Ensure inner node's name is original name
-              const isIndex = innerNode.loc.identifierName === forIndex.name;
+              const isIndex = (innerNode.loc && innerNode.loc.identifierName || innerNode.name) === forIndex.name;
               if (isScope || isItem || isIndex) {
                 innerNode.__listItem = {
                   jsxplus: false,

--- a/packages/jsx-compiler/src/modules/list.js
+++ b/packages/jsx-compiler/src/modules/list.js
@@ -87,7 +87,6 @@ function transformMapMethod(path, parsed, code, adapter) {
 
         // map callback function return path;
         const returnElPath = getReturnElementPath(body).get('argument');
-        const transformedContainerMap = {};
         returnElPath.traverse({
           Identifier(innerPath) {
             const innerNode = innerPath.node;
@@ -137,9 +136,7 @@ function transformMapMethod(path, parsed, code, adapter) {
           },
           JSXExpressionContainer: {
             exit(innerPath) {
-              const epxressionCode = genExpression(innerPath.node.expression);
-              if (!innerPath.findParent(p => p.isJSXAttribute()) && !transformedContainerMap[epxressionCode]) {
-                transformedContainerMap[epxressionCode] = true;
+              if (!innerPath.findParent(p => p.isJSXAttribute()) && !(innerPath.node.__index === renamedIndex.name)) {
                 handleListJSXExpressionContainer(innerPath, forItem, originalIndex, renamedIndex.name, properties, dynamicValue);
               }
             }
@@ -159,13 +156,26 @@ function transformMapMethod(path, parsed, code, adapter) {
           }
         });
 
-        // Use renamed index instead of original params[1]
-        params[1] = renamedIndex;
-        const listBlock = createJSX('block', {
+        const listAttr = {
           [adapter.for]: t.jsxExpressionContainer(forNode),
           [adapter.forItem]: t.stringLiteral(forItem.name),
           [adapter.forIndex]: t.stringLiteral(renamedIndex.name),
-        }, [returnElPath.node]);
+        };
+
+        if (adapter.needTransformKey && t.isJSXElement(returnElPath.node)) {
+          const attributes = returnElPath.node.openingElement.attributes;
+          const keyIndex = findIndex(attributes, attr => t.isJSXIdentifier(attr.name, { name: 'key' }));
+          if (keyIndex > -1) {
+            listAttr.key = attributes[keyIndex].value;
+            attributes.splice(keyIndex, 1);
+          } else {
+            listAttr.key = t.stringLiteral('*this');
+          }
+        }
+
+        // Use renamed index instead of original params[1]
+        params[1] = renamedIndex;
+        const listBlock = createJSX('block', listAttr, [returnElPath.node]);
 
         // Mark forItem __listItem
         forItem.__listItem = {

--- a/packages/jsx-compiler/src/utils/handleList.js
+++ b/packages/jsx-compiler/src/utils/handleList.js
@@ -71,6 +71,7 @@ module.exports = function(
       : createJSXBinding(replaceVariable);
     // Record original expression
     replaceNode.__originalExpression = originalExpression;
+    replaceNode.__index = targetPath.node.__index;
     node.value = replaceNode;
     // Record current properties info
     replaceNode.__properties = {

--- a/packages/jsx-compiler/src/utils/handleListJSXExpressionContainer.js
+++ b/packages/jsx-compiler/src/utils/handleListJSXExpressionContainer.js
@@ -13,6 +13,8 @@ module.exports = function(path, ...args) {
   const node = path.node;
   // Out of the map
   if (!(t.isCallExpression(node.expression) && t.isIdentifier(node.expression.callee.property, { name: 'map' }))) {
+    // Mark current loop
+    path.node.__index = args[2];
     if (node.__originalExpression) {
       node.__properties.value.splice(node.__properties.index, 1);
       node.expression = node.__originalExpression;

--- a/packages/jsx-compiler/src/utils/handleParentListReturn.js
+++ b/packages/jsx-compiler/src/utils/handleParentListReturn.js
@@ -16,7 +16,7 @@ module.exports = function(mapCallExpression, forNode, code) {
   const { loopFnBody } = parentList;
   const loopFnBodyLength = loopFnBody.body.length;
   const properties = loopFnBody.body[loopFnBodyLength - 1].argument.properties;
-  const forItem = properties.find(({ key }) => key.name === listItem.name);
+  const forItem = properties.find(({ key }) => key.name === listItem.__listItem.item);
   if (t.isIdentifier(forNode)) {
     forItem.value = mapCallExpression;
   }


### PR DESCRIPTION
- 支持微信小程序循环 `key` 的设置方式
- 修复循环渲染中，需要渲染对象上某个属性的时候只处理了第一个值的问题