### PR TITLE
fix export muilt component compiler

### DIFF
--- a/packages/jsx-compiler/src/modules/components.js
+++ b/packages/jsx-compiler/src/modules/components.js
@@ -159,120 +159,129 @@ function transformIdentifierComponentName(path, alias, dynamicValue, parsed, opt
 }
 
 function transformComponents(parsed, options) {
-  const { ast, templateAST, imported } = parsed;
+  const { ast, templateAST, imported, exported } = parsed;
   const dynamicValue = {};
   const contextList = [];
   const componentsAlias = {};
-  traverse(templateAST, {
-    JSXOpeningElement(path) {
-      const { node } = path;
-      if (t.isJSXIdentifier(node.name)) {
-        // <View/>
-        const componentTag = node.name.name;
-        const alias = getComponentAlias(componentTag, imported);
-        if (alias) {
-          removeImport(ast, alias);
-          const componentTag = transformIdentifierComponentName(path, alias, dynamicValue, parsed, options);
-          if (componentTag) {
-            // Collect renamed component tag & path info
-            componentsAlias[componentTag] = alias;
-          }
-        } else if (componentTag === 'slot') {
-          transformIdentifierComponentName(
-            path,
-            {
-              name: 'slot',
-              default: true
-            },
-            dynamicValue,
-            parsed,
-            options
-          );
-        }
-      } else if (t.isJSXMemberExpression(node.name)) {
-        // <RecyclerView.Cell /> or <Context.Provider>
-        const { object, property } = node.name;
-        if (t.isJSXIdentifier(object) && t.isJSXIdentifier(property)) {
-          if (property.name === 'Provider') {
-            // <Context.Provider>
-            const valueAttribute = node.attributes.find(a =>
-              t.isJSXIdentifier(a.name, { name: 'value' }),
-            );
-            const contextInitValue = valueAttribute && valueAttribute.value.expression;
-            const contextItem = {
-              contextInitValue,
-              contextName: object.name,
-            };
-            contextList.push(contextItem);
-            replaceComponentTagName(path, t.jsxIdentifier('block'));
-            node.attributes = [];
-          } else {
-            // <RecyclerView.Cell />
-            const alias = getComponentAlias(object.name, imported);
-            removeImport(parsed.ast, alias);
-            if (alias) {
-              const pkg = getComponentConfig(alias.from, options.resourcePath);
-              const isSingleComponent = pkg.miniappConfig && pkg.miniappConfig.subComponents && pkg.miniappConfig.subComponents[property.name];
-              const isComponentLibrary = pkg.miniappConfig && pkg.miniappConfig.subPackages && pkg.miniappConfig.subPackages[alias.local] && pkg.miniappConfig.subPackages[alias.local].subComponents && pkg.miniappConfig.subPackages[alias.local].subComponents[property.name];
 
-              if (isSingleComponent) {
-                let subComponent = pkg.miniappConfig.subComponents[property.name];
-                replaceComponentTagName(
-                  path,
-                  t.jsxIdentifier(subComponent.tagNameMap),
-                );
-                // subComponent default style
-                if (subComponent.attributes && subComponent.attributes.style) {
-                  node.attributes.push(
-                    t.jsxAttribute(
-                      t.jsxIdentifier('style'),
-                      t.stringLiteral(subComponent.attributes.style),
-                    ),
+  if(templateAST) {
+    traverse(templateAST, {
+      JSXOpeningElement(path) {
+        const { node } = path;
+        if (t.isJSXIdentifier(node.name)) {
+          // <View/>
+          const componentTag = node.name.name;
+          const alias = getComponentAlias(componentTag, imported);
+          if (alias) {
+            removeImport(ast, alias);
+            const componentTag = transformIdentifierComponentName(path, alias, dynamicValue, parsed, options);
+            if (componentTag) {
+              // Collect renamed component tag & path info
+              componentsAlias[componentTag] = alias;
+            }
+          } else if (componentTag === 'slot') {
+            transformIdentifierComponentName(
+              path,
+              {
+                name: 'slot',
+                default: true
+              },
+              dynamicValue,
+              parsed,
+              options
+            );
+          }
+        } else if (t.isJSXMemberExpression(node.name)) {
+          // <RecyclerView.Cell /> or <Context.Provider>
+          const { object, property } = node.name;
+          if (t.isJSXIdentifier(object) && t.isJSXIdentifier(property)) {
+            if (property.name === 'Provider') {
+              // <Context.Provider>
+              const valueAttribute = node.attributes.find(a =>
+                t.isJSXIdentifier(a.name, { name: 'value' }),
+              );
+              const contextInitValue = valueAttribute && valueAttribute.value.expression;
+              const contextItem = {
+                contextInitValue,
+                contextName: object.name,
+              };
+              contextList.push(contextItem);
+              replaceComponentTagName(path, t.jsxIdentifier('block'));
+              node.attributes = [];
+            } else {
+              // <RecyclerView.Cell />
+              const alias = getComponentAlias(object.name, imported);
+              removeImport(parsed.ast, alias);
+              if (alias) {
+                const pkg = getComponentConfig(alias.from, options.resourcePath);
+                const isSingleComponent = pkg.miniappConfig && pkg.miniappConfig.subComponents && pkg.miniappConfig.subComponents[property.name];
+                const isComponentLibrary = pkg.miniappConfig && pkg.miniappConfig.subPackages && pkg.miniappConfig.subPackages[alias.local] && pkg.miniappConfig.subPackages[alias.local].subComponents && pkg.miniappConfig.subPackages[alias.local].subComponents[property.name];
+
+                if (isSingleComponent) {
+                  let subComponent = pkg.miniappConfig.subComponents[property.name];
+                  replaceComponentTagName(
+                    path,
+                    t.jsxIdentifier(subComponent.tagNameMap),
                   );
+                  // subComponent default style
+                  if (subComponent.attributes && subComponent.attributes.style) {
+                    node.attributes.push(
+                      t.jsxAttribute(
+                        t.jsxIdentifier('style'),
+                        t.stringLiteral(subComponent.attributes.style),
+                      ),
+                    );
+                  }
+                } else if (isComponentLibrary) {
+                  let subComponent = pkg.miniappConfig.subPackages[alias.local].subComponents[property.name];
+                  const componentTag = subComponent.tagNameMap || `${alias.name}-${object.name}-${property.name}`.toLowerCase().replace(/@|\//g, '_');
+                  replaceComponentTagName(
+                    path,
+                    t.jsxIdentifier(componentTag)
+                  );
+                  componentsAlias[componentTag] = Object.assign({
+                    isSubComponent: true,
+                    subComponentName: property.name
+                  }, alias);
                 }
-              } else if (isComponentLibrary) {
-                let subComponent = pkg.miniappConfig.subPackages[alias.local].subComponents[property.name];
-                const componentTag = subComponent.tagNameMap || `${alias.name}-${object.name}-${property.name}`.toLowerCase().replace(/@|\//g, '_');
-                replaceComponentTagName(
-                  path,
-                  t.jsxIdentifier(componentTag)
-                );
-                componentsAlias[componentTag] = Object.assign({
-                  isSubComponent: true,
-                  subComponentName: property.name
-                }, alias);
               }
             }
+          } else {
+            throw new Error(
+              `NOT_SUPPORTED: Unsupported type of sub components. ${genExpression(
+                node,
+              )}`,
+            );
           }
-        } else {
-          throw new Error(
-            `NOT_SUPPORTED: Unsupported type of sub components. ${genExpression(
-              node,
-            )}`,
-          );
         }
-      }
-    },
-    JSXExpressionContainer(path) {
-      const { node, parentPath } = path;
-      // Only process under JSXEelement
-      if (parentPath.isJSXElement()) {
-        if (
-          ['this.props.children', 'props.children', 'children'].indexOf(
-            genExpression(node.expression),
-          ) > -1
-        ) {
-          path.replaceWith(createJSX('slot'));
+      },
+      JSXExpressionContainer(path) {
+        const { node, parentPath } = path;
+        // Only process under JSXEelement
+        if (parentPath.isJSXElement()) {
+          if (
+            ['this.props.children', 'props.children', 'children'].indexOf(
+              genExpression(node.expression),
+            ) > -1
+          ) {
+            path.replaceWith(createJSX('slot'));
+          }
         }
+      },
+      JSXFragment(path) {
+        // Transform <></> => <block></block>
+        const blockNode = t.jsxIdentifier('block');
+        const { children = [] } = path.node;
+        path.replaceWith(t.jsxElement(t.jsxOpeningElement(blockNode, []), t.jsxClosingElement(blockNode), children));
       }
-    },
-    JSXFragment(path) {
-      // Transform <></> => <block></block>
-      const blockNode = t.jsxIdentifier('block');
-      const { children = [] } = path.node;
-      path.replaceWith(t.jsxElement(t.jsxOpeningElement(blockNode, []), t.jsxClosingElement(blockNode), children));
+    });
+  } else {
+    // add export {} muilt component
+    for (let tagName of exported) {
+      const alias = getComponentAlias2(tagName, imported);
+      if (alias && alias.name) componentsAlias[alias.name] = alias;
     }
-  });
+  }
   return {
     contextList,
     dynamicValue,
@@ -318,6 +327,19 @@ function getComponentAlias(tagName, imported) {
       for (let i = 0, l = value.length; i < l; i++) {
         if (value[i].local === tagName)
           return Object.assign({ from: key }, value[i]);
+      }
+    }
+  }
+}
+
+  // imported && exported
+function getComponentAlias2(exportName, imported) {
+  if (imported) {
+    for (let [key, value] of Object.entries(imported)) {
+      for (let i = 0, l = value.length; i < l; i++) {
+        if (value[i].local === exportName) {
+          return Object.assign({ from: key }, value[i]);
+        }
       }
     }
   }

--- a/packages/jsx-compiler/src/modules/components.js
+++ b/packages/jsx-compiler/src/modules/components.js
@@ -276,9 +276,9 @@ function transformComponents(parsed, options) {
       }
     });
   } else {
-    // add export {} muilt component
+    // add export muilt component
     for (let tagName of exported) {
-      const alias = getComponentAlias2(tagName, imported);
+      const alias = getComponentAlias(tagName, imported);
       if (alias && alias.name) componentsAlias[alias.name] = alias;
     }
   }
@@ -327,19 +327,6 @@ function getComponentAlias(tagName, imported) {
       for (let i = 0, l = value.length; i < l; i++) {
         if (value[i].local === tagName)
           return Object.assign({ from: key }, value[i]);
-      }
-    }
-  }
-}
-
-  // imported && exported
-function getComponentAlias2(exportName, imported) {
-  if (imported) {
-    for (let [key, value] of Object.entries(imported)) {
-      for (let i = 0, l = value.length; i < l; i++) {
-        if (value[i].local === exportName) {
-          return Object.assign({ from: key }, value[i]);
-        }
       }
     }
   }

--- a/packages/jsx-compiler/src/modules/components.js
+++ b/packages/jsx-compiler/src/modules/components.js
@@ -277,8 +277,8 @@ function transformComponents(parsed, options) {
     });
   } else {
     // add export muilt component
-    for (let tagName of exported) {
-      const alias = getComponentAlias(tagName, imported);
+    for (let exportName of exported) {
+      const alias = getComponentAlias(exportName, imported);
       if (alias && alias.name) componentsAlias[alias.name] = alias;
     }
   }
@@ -321,11 +321,11 @@ module.exports = {
   _transformComponents: transformComponents
 };
 
-function getComponentAlias(tagName, imported) {
+function getComponentAlias(quoteName, imported) {
   if (imported) {
     for (let [key, value] of Object.entries(imported)) {
       for (let i = 0, l = value.length; i < l; i++) {
-        if (value[i].local === tagName)
+        if (value[i].local === quoteName)
           return Object.assign({ from: key }, value[i]);
       }
     }


### PR DESCRIPTION
The original call jsx2mp-loader / component-loader to process a single component file, jsx-complier only for a single component file.
Now change: export multiple components, compile processing, take imported & exported union to support multi-component output.

原调用 jsx2mp-loader/component-loader 处理单个组件文件，jsx-complier 仅针对组件单文件。
现改动：可export多组件，compile处理，取imported & exported并集，从而支持多组件输出