### PR TITLE
fix: destory function of a passive effect should call synchronously

### DIFF
--- a/packages/rax/src/__tests__/hooks.js
+++ b/packages/rax/src/__tests__/hooks.js
@@ -1480,10 +1480,7 @@ describe('hooks', () => {
 
       logs = [];
       render(<div />, container);
-      // TODO
-      jest.runAllTimers();
       expect(logs).toEqual(['Did destroy [0]']);
-      // TODO
       expect(container.childNodes[0].tagName).toEqual('DIV');
     });
 
@@ -1520,8 +1517,6 @@ describe('hooks', () => {
 
       logs = [];
       render([], container);
-      // TODO
-      jest.runAllTimers();
       expect(logs).toEqual(['Did destroy [0]']);
       expect(container.childNodes).toEqual([]);
     });
@@ -1560,8 +1555,6 @@ describe('hooks', () => {
 
       logs = [];
       render([], container);
-      // TODO
-      jest.runAllTimers();
       expect(logs).toEqual(['Did destroy']);
       expect(container.childNodes).toEqual([]);
     });
@@ -1672,8 +1665,6 @@ describe('hooks', () => {
 
       logs = [];
       render([], container);
-      // TODO
-      jest.runAllTimers();
       expect(logs).toEqual(['Unmount: 1']);
       expect(container.childNodes).toEqual([]);
     });

--- a/packages/rax/src/hooks.js
+++ b/packages/rax/src/hooks.js
@@ -170,7 +170,7 @@ function useEffectImpl(effect, inputs, defered) {
     };
 
     currentInstance.didMount.push(__create);
-    currentInstance.willUnmount.push(__destory);
+    currentInstance.willUnmount.push(() => __destory(true));
     currentInstance.didUpdate.push(() => {
       const { __prevInputs, __inputs, __create } = hooks[hookID];
       if (__inputs == null || !areInputsEqual(__inputs, __prevInputs)) {


### PR DESCRIPTION
unmount时候，use effect的destory 需要同步进行执行
不然可能和 layout effect可能产生时间差，造成bug
```js

Child() {
 useEffect(() => {
    event.on(setState);
    return () => {
      event.off(setState);
    }
 })
}

App () {
  useLayout() {
    event.emit()
  }
  return type === 1 ? <<Child /> : null
}

```

比如上面，当前渲染中，child 可能已经卸载了，但是先执行app的 useLayout 触发了卸载的child的 setState


