### PR TITLE
Refactor/windows path resolve

### DIFF
--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/src/modules/code.js
+++ b/packages/jsx-compiler/src/modules/code.js
@@ -6,7 +6,7 @@ const isClassComponent = require('../utils/isClassComponent');
 const isFunctionComponent = require('../utils/isFunctionComponent');
 const traverse = require('../utils/traverseNodePath');
 const { isNpmModule, isWeexModule } = require('../utils/checkModule');
-const { getNpmName, normalizeFileName, addRelativePathPrefix } = require('../utils/pathHelper');
+const { getNpmName, normalizeFileName, addRelativePathPrefix, normalizeOutputFilePath } = require('../utils/pathHelper');
 const { BINDING_REG } = require('../utils/checkAttr');
 
 const RAX_PACKAGE = 'rax';
@@ -204,7 +204,7 @@ function genTagIdExp(expressions) {
 function getRuntimePath(outputPath, targetFileDir, platform, disableCopyNpm) {
   let runtimePath = getRuntimeByPlatform(platform.type);
   if (!disableCopyNpm) {
-    runtimePath = addRelativePathPrefix(relative(targetFileDir, join(outputPath, 'npm', RUNTIME)));
+    runtimePath = addRelativePathPrefix(normalizeOutputFilePath(relative(targetFileDir, join(outputPath, 'npm', RUNTIME))));
   }
   return runtimePath;
 }
@@ -297,7 +297,7 @@ function renameNpmModules(ast, npmRelativePath, filename, cwd) {
     } else {
       ret = join(prefix, value.replace(npmName, realNpmName));
     }
-    ret = addRelativePathPrefix(ret);
+    ret = addRelativePathPrefix(normalizeOutputFilePath(ret));
     // ret => '../npm/_ali/universal-toast/lib/index.js
 
     return t.stringLiteral(normalizeFileName(ret));
@@ -569,7 +569,7 @@ function ensureIndexInPath(value, resourcePath) {
     extensions: ['.js', '.ts']
   });
   const result = relative(dirname(resourcePath), target);
-  return removeJSExtension(addRelativePathPrefix(result));
+  return removeJSExtension(addRelativePathPrefix(normalizeOutputFilePath(result)));
 };
 
 function removeJSExtension(filePath) {

--- a/packages/jsx-compiler/src/modules/components.js
+++ b/packages/jsx-compiler/src/modules/components.js
@@ -12,7 +12,7 @@ const Expression = require('../utils/Expression');
 const compiledComponents = require('../compiledComponents');
 const baseComponents = require('../baseComponents');
 const replaceComponentTagName = require('../utils/replaceComponentTagName');
-const { getNpmName, normalizeFileName, addRelativePathPrefix } = require('../utils/pathHelper');
+const { getNpmName, normalizeFileName, addRelativePathPrefix, normalizeOutputFilePath } = require('../utils/pathHelper');
 
 const RELATIVE_COMPONENTS_REG = /^\..*(\.jsx?)?$/i;
 const PKG_NAME_REG = new RegExp(`^.*\\${sep}node_modules\\${sep}([^\\${sep}]*).*$`);
@@ -365,7 +365,7 @@ function getComponentPath(alias, options) {
 
     // Use specific path to import native miniapp component
     if (pkgName !== alias.from) {
-      return normalizeFileName(addRelativePathPrefix(join(npmRelativePath, alias.from.replace(pkgName, realPkgName))));
+      return normalizeFileName(addRelativePathPrefix(normalizeOutputFilePath(join(npmRelativePath, alias.from.replace(pkgName, realPkgName)))));
     }
     // Use miniappConfig in package.json to import native miniapp component
     const pkg = getComponentConfig(alias.from, options.resourcePath);
@@ -389,13 +389,13 @@ function getComponentPath(alias, options) {
           pkg.miniappConfig.subPackages[alias.local][mainName];
 
       if (disableCopyNpm) {
-        return join(pkg.name, miniappComponentPath);
+        return normalizeOutputFilePath(join(pkg.name, miniappComponentPath));
       }
 
       const miniappConfigRelativePath = relative(pkg.main, miniappComponentPath);
       const realMiniappAbsPath = resolve(realNpmFile, miniappConfigRelativePath);
       const realMiniappRelativePath = realMiniappAbsPath.slice(realMiniappAbsPath.indexOf(realPkgName) + realPkgName.length);
-      return normalizeFileName(addRelativePathPrefix(join(npmRelativePath, realPkgName, realMiniappRelativePath)));
+      return normalizeFileName(addRelativePathPrefix(normalizeOutputFilePath(join(npmRelativePath, realPkgName, realMiniappRelativePath))));
     }
   }
 }

