### PR TITLE
feat(jsx2mp): support computed memberepxression

### DIFF
--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -599,12 +599,30 @@ function transformMemberExpression(expression, dynamicBinding, isDirective) {
         isDirective,
       );
     }
-    if (computed && t.isIdentifier(property) && property.__listItem) { // others[index] => others[item.index]
-      propertyReplaceNode = transformIdentifier(
-        property,
-        dynamicBinding,
-        isDirective,
-      );
+    if (computed) { // others[index] => others[item.index]
+      switch (property.type) {
+        case 'Identifier':
+          propertyReplaceNode = transformIdentifier(
+            property,
+            dynamicBinding,
+            isDirective,
+          );
+          break;
+        case 'MemberExpression':
+          propertyReplaceNode = transformMemberExpression(
+            property,
+            dynamicBinding,
+            isDirective,
+          );
+          break;
+        default:
+          const name = dynamicBinding.add({
+            expression: property,
+            isDirective,
+          });
+          propertyReplaceNode = t.identifier(name);
+          break;
+      }
       propertyReplaceNode.__transformed = true;
     }
   }


### PR DESCRIPTION
Support:
```js
const someObject = {info: 'xxxxx'};
const info = 'info';
```
```jsx
<View>someObject[info]</View>
```