### PR TITLE
fix: sibling text node hydrating error

### DIFF
--- a/packages/driver-dom/package.json
+++ b/packages/driver-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "driver-dom",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "description": "DOM driver for Rax",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/driver-dom/src/__tests__/hydrate.js
+++ b/packages/driver-dom/src/__tests__/hydrate.js
@@ -16,7 +16,7 @@ describe('Hydrate', () => {
 
   it('should keep comment node when rendering multi adjacent text nodes', () => {
     container = document.createElement('div');
-    container.innerHTML = '<div>About:<!--$-->Rax</div>';
+    container.innerHTML = '<div>About:<!--|-->Rax</div>';
     (document.body || document.documentElement).appendChild(container);
 
     const Component = (props) => {

--- a/packages/driver-dom/src/__tests__/hydrate.js
+++ b/packages/driver-dom/src/__tests__/hydrate.js
@@ -14,6 +14,25 @@ describe('Hydrate', () => {
     (document.body || document.documentElement).appendChild(container);
   });
 
+  it('should keep comment node when rendering multi adjacent text nodes', () => {
+    container = document.createElement('div');
+    container.innerHTML = '<div>About:<!--$-->Rax</div>';
+    (document.body || document.documentElement).appendChild(container);
+
+    const Component = (props) => {
+      return (
+        <div>About:{props.name}</div>
+      );
+    };
+
+    render(<Component name="Rax" />, container, { driver: DriverDOM, hydrate: true });
+    jest.runAllTimers();
+
+    expect(container.childNodes[0].childNodes[0].data).toBe('About:');
+    expect(container.childNodes[0].childNodes[1].nodeType).toBe(8); // comment
+    expect(container.childNodes[0].childNodes[2].data).toBe('Rax');
+  });
+
   it('should warn for replaced hydratable element', () => {
     const Component = () => {
       return (

--- a/packages/driver-dom/src/index.js
+++ b/packages/driver-dom/src/index.js
@@ -40,6 +40,7 @@ const REMOVE_ATTRIBUTE = 'removeAttribute';
 const SVG_NS = 'http://www.w3.org/2000/svg';
 const TEXT_NODE = 3;
 const COMMENT_NODE = 8;
+const TEXT_SPLIT_COMMENT = '$';
 const EMPTY = '';
 const HYDRATION_INDEX = '__i';
 const HYDRATION_APPEND = '__a';
@@ -194,6 +195,13 @@ export function updateText(node, text) {
 function findHydrationChild(parent) {
   if (parent[HYDRATION_INDEX] == null) {
     parent[HYDRATION_INDEX] = 0;
+  }
+
+  const child = parent.childNodes[parent[HYDRATION_INDEX]];
+
+  // If child is an comment node for spliting text node, use the next node. eg.
+  if (child && child.nodeType && child.nodeType === COMMENT_NODE && child.data === TEXT_SPLIT_COMMENT) {
+    parent[HYDRATION_INDEX]++;
   }
 
   return parent.childNodes[parent[HYDRATION_INDEX]++];

--- a/packages/driver-dom/src/index.js
+++ b/packages/driver-dom/src/index.js
@@ -40,7 +40,7 @@ const REMOVE_ATTRIBUTE = 'removeAttribute';
 const SVG_NS = 'http://www.w3.org/2000/svg';
 const TEXT_NODE = 3;
 const COMMENT_NODE = 8;
-const TEXT_SPLIT_COMMENT = '$';
+const TEXT_SPLIT_COMMENT = '|';
 const EMPTY = '';
 const HYDRATION_INDEX = '__i';
 const HYDRATION_APPEND = '__a';
@@ -193,18 +193,20 @@ export function updateText(node, text) {
 }
 
 function findHydrationChild(parent) {
+  const childNodes = parent.childNodes;
+
   if (parent[HYDRATION_INDEX] == null) {
     parent[HYDRATION_INDEX] = 0;
   }
 
-  const child = parent.childNodes[parent[HYDRATION_INDEX]];
+  const child = childNodes[parent[HYDRATION_INDEX]++];
 
-  // If child is an comment node for spliting text node, use the next node. eg.
-  if (child && child.nodeType && child.nodeType === COMMENT_NODE && child.data === TEXT_SPLIT_COMMENT) {
-    parent[HYDRATION_INDEX]++;
+  // If child is an comment node for spliting text node, use the next node.
+  if (child && child.nodeType === COMMENT_NODE && child.data === TEXT_SPLIT_COMMENT) {
+    return childNodes[parent[HYDRATION_INDEX]++];
+  } else {
+    return child;
   }
-
-  return parent.childNodes[parent[HYDRATION_INDEX]++];
 }
 
 /**

--- a/packages/driver-dom/src/warning.js
+++ b/packages/driver-dom/src/warning.js
@@ -71,6 +71,11 @@ export function warnForInsertedHydratedElement(
  * @returns {string} for example: <div#home.rax-view.home>
  */
 function getNodeName(node) {
+  // text node don`t have tagName
+  if (!node.tagName) {
+    return node.nodeName;
+  }
+
   const name = node.tagName.toLowerCase();
   const id = node.id ? '#' + node.id : '';
   const classStr = node.className || '';

--- a/packages/rax-server-renderer/package.json
+++ b/packages/rax-server-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-server-renderer",
-  "version": "2.0.0",
+  "version": "1.2.0",
   "description": "Rax renderer for server-side render.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-server-renderer/package.json
+++ b/packages/rax-server-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-server-renderer",
-  "version": "1.1.7",
+  "version": "2.0.0",
   "description": "Rax renderer for server-side render.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/rax-server-renderer/src/__tests__/elements.js
+++ b/packages/rax-server-renderer/src/__tests__/elements.js
@@ -34,7 +34,7 @@ describe('elements and children', () => {
           {''}
         </div>
       );
-      expect(str).toBe('<div></div>');
+      expect(str).toBe('<div><!--$--><!--$--></div>');
     });
 
     it('a div with multiple whitespace children', () => {
@@ -45,7 +45,7 @@ describe('elements and children', () => {
           {' '}
         </div>
       );
-      expect(str).toBe('<div>   </div>');
+      expect(str).toBe('<div> <!--$--> <!--$--> </div>');
     });
 
     it('a div with text sibling to a node', () => {
@@ -77,17 +77,12 @@ describe('elements and children', () => {
 
     it('a leading blank child with a text sibling', () => {
       const str = renderToString(<div>{''}foo</div>);
-      expect(str).toBe('<div>foo</div>');
-    });
-
-    it('a leading blank child with a text sibling', () => {
-      const str = renderToString(<div>{''}foo</div>);
-      expect(str).toBe('<div>foo</div>');
+      expect(str).toBe('<div><!--$-->foo</div>');
     });
 
     it('a trailing blank child with a text sibling', () => {
       const str = renderToString(<div>foo{''}</div>);
-      expect(str).toBe('<div>foo</div>');
+      expect(str).toBe('<div>foo<!--$--></div>');
     });
 
     it('an element with two text children', () => {
@@ -97,7 +92,7 @@ describe('elements and children', () => {
           {'bar'}
         </div>
       );
-      expect(str).toBe('<div>foobar</div>');
+      expect(str).toBe('<div>foo<!--$-->bar</div>');
     });
 
     it('a component returning text node between two text nodes', () => {
@@ -109,7 +104,7 @@ describe('elements and children', () => {
           {'c'}
         </div>
       );
-      expect(str).toBe('<div>abc</div>');
+      expect(str).toBe('<div>a<!--$-->b<!--$-->c</div>');
     });
 
     it('a tree with sibling host and text nodes', () => {
@@ -137,7 +132,7 @@ describe('elements and children', () => {
           e
         </div>,
       );
-      expect(str).toBe('<div>ab<div><!-- _ --><!-- _ -->c<!-- _ -->d</div>e</div>');
+      expect(str).toBe('<div>a<!--$-->b<div><!-- _ --><!-- _ -->c<!-- _ -->d</div>e</div>');
     });
   });
 
@@ -163,7 +158,7 @@ describe('elements and children', () => {
           {40}
         </div>
       );
-      expect(str).toBe('<div>foo40</div>');
+      expect(str).toBe('<div>foo<!--$-->40</div>');
     });
   });
 
@@ -502,7 +497,7 @@ describe('elements and children', () => {
       const str = renderToString(
         <Component>{['a', 'b', [undefined], [[false, 'c']]]}</Component>,
       );
-      expect(str).toBe('ab<!-- _ --><!-- _ -->c');
+      expect(str).toBe('a<!--$-->b<!-- _ --><!-- _ -->c');
     });
   });
 
@@ -521,7 +516,7 @@ describe('elements and children', () => {
           {'<span>Text2&quot;</span>'}
         </div>
       );
-      expect(str).toBe('<div>&lt;span&gt;Text1&amp;quot;&lt;/span&gt;&lt;span&gt;Text2&amp;quot;&lt;/span&gt;</div>');
+      expect(str).toBe('<div>&lt;span&gt;Text1&amp;quot;&lt;/span&gt;<!--$-->&lt;span&gt;Text2&amp;quot;&lt;/span&gt;</div>');
     });
   });
 
@@ -540,7 +535,7 @@ describe('elements and children', () => {
           {'\r\nbaz\nqux\u0000'}
         </div>
       );
-      expect(str).toBe('<div>foo\rbar\r\nbaz\nqux\u0000</div>');
+      expect(str).toBe('<div>foo\rbar<!--$-->\r\nbaz\nqux\u0000</div>');
     });
 
     it('an element with an attribute value with special characters', () => {

--- a/packages/rax-server-renderer/src/__tests__/elements.js
+++ b/packages/rax-server-renderer/src/__tests__/elements.js
@@ -34,7 +34,7 @@ describe('elements and children', () => {
           {''}
         </div>
       );
-      expect(str).toBe('<div><!--$--><!--$--></div>');
+      expect(str).toBe('<div><!--|--><!--|--></div>');
     });
 
     it('a div with multiple whitespace children', () => {
@@ -45,7 +45,7 @@ describe('elements and children', () => {
           {' '}
         </div>
       );
-      expect(str).toBe('<div> <!--$--> <!--$--> </div>');
+      expect(str).toBe('<div> <!--|--> <!--|--> </div>');
     });
 
     it('a div with text sibling to a node', () => {
@@ -77,12 +77,12 @@ describe('elements and children', () => {
 
     it('a leading blank child with a text sibling', () => {
       const str = renderToString(<div>{''}foo</div>);
-      expect(str).toBe('<div><!--$-->foo</div>');
+      expect(str).toBe('<div><!--|-->foo</div>');
     });
 
     it('a trailing blank child with a text sibling', () => {
       const str = renderToString(<div>foo{''}</div>);
-      expect(str).toBe('<div>foo<!--$--></div>');
+      expect(str).toBe('<div>foo<!--|--></div>');
     });
 
     it('an element with two text children', () => {
@@ -92,7 +92,7 @@ describe('elements and children', () => {
           {'bar'}
         </div>
       );
-      expect(str).toBe('<div>foo<!--$-->bar</div>');
+      expect(str).toBe('<div>foo<!--|-->bar</div>');
     });
 
     it('a component returning text node between two text nodes', () => {
@@ -104,7 +104,7 @@ describe('elements and children', () => {
           {'c'}
         </div>
       );
-      expect(str).toBe('<div>a<!--$-->b<!--$-->c</div>');
+      expect(str).toBe('<div>a<!--|-->b<!--|-->c</div>');
     });
 
     it('a tree with sibling host and text nodes', () => {
@@ -132,7 +132,7 @@ describe('elements and children', () => {
           e
         </div>,
       );
-      expect(str).toBe('<div>a<!--$-->b<div><!-- _ --><!-- _ -->c<!-- _ -->d</div>e</div>');
+      expect(str).toBe('<div>a<!--|-->b<div><!-- _ --><!-- _ -->c<!-- _ -->d</div>e</div>');
     });
   });
 
@@ -158,7 +158,7 @@ describe('elements and children', () => {
           {40}
         </div>
       );
-      expect(str).toBe('<div>foo<!--$-->40</div>');
+      expect(str).toBe('<div>foo<!--|-->40</div>');
     });
   });
 
@@ -497,7 +497,7 @@ describe('elements and children', () => {
       const str = renderToString(
         <Component>{['a', 'b', [undefined], [[false, 'c']]]}</Component>,
       );
-      expect(str).toBe('a<!--$-->b<!-- _ --><!-- _ -->c');
+      expect(str).toBe('a<!--|-->b<!-- _ --><!-- _ -->c');
     });
   });
 
@@ -516,7 +516,7 @@ describe('elements and children', () => {
           {'<span>Text2&quot;</span>'}
         </div>
       );
-      expect(str).toBe('<div>&lt;span&gt;Text1&amp;quot;&lt;/span&gt;<!--$-->&lt;span&gt;Text2&amp;quot;&lt;/span&gt;</div>');
+      expect(str).toBe('<div>&lt;span&gt;Text1&amp;quot;&lt;/span&gt;<!--|-->&lt;span&gt;Text2&amp;quot;&lt;/span&gt;</div>');
     });
   });
 
@@ -535,7 +535,7 @@ describe('elements and children', () => {
           {'\r\nbaz\nqux\u0000'}
         </div>
       );
-      expect(str).toBe('<div>foo\rbar<!--$-->\r\nbaz\nqux\u0000</div>');
+      expect(str).toBe('<div>foo\rbar<!--|-->\r\nbaz\nqux\u0000</div>');
     });
 
     it('an element with an attribute value with special characters', () => {

--- a/packages/rax-server-renderer/src/__tests__/form.js
+++ b/packages/rax-server-renderer/src/__tests__/form.js
@@ -146,7 +146,7 @@ describe('form', () => {
           <option value="bar">A {'B'}</option>
         </select>
       );
-      expect(str).toBe('<select value="bar"><option value="bar">A <!--$-->B</option></select>');
+      expect(str).toBe('<select value="bar"><option value="bar">A <!--|-->B</option></select>');
     });
   });
 

--- a/packages/rax-server-renderer/src/__tests__/form.js
+++ b/packages/rax-server-renderer/src/__tests__/form.js
@@ -146,7 +146,7 @@ describe('form', () => {
           <option value="bar">A {'B'}</option>
         </select>
       );
-      expect(str).toBe('<select value="bar"><option value="bar">A B</option></select>');
+      expect(str).toBe('<select value="bar"><option value="bar">A <!--$-->B</option></select>');
     });
   });
 

--- a/packages/rax-server-renderer/src/__tests__/hooks.js
+++ b/packages/rax-server-renderer/src/__tests__/hooks.js
@@ -16,7 +16,7 @@ describe('hooks', () => {
       }
 
       let str = renderToString(<Counter />);
-      expect(str).toBe('<span>Count: 0</span>');
+      expect(str).toBe('<span>Count: <!--$-->0</span>');
     });
 
     it('lazy state initialization', () => {
@@ -28,7 +28,7 @@ describe('hooks', () => {
       }
 
       let str = renderToString(<Counter />);
-      expect(str).toBe('<span>Count: 0</span>');
+      expect(str).toBe('<span>Count: <!--$-->0</span>');
     });
 
     it('should ignore setCount on the server', () => {
@@ -41,7 +41,7 @@ describe('hooks', () => {
       }
 
       let str = renderToString(<Counter />);
-      expect(str).toBe('<span>Count: 0</span>');
+      expect(str).toBe('<span>Count: <!--$-->0</span>');
     });
   });
 
@@ -131,7 +131,7 @@ describe('hooks', () => {
       }
 
       let str = renderToString(<Counter />);
-      expect(str).toBe('<span>Count: 0</span>');
+      expect(str).toBe('<span>Count: <!--$-->0</span>');
     });
   });
 