--- a/packages/jsx-compiler/src/utils/checkModule.js
+++ b/packages/jsx-compiler/src/utils/checkModule.js
@@ -1,5 +1,3 @@
-const { sep } = require('path');
-
 const WEEX_MODULE_REG = /^@?weex-/;
 
 function isWeexModule(value) {
@@ -7,7 +5,7 @@ function isWeexModule(value) {
 }
 
 function isNpmModule(value) {
-  return !(value[0] === '.' || value[0] === sep);
+  return !(value[0] === '.' || value[0] === '/');
 }
 
 module.exports = {

--- a/packages/jsx-compiler/src/utils/moduleResolve.js
+++ b/packages/jsx-compiler/src/utils/moduleResolve.js
@@ -1,5 +1,6 @@
 const { sep, join, dirname } = require('path');
 const { existsSync, statSync, readFileSync } = require('fs-extra');
+const { normalizeLocalFilePath } = require('../utils/pathHelper');
 
 function startsWith(prevString, nextString) {
   return prevString.indexOf(nextString) === 0;
@@ -87,11 +88,13 @@ function loadNpmModules(module, start, extension) {
  */
 function moduleResolve(script, dependency, extension = '.js') {
   let target;
-  if (startsWithArr(dependency, ['./', '../', '/', '.\\', '..\\', '\\'])) {
-    let dependencyPath = join(dirname(script), dependency);
+  const normalizedScript = normalizeLocalFilePath(script);
+  const normalizedDependency = normalizeLocalFilePath(dependency);
+  if (startsWithArr(normalizedDependency, [sep, `.${sep}`, `..${sep}`])) {
+    let dependencyPath = join(dirname(normalizedScript), normalizedDependency);
     target = loadAsFile(dependencyPath, extension) || loadAsDirectory(dependencyPath, extension);
   } else {
-    target = loadNpmModules(dependency, dirname(script), extension);
+    target = loadNpmModules(normalizedDependency, dirname(normalizedScript), extension);
   }
   return target;
 };

--- a/packages/jsx-compiler/src/utils/pathHelper.js
+++ b/packages/jsx-compiler/src/utils/pathHelper.js
@@ -13,15 +13,34 @@ function normalizeFileName(filename) {
 }
 
 /**
- * Add ./ (Linux/Unix) or .\ (Windows) at the start of filepath
+ * Add ./ at the start of filepath
  * @param {string} filepath
  * @returns {string}
  */
 function addRelativePathPrefix(filepath) {
-  return filepath[0] !== '.' ? `.${sep}${filepath}` : filepath;
+  return filepath[0] !== '.' ? `./${filepath}` : filepath;
 }
+
+/**
+ * Use '/' as path sep regardless of OS when outputting the path to code
+ * @param {string} filepath
+ */
+function normalizeOutputFilePath(filepath) {
+  return filepath.replace(/\\/g, '/');
+}
+
+/**
+ * use '/'(Linux/Unix) or '\'(Windows) as path sep in local file system
+ * @param {string} filepath
+ */
+function normalizeLocalFilePath(filepath) {
+  return filepath.replace(/\\|\//g, sep);
+}
+
 module.exports = {
   getNpmName,
   normalizeFileName,
-  addRelativePathPrefix
+  addRelativePathPrefix,
+  normalizeOutputFilePath,
+  normalizeLocalFilePath
 };

--- a/packages/jsx2mp-loader/package.json
+++ b/packages/jsx2mp-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-loader",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "",
   "files": [
     "src"

--- a/packages/jsx2mp-loader/src/app-loader.js
+++ b/packages/jsx2mp-loader/src/app-loader.js
@@ -5,7 +5,7 @@ const { getOptions } = require('loader-utils');
 const chalk = require('chalk');
 const PrettyError = require('pretty-error');
 const moduleResolve = require('./utils/moduleResolve');
-const { removeExt, doubleBackslash, replaceBackSlashWithSlash } = require('./utils/pathHelper');
+const { removeExt, doubleBackslash, normalizeOutputFilePath } = require('./utils/pathHelper');
 const eliminateDeadCode = require('./utils/dce');
 const defaultStyle = require('./defaultStyle');
 const processCSS = require('./styleProcessor');
@@ -118,10 +118,10 @@ function transformAppConfig(entryPath, originalConfig, platform) {
           value.forEach(({ component, source, targets }) => {
             // Compatible with old version definition of `component`.
             if (!Array.isArray(targets)) {
-              pages.push(replaceBackSlashWithSlash(moduleResolve(entryPath, getRelativePath(source || component))));
+              pages.push(normalizeOutputFilePath(moduleResolve(entryPath, getRelativePath(source || component))));
             }
             if (Array.isArray(targets) && targets.indexOf('miniapp') > -1) {
-              pages.push(replaceBackSlashWithSlash(moduleResolve(entryPath, getRelativePath(source || component))));
+              pages.push(normalizeOutputFilePath(moduleResolve(entryPath, getRelativePath(source || component))));
             }
           });
         }

--- a/packages/jsx2mp-loader/src/component-loader.js
+++ b/packages/jsx2mp-loader/src/component-loader.js
@@ -5,7 +5,7 @@ const { getOptions } = require('loader-utils');
 const chalk = require('chalk');
 const PrettyError = require('pretty-error');
 const cached = require('./cached');
-const { removeExt, isFromTargetDirs, doubleBackslash, replaceBackSlashWithSlash, addRelativePathPrefix } = require('./utils/pathHelper');
+const { removeExt, isFromTargetDirs, doubleBackslash, normalizeOutputFilePath, addRelativePathPrefix } = require('./utils/pathHelper');
 const eliminateDeadCode = require('./utils/dce');
 const { isTypescriptFile } = require('./utils/judgeModule');
 const processCSS = require('./styleProcessor');
@@ -70,9 +70,9 @@ module.exports = async function componentLoader(content) {
 
       if (/^c-/.test(key)) {
         const result = removeExt(addRelativePathPrefix(relative(dirname(this.resourcePath), value))); // ./components/Repo
-        usingComponents[key] = replaceBackSlashWithSlash(result);
+        usingComponents[key] = normalizeOutputFilePath(result);
       } else {
-        usingComponents[key] = replaceBackSlashWithSlash(value);
+        usingComponents[key] = normalizeOutputFilePath(value);
       }
     });
     config.usingComponents = usingComponents;

--- a/packages/jsx2mp-loader/src/page-loader.js
+++ b/packages/jsx2mp-loader/src/page-loader.js
@@ -5,7 +5,7 @@ const compiler = require('jsx-compiler');
 const chalk = require('chalk');
 const PrettyError = require('pretty-error');
 const cached = require('./cached');
-const { removeExt, isFromTargetDirs, doubleBackslash, replaceBackSlashWithSlash, addRelativePathPrefix } = require('./utils/pathHelper');
+const { removeExt, isFromTargetDirs, doubleBackslash, normalizeOutputFilePath, addRelativePathPrefix } = require('./utils/pathHelper');
 const eliminateDeadCode = require('./utils/dce');
 const processCSS = require('./styleProcessor');
 const output = require('./output');
@@ -77,9 +77,9 @@ module.exports = async function pageLoader(content) {
       const value = config.usingComponents[key];
       if (/^c-/.test(key)) {
         const result = removeExt(addRelativePathPrefix(relative(dirname(this.resourcePath), value)));
-        usingComponents[key] = replaceBackSlashWithSlash(result);
+        usingComponents[key] = normalizeOutputFilePath(result);
       } else {
-        usingComponents[key] = replaceBackSlashWithSlash(value);
+        usingComponents[key] = normalizeOutputFilePath(value);
       }
     });
     config.usingComponents = usingComponents;

--- a/packages/jsx2mp-loader/src/script-loader.js
+++ b/packages/jsx2mp-loader/src/script-loader.js
@@ -3,7 +3,7 @@ const { join, dirname, relative, resolve, sep } = require('path');
 const { copySync, existsSync, mkdirpSync, writeJSONSync, readFileSync, readJSONSync } = require('fs-extra');
 const { getOptions } = require('loader-utils');
 const cached = require('./cached');
-const { removeExt, isFromTargetDirs, doubleBackslash, replaceBackSlashWithSlash, addRelativePathPrefix } = require('./utils/pathHelper');
+const { removeExt, isFromTargetDirs, doubleBackslash, normalizeOutputFilePath, addRelativePathPrefix } = require('./utils/pathHelper');
 const { isNpmModule, isJSONFile, isTypescriptFile } = require('./utils/judgeModule');
 const isMiniappComponent = require('./utils/isMiniappComponent');
 const output = require('./output');
@@ -121,13 +121,13 @@ module.exports = function scriptLoader(content) {
                 paths: [this.resourcePath]
               });
               const relativeComponentPath = normalizeNpmFileName(addRelativePathPrefix(relative(dirname(sourceNativeMiniappScriptFile), realComponentPath)));
-              componentConfig.usingComponents[key] = replaceBackSlashWithSlash(removeExt(relativeComponentPath));
+              componentConfig.usingComponents[key] = normalizeOutputFilePath(removeExt(relativeComponentPath));
               dependencies.push({
                 name: realComponentPath,
                 loader: ScriptLoader, // Native miniapp component js file will loaded by script-loader
                 options: loaderOptions
               });
-            } else if (componentPath.indexOf(`${sep}npm${sep}`) === -1) { // Exclude the path that has been modified by jsx-compiler
+            } else if (componentPath.indexOf('/npm/') === -1) { // Exclude the path that has been modified by jsx-compiler
               const absComponentPath = resolve(dirname(sourceNativeMiniappScriptFile), componentPath);
               dependencies.push({
                 name: absComponentPath,

--- a/packages/jsx2mp-loader/src/utils/judgeModule.js
+++ b/packages/jsx2mp-loader/src/utils/judgeModule.js
@@ -1,10 +1,10 @@
-const { sep, extname } = require('path');
+const { extname } = require('path');
 
 const WEEX_MODULE_REG = /^@?weex-/;
 const JSX2MP_RUNTIME_MODULE_REG = /^jsx2mp-runtime/;
 
 function isNpmModule(value) {
-  return !(value[0] === '.' || value[0] === sep);
+  return !(value[0] === '.' || value[0] === '/');
 }
 
 function isWeexModule(value) {

--- a/packages/jsx2mp-loader/src/utils/pathHelper.js
+++ b/packages/jsx2mp-loader/src/utils/pathHelper.js
@@ -76,22 +76,20 @@ function doubleBackslash(filePath) {
 }
 
 /**
- * Replace backslashs with slashs
- * for pages and usingComponents in json don't support backslashs
- *
- * @param {*} filePath
+ * Use '/' as path sep regardless of OS when outputting the path to code
+ * @param {string} filepath
  */
-function replaceBackSlashWithSlash(filePath) {
-  return filePath.replace(/\\/g, '/');
+function normalizeOutputFilePath(filepath) {
+  return filepath.replace(/\\/g, '/');
 }
 
 /**
- * Add ./ (Linux/Unix) or .\ (Windows) at the start of filepath
+ * Add ./ at the start of filepath
  * @param {string} filepath
  * @returns {string}
  */
 function addRelativePathPrefix(filepath) {
-  return filepath[0] !== '.' ? `.${sep}${filepath}` : filepath;
+  return filepath[0] !== '.' ? `./${filepath}` : filepath;
 }
 
 module.exports = {
@@ -99,6 +97,6 @@ module.exports = {
   isFromTargetDirs,
   replaceExtension,
   doubleBackslash,
-  replaceBackSlashWithSlash,
+  normalizeOutputFilePath,
   addRelativePathPrefix
 };


### PR DESCRIPTION
- Use '/' as path sep both in Windows and Linux/Unix because in miniapp cloud platform, '\' ( windows path sep) can't be identified.