### PR TITLE
fix: fragment cache native node

### DIFF
--- a/packages/rax/src/vdom/fragment.js
+++ b/packages/rax/src/vdom/fragment.js
@@ -61,7 +61,7 @@ class FragmentComponent extends NativeComponent {
 
   __getNativeNode() {
     const renderedChildren = this.__renderedChildren || {};
-    return Array.prototype.concat.apply([], Object.keys(renderedChildren).map(key => renderedChildren[key].__getNativeNode()));
+    return [].concat.apply([], Object.keys(renderedChildren).map(key => renderedChildren[key].__getNativeNode()));
   }
 }
 

--- a/packages/rax/src/vdom/fragment.js
+++ b/packages/rax/src/vdom/fragment.js
@@ -61,7 +61,7 @@ class FragmentComponent extends NativeComponent {
 
   __getNativeNode() {
     const renderedChildren = this.__renderedChildren || {};
-    return Array.prototype.concat.apply([], Object.values(renderedChildren).map(child => child.__getNativeNode()));
+    return Array.prototype.concat.apply([], Object.keys(renderedChildren).map(key => renderedChildren[key].__getNativeNode()));
   }
 }
 

--- a/packages/rax/src/vdom/fragment.js
+++ b/packages/rax/src/vdom/fragment.js
@@ -1,6 +1,5 @@
 import Host from './host';
 import NativeComponent from './native';
-import Instance from './instance';
 import toArray from '../toArray';
 import { INSTANCE, INTERNAL, NATIVE_NODE } from '../constant';
 
@@ -14,11 +13,13 @@ class FragmentComponent extends NativeComponent {
     let instance = this[INSTANCE] = {};
     instance[INTERNAL] = this;
 
-    // Mount children
-    this.__mountChildren(this.__currentElement, context);
-
-    let fragment = this.__getNativeNode();
-
+    const fragment = [];
+    this.__mountChildrenImpl(this._parent, this.__currentElement, context, (nativeNode) => {
+      nativeNode = toArray(nativeNode);
+      for (let i = 0; i < nativeNode.length; i++) {
+        fragment.push(nativeNode[i]);
+      }
+    });
     if (nativeNodeMounter) {
       nativeNodeMounter(fragment, parent);
     } else {
@@ -26,7 +27,6 @@ class FragmentComponent extends NativeComponent {
         Host.driver.appendChild(fragment[i], parent);
       }
     }
-
     if (process.env.NODE_ENV !== 'production') {
       this.__currentElement.type = FragmentComponent;
       Host.reconciler.mountComponent(this);
@@ -35,33 +35,16 @@ class FragmentComponent extends NativeComponent {
     return instance;
   }
 
-  __mountChildren(children, context) {
-    let fragment = this.__getNativeNode();
-
-    return this.__mountChildrenImpl(this._parent, children, context, (nativeNode) => {
-      nativeNode = toArray(nativeNode);
-      for (let i = 0; i < nativeNode.length; i++) {
-        fragment.push(nativeNode[i]);
-      }
-    });
-  }
-
   unmountComponent(shouldNotRemoveChild) {
-    let nativeNode = this[NATIVE_NODE];
-
-    if (nativeNode) {
-      Instance.remove(nativeNode);
-
-      if (!shouldNotRemoveChild) {
-        for (let i = 0, l = nativeNode.length; i < l; i++) {
-          Host.driver.removeChild(nativeNode[i]);
-        }
+    if (!shouldNotRemoveChild) {
+      const nativeNode = this.__getNativeNode();
+      for (let i = 0, l = nativeNode.length; i < l; i++) {
+        Host.driver.removeChild(nativeNode[i]);
       }
     }
 
     // Do not need remove child when their parent is removed
     this.__unmountChildren(true);
-
     this.__destoryComponent();
   }
 
@@ -76,8 +59,9 @@ class FragmentComponent extends NativeComponent {
     }
   }
 
-  __createNativeNode() {
-    return [];
+  __getNativeNode() {
+    const renderedChildren = this.__renderedChildren || {};
+    return Array.prototype.concat.apply([], Object.values(renderedChildren).map(child => child.__getNativeNode()));
   }
 }
 

--- a/packages/rax/src/vdom/native.js
+++ b/packages/rax/src/vdom/native.js
@@ -386,7 +386,6 @@ export default class NativeComponent extends BaseComponent {
     if (nextChildren != null) {
       // `nextIndex` will increment for each child in `nextChildren`
       let nextIndex = 0;
-      let nextNativeNodes = [];
 
       function insertNodes(nativeNodes, parentNode) {
         // The nativeNodes maybe fragment, so convert to array type
@@ -441,20 +440,9 @@ export default class NativeComponent extends BaseComponent {
         // Get the last child
         lastPlacedNode = nextChild.__getNativeNode();
 
-        // Push to nextNativeNodes
         if (isArray(lastPlacedNode)) {
-          nextNativeNodes = nextNativeNodes.concat(lastPlacedNode);
           lastPlacedNode = lastPlacedNode[lastPlacedNode.length - 1];
-        } else {
-          nextNativeNodes.push(lastPlacedNode);
         }
-      }
-
-      // Sync update native refs
-      if (isArray(this[NATIVE_NODE])) {
-        // Clear all and push the new array
-        this[NATIVE_NODE].length = 0;
-        assign(this[NATIVE_NODE], nextNativeNodes);
       }
     }
 


### PR DESCRIPTION
fragment的native node 应该类似 composite 一样，应该是个只读的操作
之前的代码都是自上往下考虑 fragment的native node节点
但是fragment本身并不清楚子节点自身更新带来的native node的变化，从而造成内存泄露和bug