@@ -145,7 +145,7 @@ describe('hooks', () => {
       }
 
       let str = renderToString(<Counter count={0} />);
-      expect(str).toBe('<span>Count: 0</span>');
+      expect(str).toBe('<span>Count: <!--$-->0</span>');
     });
   });
 
@@ -159,7 +159,7 @@ describe('hooks', () => {
       }
 
       let str = renderToString(<Counter count={0} />);
-      expect(str).toBe('<span>Count: 0</span>');
+      expect(str).toBe('<span>Count: <!--$-->0</span>');
     });
 
     it('should support render time callbacks', () => {

--- a/packages/rax-server-renderer/src/__tests__/hooks.js
+++ b/packages/rax-server-renderer/src/__tests__/hooks.js
@@ -16,7 +16,7 @@ describe('hooks', () => {
       }
 
       let str = renderToString(<Counter />);
-      expect(str).toBe('<span>Count: <!--$-->0</span>');
+      expect(str).toBe('<span>Count: <!--|-->0</span>');
     });
 
     it('lazy state initialization', () => {
@@ -28,7 +28,7 @@ describe('hooks', () => {
       }
 
       let str = renderToString(<Counter />);
-      expect(str).toBe('<span>Count: <!--$-->0</span>');
+      expect(str).toBe('<span>Count: <!--|-->0</span>');
     });
 
     it('should ignore setCount on the server', () => {
@@ -41,7 +41,7 @@ describe('hooks', () => {
       }
 
       let str = renderToString(<Counter />);
-      expect(str).toBe('<span>Count: <!--$-->0</span>');
+      expect(str).toBe('<span>Count: <!--|-->0</span>');
     });
   });
 
@@ -131,7 +131,7 @@ describe('hooks', () => {
       }
 
       let str = renderToString(<Counter />);
-      expect(str).toBe('<span>Count: <!--$-->0</span>');
+      expect(str).toBe('<span>Count: <!--|-->0</span>');
     });
   });
 
