### PR TITLE
release rax@1.1.3

### DIFF
--- a/packages/rax/package.json
+++ b/packages/rax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax",
-  "version": "1.1.2",
+  "version": "1.1.3-0",
   "description": "A universal React-compatible render engine.",
   "license": "BSD-3-Clause",
   "main": "index.js",

--- a/packages/rax/package.json
+++ b/packages/rax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax",
-  "version": "1.1.3-0",
+  "version": "1.1.3",
   "description": "A universal React-compatible render engine.",
   "license": "BSD-3-Clause",
   "main": "index.js",

--- a/packages/rax/src/__tests__/hooks.js
+++ b/packages/rax/src/__tests__/hooks.js
@@ -719,6 +719,44 @@ describe('hooks', () => {
     expect(container.childNodes[0].data).toEqual('2');
   });
 
+  it('destory function of a passive effect should call synchronously', () => {
+    const container = createNodeElement('div');
+    const event = {
+      listeners: [],
+      emit: () => event.listeners.forEach(f => f()),
+      off: (f) => event.listeners = event.listeners.filter(_f => _f !== f),
+      on: (f) => event.listeners.push(f)
+    };
+
+    function useForceUpdate() {
+      const [, setCount] = useState(0);
+      return () => setCount(count => count + 1);
+    }
+
+    function Child() {
+      const forceUpdate = useForceUpdate();
+      useEffect(() => {
+        event.on(forceUpdate);
+        return () => {
+          event.off(forceUpdate);
+        };
+      });
+      return <div>child</div>;
+    }
+
+    function App(props) {
+      useLayoutEffect(() => {
+        event.emit();
+      }, [props.type]);
+      return props.type === 1 ? <Child /> : null;
+    }
+
+    render(<App type={1} />, container);
+    expect(container.childNodes[0].childNodes[0].data).toEqual('child');
+    render(<App type={2} />, container);
+    expect(container.childNodes[0].nodeType).toBe(8);
+  });
+
   describe('updates during the render phase', () => {
     it('restarts the render function and applies the new updates on top', () => {
       const container = createNodeElement('div');
@@ -1480,10 +1518,7 @@ describe('hooks', () => {
 
       logs = [];
       render(<div />, container);
-      // TODO
-      jest.runAllTimers();
       expect(logs).toEqual(['Did destroy [0]']);
-      // TODO
       expect(container.childNodes[0].tagName).toEqual('DIV');
     });
 
@@ -1520,8 +1555,6 @@ describe('hooks', () => {
 
       logs = [];
       render([], container);
-      // TODO
-      jest.runAllTimers();
       expect(logs).toEqual(['Did destroy [0]']);
       expect(container.childNodes).toEqual([]);
     });
@@ -1560,8 +1593,6 @@ describe('hooks', () => {
 
       logs = [];
       render([], container);
-      // TODO
-      jest.runAllTimers();
       expect(logs).toEqual(['Did destroy']);
       expect(container.childNodes).toEqual([]);
     });
@@ -1672,8 +1703,6 @@ describe('hooks', () => {
 
       logs = [];
       render([], container);
-      // TODO
-      jest.runAllTimers();
       expect(logs).toEqual(['Unmount: 1']);
       expect(container.childNodes).toEqual([]);
     });

--- a/packages/rax/src/hooks.js
+++ b/packages/rax/src/hooks.js
@@ -170,7 +170,7 @@ function useEffectImpl(effect, inputs, defered) {
     };
 
     currentInstance.didMount.push(__create);
-    currentInstance.willUnmount.push(__destory);
+    currentInstance.willUnmount.push(() => __destory(true));
     currentInstance.didUpdate.push(() => {
       const { __prevInputs, __inputs, __create } = hooks[hookID];
       if (__inputs == null || !areInputsEqual(__inputs, __prevInputs)) {


### PR DESCRIPTION
- [x] fix: fragment cache native node https://github.com/alibaba/rax/pull/1867
- [x] fix: portal with new context https://github.com/alibaba/rax/pull/1866
- [x] fix: unmount dirty component https://github.com/alibaba/rax/pull/1865
- [x] fix: destory function of a passive effect should call synchronously https://github.com/alibaba/rax/pull/1864
- [x] fix: render returns null to null empty nodes are also rebuilt https://github.com/alibaba/rax/pull/1842