### PR TITLE
fix(jsx2mp): memo update

### DIFF
--- a/packages/jsx2mp-runtime/src/bridge.js
+++ b/packages/jsx2mp-runtime/src/bridge.js
@@ -246,7 +246,7 @@ function createReactiveClass(pureRender) {
             }
           }
 
-          return !arePropsEqual || this.__prevForwardRef !== this._forwardRef;
+          return this.__shouldUpdate || !arePropsEqual || this.__prevForwardRef !== this._forwardRef;
         };
       }
     }

--- a/packages/jsx2mp-runtime/src/bridge.js
+++ b/packages/jsx2mp-runtime/src/bridge.js
@@ -245,7 +245,7 @@ function createReactiveClass(pureRender) {
               break;
             }
           }
-
+          // Currently this component is function component, then when state which defined by useState updated, it need check __shouldUpdate.
           return this.__shouldUpdate || !arePropsEqual || this.__prevForwardRef !== this._forwardRef;
         };
       }

--- a/packages/jsx2mp-runtime/src/component.js
+++ b/packages/jsx2mp-runtime/src/component.js
@@ -446,6 +446,7 @@ function diffArray(prev, next) {
   // Only concern about list append case
   if (next.length === 0) return false;
   if (prev.length === 0) return true;
+  // When item's type is object, they have differrent reference, so should use shallowEqual
   return next.slice(0, prev.length).every((val, index) => shallowEqual(prev[index], val));
 }
 

--- a/packages/jsx2mp-runtime/src/hooks.js
+++ b/packages/jsx2mp-runtime/src/hooks.js
@@ -76,6 +76,8 @@ export function useState(initialState) {
         // Current instance is in render update phase.
         // After this one render finish, will continue run.
         hook[2] = newState;
+        // Mark need update
+        currentInstance.__shouldUpdate = true;
         enqueueRender(currentInstance);
       }
     };


### PR DESCRIPTION
解决的问题是，加上 `memo` 之后，组件的 `shouldComponentUpdate ` 方法会默认添加 props 的浅对比来避免父组件重新渲染的时候，子组件也被重新渲染。但是会导致，函数组件自身状态发生更新时，也被这个条件拦下来，导致组件没有重新渲染。