@@ -145,7 +145,7 @@ describe('hooks', () => {
       }
 
       let str = renderToString(<Counter count={0} />);
-      expect(str).toBe('<span>Count: <!--$-->0</span>');
+      expect(str).toBe('<span>Count: <!--|-->0</span>');
     });
   });
 
@@ -159,7 +159,7 @@ describe('hooks', () => {
       }
 
       let str = renderToString(<Counter count={0} />);
-      expect(str).toBe('<span>Count: <!--$-->0</span>');
+      expect(str).toBe('<span>Count: <!--|-->0</span>');
     });
 
     it('should support render time callbacks', () => {

--- a/packages/rax-server-renderer/src/__tests__/lifecycle.js
+++ b/packages/rax-server-renderer/src/__tests__/lifecycle.js
@@ -46,7 +46,7 @@ describe('lifecycle', () => {
 
     const response = renderToString(<TestComponent />);
 
-    expect(response).toBe('<span>Component name: <!--$-->TestComponent</span>');
+    expect(response).toBe('<span>Component name: <!--|-->TestComponent</span>');
 
     expect(lifecycle).toEqual([
       'getInitialState',

--- a/packages/rax-server-renderer/src/__tests__/lifecycle.js
+++ b/packages/rax-server-renderer/src/__tests__/lifecycle.js
@@ -46,7 +46,7 @@ describe('lifecycle', () => {
 
     const response = renderToString(<TestComponent />);
 
-    expect(response).toBe('<span>Component name: TestComponent</span>');
+    expect(response).toBe('<span>Component name: <!--$-->TestComponent</span>');
 
     expect(lifecycle).toEqual([
       'getInitialState',

--- a/packages/rax-server-renderer/src/__tests__/renderToString.js
+++ b/packages/rax-server-renderer/src/__tests__/renderToString.js
@@ -87,7 +87,7 @@ describe('renderToString', () => {
     };
 
     let str = renderToString(<MyComponent name="rax" />);
-    expect(str).toBe('<h1> Hello <!--$-->rax</h1>');
+    expect(str).toBe('<h1> Hello <!--|-->rax</h1>');
   });
 
   it('render with effect hook', () => {
@@ -104,7 +104,7 @@ describe('renderToString', () => {
     };
 
     let str = renderToString(<MyComponent name="rax" />);
-    expect(str).toBe('<h1> Hello <!--$-->rax</h1>');
+    expect(str).toBe('<h1> Hello <!--|-->rax</h1>');
   });
 
   it('render with Context.Provider', () => {
@@ -126,7 +126,7 @@ describe('renderToString', () => {
     };
 
     let str = renderToString(<MyContext />);
-    expect(str).toBe('<div>Current theme is <!--$-->dark<!--$-->.</div>');
+    expect(str).toBe('<div>Current theme is <!--|-->dark<!--|-->.</div>');
   });
 
 
@@ -150,7 +150,7 @@ describe('renderToString', () => {
     };
 
     let str = renderToString(<MyContext />);
-    expect(str).toBe('<div>Current theme is <!--$-->dark<!--$-->.</div>');
+    expect(str).toBe('<div>Current theme is <!--|-->dark<!--|-->.</div>');
   });
 
   it('render with context hook', () => {
@@ -165,7 +165,7 @@ describe('renderToString', () => {
     };
 
     let str = renderToString(<MyComponent />);
-    expect(str).toBe('<div>The answer is <!--$-->5<!--$-->.</div>');
+    expect(str).toBe('<div>The answer is <!--|-->5<!--|-->.</div>');
   });
 
   it('render with reducer hook', () => {
@@ -194,7 +194,7 @@ describe('renderToString', () => {
     }
 
     let str = renderToString(<MyComponent initialCount={0} />);
-    expect(str).toBe('<div>Count: <!--$-->0</div>');
+    expect(str).toBe('<div>Count: <!--|-->0</div>');
   });
 
   it('render with pre compiled html and attrs', () => {

--- a/packages/rax-server-renderer/src/__tests__/renderToString.js
+++ b/packages/rax-server-renderer/src/__tests__/renderToString.js
@@ -87,7 +87,7 @@ describe('renderToString', () => {
     };
 
     let str = renderToString(<MyComponent name="rax" />);
-    expect(str).toBe('<h1> Hello rax</h1>');
+    expect(str).toBe('<h1> Hello <!--$-->rax</h1>');
   });
 
   it('render with effect hook', () => {
@@ -104,7 +104,7 @@ describe('renderToString', () => {
     };
 
     let str = renderToString(<MyComponent name="rax" />);
-    expect(str).toBe('<h1> Hello rax</h1>');
+    expect(str).toBe('<h1> Hello <!--$-->rax</h1>');
   });
 
   it('render with Context.Provider', () => {
@@ -126,7 +126,7 @@ describe('renderToString', () => {
     };
 
     let str = renderToString(<MyContext />);
-    expect(str).toBe('<div>Current theme is dark.</div>');
+    expect(str).toBe('<div>Current theme is <!--$-->dark<!--$-->.</div>');
   });
 
 
@@ -150,7 +150,7 @@ describe('renderToString', () => {
     };
 
     let str = renderToString(<MyContext />);
-    expect(str).toBe('<div>Current theme is dark.</div>');
+    expect(str).toBe('<div>Current theme is <!--$-->dark<!--$-->.</div>');
   });
 
   it('render with context hook', () => {
@@ -165,7 +165,7 @@ describe('renderToString', () => {
     };
 
     let str = renderToString(<MyComponent />);
-    expect(str).toBe('<div>The answer is 5.</div>');
+    expect(str).toBe('<div>The answer is <!--$-->5<!--$-->.</div>');
   });
 
   it('render with reducer hook', () => {
@@ -194,7 +194,7 @@ describe('renderToString', () => {
     }
 
     let str = renderToString(<MyComponent initialCount={0} />);
-    expect(str).toBe('<div>Count: 0</div>');
+    expect(str).toBe('<div>Count: <!--$-->0</div>');
   });
 
   it('render with pre compiled html and attrs', () => {

--- a/packages/rax-server-renderer/src/index.js
+++ b/packages/rax-server-renderer/src/index.js
@@ -21,7 +21,7 @@ const VOID_ELEMENTS = {
   'wbr': true
 };
 
-const TEXT_SPLIT_COMMENT = '<!--$-->';
+const TEXT_SPLIT_COMMENT = '<!----->';
 
 const ESCAPE_LOOKUP = {
   '&': '&amp;',

--- a/packages/rax-server-renderer/src/index.js
+++ b/packages/rax-server-renderer/src/index.js
@@ -308,7 +308,6 @@ class ServerRenderer {
 
   renderElementToString(element, context) {
     if (typeof element === 'string') {
-      debugger;
       if (this.previousWasTextNode) {
         return TEXT_SPLIT_COMMENT + escapeText(element);
       }

--- a/packages/rax-server-renderer/src/index.js
+++ b/packages/rax-server-renderer/src/index.js
@@ -21,7 +21,7 @@ const VOID_ELEMENTS = {
   'wbr': true
 };
 
-const TEXT_SPLIT_COMMENT = '<!----->';
+const TEXT_SPLIT_COMMENT = '<!--|-->';
 
 const ESCAPE_LOOKUP = {
   '&': '&amp;',


### PR DESCRIPTION
Fix：https://github.com/alibaba/rax/issues/1883

Add comment tag `<!--$-->`  between sibling text node to avoid hydrate error. 

When rendering such a Component:

```jsx
<div>{year}{month}{date}</div>
```

The HTML string after SSR is:

```html
<div>2020<!--$-->05<!--$-->21</div>
```

When hydrate the `month`, it will find the text node after `<!--$-->` to compare text, instand of create a new text node.

The child nodes of div after hydrate is:

```json
[
"2020",
"<!--$-->",
"05",
"<!--$-->",
"21"
]
```

