### PR TITLE
[BETA] Feat: jsx-compiler support quickapp

### DIFF
--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.4.10",
+  "version": "0.4.11-0",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [
@@ -29,7 +29,7 @@
     "kebab-case": "^1.0.0",
     "md5": "^2.2.1",
     "resolve": "^1.12.0",
-    "jsx2qa-compiler": "^0.1.0"
+    "jsx2qa-compiler": "0.1.0-0"
   },
   "devDependencies": {
     "handlebars": "^4.5.0",

--- a/packages/jsx2qa-compiler/README.md
+++ b/packages/jsx2qa-compiler/README.md
@@ -1,0 +1,83 @@
+# jsx2qa-compiler
+
+Transform JSX styled Rax Components into quickapp parts.
+
+## example
+
+input:
+
+```jsx
+import { Component } from 'rax';
+
+export default class extends Component {
+
+  render() {
+    return (<view>hello world</view>);
+  }
+}
+```
+
+Run jsx2qa compiler.
+
+- type: Required, enum of `app`, `page`, `component`.
+- outputPath: Required, string of dist path.
+- sourcePath: Required, string of source path.
+- resourcePath: Required, string of original file path.
+
+```js
+const compile = require('jsx2qa-compiler');
+const { baseOptions } = compile;
+
+const output = compile(code, { ...baseOptions, type: 'component' });
+```
+
+output:
+
+- ast
+  - Babel 7 format AST of JS code
+- imported
+  - Imported modules and local identifiers
+- exported
+  - Exported identifiers
+- template
+  - axml template for quickapp
+- code
+  - Transformed JS code.
+- map
+  - Source map of JS code
+- config
+  - JS Object, quickapp config
+- style
+  - String, acss of style.
+- usingComponents
+
+eg.
+
+```js
+{
+  ast: ASTNodeTree,
+  imported: {
+    rax: [
+      {
+        local: "Component",
+        default: false,
+        importFrom: "Component",
+        name: "rax",
+        external: true
+      }
+    ]
+  },
+  exported: ["default"],
+  code:
+    'import { createComponent as __create_component__, Component as __component__ } from "jsx2mp-runtime";\n\nconst __def__ = class extends __component__ {\n  render() {\n    return {};\n  }\n\n};\n\nComponent(__create_component__(__def__, {\n  events: []\n}));',
+  map: null,
+  config: {
+    component: true,
+    usingComponents: {}
+  },
+  style: "",
+  usingComponents: {},
+  iconfontMap: [],
+  template: "<div>hello world</div>"
+}
+```

--- a/packages/jsx2qa-compiler/package.json
+++ b/packages/jsx2qa-compiler/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@ali/jsx2qa-compiler",
-  "version": "0.1.0",
+  "name": "jsx2qa-compiler",
+  "version": "0.1.0-0",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx2qa-compiler/package.json
+++ b/packages/jsx2qa-compiler/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "jsx-compiler",
-  "version": "0.4.10",
+  "name": "@ali/jsx2qa-compiler",
+  "version": "0.1.0",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [
@@ -28,8 +28,7 @@
     "fs-extra": "^7.0.1",
     "kebab-case": "^1.0.0",
     "md5": "^2.2.1",
-    "resolve": "^1.12.0",
-    "jsx2qa-compiler": "^0.1.0"
+    "resolve": "^1.12.0"
   },
   "devDependencies": {
     "handlebars": "^4.5.0",

--- a/packages/jsx2qa-compiler/src/__tests__/__modules__/stripIndent.js
+++ b/packages/jsx2qa-compiler/src/__tests__/__modules__/stripIndent.js
@@ -1,0 +1,23 @@
+function minIndent(str) {
+  const match = str.match(/^[ \t]*(?=\S)/gm);
+
+  if (!match) {
+    return 0;
+  }
+
+  return Math.min.apply(Math, match.map(x => x.length));
+}
+
+module.exports = function stripIndent(template) {
+  if (typeof template !== 'string') return template;
+
+  const indent = minIndent(template);
+
+  if (indent === 0) {
+    return template;
+  }
+
+  const re = new RegExp(`^[ \\t]{${indent}}`, 'gm');
+
+  return template.replace(re, '').trim();
+};

--- a/packages/jsx2qa-compiler/src/baseComponents.js
+++ b/packages/jsx2qa-compiler/src/baseComponents.js
@@ -1,0 +1,11 @@
+module.exports = [
+  'rax-text',
+  'rax-scrollview',
+  'rax-textinput',
+  'rax-picture',
+  'rax-slider',
+  'rax-icon',
+  'rax-link',
+  'rax-video',
+  'rax-image'
+];

--- a/packages/jsx2qa-compiler/src/codegen/genCode.js
+++ b/packages/jsx2qa-compiler/src/codegen/genCode.js
@@ -1,0 +1,17 @@
+const generate = require('@babel/generator').default;
+
+const generateOptions = {
+  sourceFileName: '',
+  sourceMaps: true
+};
+
+/**
+ * Generate code and map from babel ast.
+ * @param ast
+ */
+function genCode(ast, options = {}) {
+  options.sourceMaps = !options.turnOffSourceMap;
+  return generate(ast, Object.assign({}, generateOptions, options));
+}
+
+module.exports = genCode;

--- a/packages/jsx2qa-compiler/src/codegen/genExpression.js
+++ b/packages/jsx2qa-compiler/src/codegen/genExpression.js
@@ -1,0 +1,16 @@
+const generate = require('@babel/generator').default;
+
+/**
+ * @param expression {Expression}
+ * @param overridesOption {Object}
+ * @return {String}
+ */
+function generateExpression(expression, overridesOption = {}) {
+  const { code } = generate(
+    expression,
+    overridesOption
+  );
+  return code;
+}
+
+module.exports = generateExpression;

--- a/packages/jsx2qa-compiler/src/codegen/index.js
+++ b/packages/jsx2qa-compiler/src/codegen/index.js
@@ -1,0 +1,18 @@
+const invokeModules = require('../utils/invokeModules');
+const genCode = require('./genCode');
+const { baseOptions } = require('../options');
+
+function generate(parsed, options = baseOptions) {
+  const { code, map } = genCode(parsed.ast, options);
+  const ret = {
+    code, map,
+    // config, template, style and others should be generated in plugin modules.
+  };
+
+  invokeModules(options.modules, 'generate', ret, parsed, options);
+
+  return ret;
+}
+
+
+exports.generate = generate;

--- a/packages/jsx2qa-compiler/src/const.js
+++ b/packages/jsx2qa-compiler/src/const.js
@@ -1,0 +1,24 @@
+module.exports = {
+  for: 'for',
+  if: 'if',
+  else: 'else',
+  elseif: 'elif',
+  key: 'key',
+  ext: 'ux',
+  div: {
+    onClick: 'onclick',
+    onLongPress: 'onlongpress',
+    onTouchStart: 'ontouchstart',
+    onTouchEnd: 'ontouchend',
+    onTouchMove: 'ontouchmove',
+    onTouchCancel: 'ontouchcancel',
+    onAppear: 'onappear',
+    onDisAppear: 'ondisappear',
+    onBlur: 'onblur',
+    onFocus: 'onfocus',
+    onSwipe: 'onswipe',
+    onResize: 'onresize',
+    className: '__rax-view'
+  },
+  baseComponent: 'div',
+};

--- a/packages/jsx2qa-compiler/src/getCompiledComponents.js
+++ b/packages/jsx2qa-compiler/src/getCompiledComponents.js
@@ -1,0 +1,3 @@
+module.exports = {
+  'rax-view': 'div',
+};

--- a/packages/jsx2qa-compiler/src/index.js
+++ b/packages/jsx2qa-compiler/src/index.js
@@ -1,21 +1,16 @@
 const { generate } = require('./codegen');
 const { parse } = require('./parser');
 const { baseOptions } = require('./options');
-const adapter = require('./adapter');
-const jsx2qaCompiler = require('jsx2qa-compiler');
 
 /**
  * @param template {String} Template string.
  * @param options {Object} Compiler options.
  */
 function compile(template, options) {
-  const type = options.platform && options.platform.type || 'ali';
-  if (type === 'quickapp') return jsx2qaCompiler(template, options);
-  options.adapter = options.adapter || adapter[type];
   const parsed = parse(template.trim(), options);
   const generated = generate(parsed, options);
   const { ast, imported, exported } = parsed;
-
+  console.log('res', Object.assign({ ast, imported, exported }, generated));
   return Object.assign({ ast, imported, exported }, generated);
 }
 

--- a/packages/jsx2qa-compiler/src/modules/__tests__/attribute.js
+++ b/packages/jsx2qa-compiler/src/modules/__tests__/attribute.js
@@ -1,0 +1,34 @@
+const t = require('@babel/types');
+const { _transformAttribute, _transformPreComponentAttr } = require('../attribute');
+const { parseExpression } = require('../../parser');
+const genCode = require('../../codegen/genCode');
+
+describe('Transform JSX Attribute', () => {
+  it('should transform attribute name is key', () => {
+    const code = '<View key={1}>test</View>';
+    const ast = parseExpression(code);
+    _transformAttribute(ast, code);
+    expect(genCode(ast).code).toEqual('<View key={1}>test</View>');
+  });
+  it('should transform attribute name is className', () => {
+    const code = '<rax-view className="box">test</rax-view>';
+    const ast = parseExpression(code);
+    _transformAttribute(ast, code);
+    expect(genCode(ast).code).toEqual('<rax-view class="box">test</rax-view>');
+  });
+  it("should collect attribute name is ref and parse it's value as a string in quickApp", () => {
+    const code = '<View ref={scrollViewRef}>test</View>';
+    const ast = parseExpression(code);
+    const { refs } = _transformAttribute(ast, code);
+    expect(genCode(ast).code).toEqual('<View id="scrollViewRef">test</View>');
+    expect(refs[0].name.value).toEqual('scrollViewRef');
+  });
+  it('should transform quickApp custom component style into styleSheet', () => {
+    const code = "<rax-link style={{width: '100rpx'}}>test</rax-link>";
+    const ast = parseExpression(code);
+    _transformAttribute(ast, code);
+    expect(genCode(ast).code).toEqual(`<rax-link styleSheet={{
+  width: '100rpx'
+}}>test</rax-link>`);
+  });
+});

--- a/packages/jsx2qa-compiler/src/modules/__tests__/components.js
+++ b/packages/jsx2qa-compiler/src/modules/__tests__/components.js
@@ -1,0 +1,52 @@
+const { _transformComponents, _transformDataset } = require('../components');
+const { parseExpression, parseCode, getImported } = require('../../parser/index');
+const genCode = require('../../codegen/genCode');
+
+describe('Transform components', () => {
+  it('should transform Provider', () => {
+    const ast = parseExpression(`
+    <ThemeContext.Provider value={this.state}>
+        <View>Test</View>
+      </ThemeContext.Provider>`);
+    const parsed = {
+      templateAST: ast
+    };
+    const { contextList } = _transformComponents(parsed);
+    expect(genCode(ast).code).toEqual(`<block>
+        <View>Test</View>
+      </block>`);
+    expect(contextList[0].contextName).toEqual('ThemeContext');
+    expect(genCode(contextList[0].contextInitValue).code).toEqual('this.state');
+  });
+  it('should transform Custom Component', () => {
+    const importedAST = parseCode(`
+      import CustomEl from '../components/CustomEl';
+      import View from 'rax-view';
+    `);
+    const imported = getImported(importedAST);
+    const ast = parseExpression(`
+      <View>
+        <CustomEl />
+      </View>
+    `);
+    const parsed = {
+      templateAST: ast,
+      imported,
+      componentDependentProps: {},
+      componentsAlias: {}
+    };
+    const { componentsAlias } = _transformComponents(parsed);
+    expect(genCode(ast).code).toEqual(`<rax-view>
+        <c-a94616 tag-id="{{tagId}}-0" />
+      </rax-view>`);
+    expect(componentsAlias).toEqual({'c-a94616': {'default': true, 'namespace': false, 'from': '../components/CustomEl', 'isCustomEl': true, 'local': 'CustomEl', 'name': 'c-a94616'}});
+  });
+  it('should transform JSX Fragment', () => {
+    const ast = parseExpression('<View><>Test</></View>');
+    const parsed = {
+      templateAST: ast
+    };
+    _transformComponents(parsed);
+    expect(genCode(ast).code).toEqual('<View><block>Test</block></View>');
+  });
+});

--- a/packages/jsx2qa-compiler/src/modules/__tests__/condition.js
+++ b/packages/jsx2qa-compiler/src/modules/__tests__/condition.js
@@ -1,0 +1,242 @@
+const t = require('@babel/types');
+const { _transformTemplate, _transformRenderFunction } = require('../condition');
+const { parseExpression } = require('../../parser');
+const genCode = require('../../codegen/genCode');
+const genExpression = require('../../codegen/genExpression');
+
+describe('Transform condition', () => {
+  it('transform conditional expression in JSXContainer', () => {
+    const ast = parseExpression(`
+      <View>{foo ? <View /> : <Text />}</View>
+    `);
+    _transformTemplate(ast, {}, {});
+    expect(genCode(ast).code).toEqual('<View><block if={foo}><View /></block><block else><Text /></block></View>');
+  });
+
+  it("transform conditional's consequent is conditional expression", () => {
+    const ast = parseExpression(`
+      <View>{foo ? bar ? <Bar /> : <View /> : <Text />}</View>
+    `);
+    const dynamicValue = _transformTemplate(ast, {}, {});
+
+    expect(genCode(ast).code).toEqual('<View><block if={foo}><block if={bar}><Bar /></block><block else><View /></block></block><block else><Text /></block></View>');
+  });
+
+  it("transform condition's alternate is conditional expression", () => {
+    const ast = parseExpression(`
+      <View>{empty ? <Empty /> : loading ? null : 'xxx' }</View>
+    `);
+    const dynamicValue = _transformTemplate(ast, {}, {});
+
+    expect(genCode(ast).code).toEqual('<View><View if={empty}><Empty /></View><View else><View if={loading}></View><View else>xxx</View></View></View>');
+  });
+
+  it('skip list dynamic value', () => {
+    const ast = parseExpression(`
+      <view className="content">
+          {list.map(item => {
+            return (
+              <text>{item.type === 'FLOW_WALLET' ? 'M' : '¥'}</text>
+            );
+          })}
+        </view>
+    `);
+    _transformTemplate(ast, {}, {});
+    expect(genCode(ast).code).toEqual(
+      `<view className=\"content\">
+          {list.map(item => {
+    return <text><View if={item.type === 'FLOW_WALLET'}>M</View><View else>¥</View></text>;
+  })}
+        </view>`);
+  });
+
+  it('transform conditional expression with list', () => {
+    const ast = parseExpression(`
+      <View>
+        { tabList ? tabList.map(tab => {
+          return <View>{tab}</View>
+        }) : 123 }
+      </View>
+    `);
+    _transformTemplate(ast, {}, {});
+    expect(genCode(ast).code).toEqual(`<View>
+        <View if={tabList}>{tabList.map(tab => {
+      return <View>{tab}</View>;
+    })}</View><View else>123</View>
+      </View>`);
+  });
+
+  it('transform simple logical expression', () => {
+    const ast = parseExpression(`
+      <View>
+        { a && <View>1</View>}
+      </View>
+    `);
+    _transformTemplate(ast, {}, {});
+    expect(genCode(ast).code).toEqual(`<View>
+        <block if={a}><View>1</View></block><block else>{a}</block>
+      </View>`);
+  });
+
+  it('transform nested logical expression', () => {
+    const ast = parseExpression(`
+      <View>
+        { a || b && <View>1</View>}
+      </View>
+    `);
+    _transformTemplate(ast, {}, {});
+    expect(genCode(ast).code).toEqual(`<View>
+        <block if={!a}><block if={b}><View>1</View></block><block else>{b}</block></block><block else>{a}</block>
+      </View>`);
+  });
+
+  it('transform logical expression with jsx', () => {
+    const ast = parseExpression(`
+      <View>
+        { <View>1</View> && <View>2</View> }
+        { <View>1</View> || <View>2</View> }
+      </View>
+    `);
+    _transformTemplate(ast, {}, {});
+    expect(genCode(ast).code).toEqual(`<View>
+        <View>2</View>
+        <View>1</View>
+      </View>`);
+  });
+});
+
+describe('Transiform condition render function', () => {
+  it('basic case', () => {
+    const ast = parseExpression(`(function render(props) {
+        let { a, b, ...c } = props;
+        let vdom;
+        if (a > 0) {
+          vdom = <view>case 1</view>
+        } else {
+          vdom = <view>case 1.1</view>
+        }
+        if (a > 1) {
+          vdom = <view>case 2</view>
+        }
+        return vdom;
+      })
+    `);
+
+    const tmpVars = _transformRenderFunction(ast);
+    expect(genExpression(tmpVars.vdom)).toEqual('<block><block if={a > 0}><view>case 1</view></block><block else><view>case 1.1</view></block><block if={a > 1}><view>case 2</view></block></block>');
+    expect(genExpression(ast)).toEqual(`function render(props) {
+  let {
+    a,
+    b,
+    ...c
+  } = props;
+  let vdom;
+
+  if (a > 0) {} else {}
+
+  if (a > 1) {}
+
+  return vdom;
+}`);
+  });
+
+  it('without consequent body', () => {
+    const ast = parseExpression(`(function render(props) {
+        let { a, b, ...c } = props;
+        let vdom;
+        if (a > 0) {
+          vdom = <view>case 1</view>
+        } else {
+          vdom = <view>case 1.1</view>
+        }
+        if (a > 1) vdom = <view>case 2</view>
+        return vdom;
+      })
+    `);
+
+    const tmpVars = _transformRenderFunction(ast);
+    expect(genExpression(tmpVars.vdom)).toEqual('<block><block if={a > 0}><view>case 1</view></block><block else><view>case 1.1</view></block><block if={a > 1}><view>case 2</view></block></block>');
+    expect(genExpression(ast)).toEqual(`function render(props) {
+  let {
+    a,
+    b,
+    ...c
+  } = props;
+  let vdom;
+
+  if (a > 0) {} else {}
+
+  if (a > 1) {}
+
+  return vdom;
+}`);
+  });
+
+  it('assign without jsx element', () => {
+    const ast = parseExpression(`(function render(props) {
+        let { a, b, ...c } = props;
+        let vdom;
+        if (a > 0) {
+          vdom = 123;
+          b = 2;
+        } else {
+          vdom = <view>case 1.1</view>
+        }
+        return vdom;
+      })
+    `);
+
+    const tmpVars = _transformRenderFunction(ast);
+    expect(genExpression(tmpVars.vdom)).toEqual('<block><block if={a > 0}>{123}</block><block else><view>case 1.1</view></block></block>');
+    expect(genExpression(ast)).toEqual(`function render(props) {
+  let {
+    a,
+    b,
+    ...c
+  } = props;
+  let vdom;
+
+  if (a > 0) {
+    vdom = 123;
+    b = 2;
+  } else {}
+
+  return vdom;
+}`);
+  });
+
+  it('local variable and render value are the same', () => {
+    const ast = parseExpression(`(function render(props) {
+        const [a, setState] = useState(1);
+        useEffect(() => {
+          const { isLogin } = app;
+          let a = 2;
+          if (isLogin) {
+            a = 3;
+          }
+          setState(a);
+        }, [])
+        return <View>{a}</View>;
+      })
+    `);
+
+    const tmpVars = _transformRenderFunction(ast);
+    expect(genExpression(tmpVars.vdom)).toEqual('');
+    expect(genExpression(ast)).toEqual(`function render(props) {
+  const [a, setState] = useState(1);
+  useEffect(() => {
+    const {
+      isLogin
+    } = app;
+    let a = 2;
+
+    if (isLogin) {
+      a = 3;
+    }
+
+    setState(a);
+  }, []);
+  return <View>{a}</View>;
+}`);
+  });
+});

--- a/packages/jsx2qa-compiler/src/modules/__tests__/element.js
+++ b/packages/jsx2qa-compiler/src/modules/__tests__/element.js
@@ -1,0 +1,373 @@
+const t = require('@babel/types');
+const { _transform } = require('../element');
+const { parseExpression } = require('../../parser');
+const genCode = require('../../codegen/genCode');
+const traverse = require('../../utils/traverseNodePath');
+const DynamicBinding = require('../../utils/DynamicBinding');
+
+function genInlineCode(ast) {
+  return genCode(ast, {
+    comments: false, // Remove template comments.
+    concise: true, // Reduce whitespace, but not to disable all.
+  });
+}
+
+function genDynamicValue(dynamicValue) {
+  const properties = [];
+  const store = dynamicValue.getStore();
+  store.map(({name, value}) => {
+    properties.push(t.objectProperty(t.identifier(name), value));
+  });
+  return genInlineCode(t.objectExpression(properties)).code;
+}
+
+function genDynamicEvents(dynamicEvents) {
+  const properties = [];
+  dynamicEvents.map(({name, value}) => {
+    properties.push(t.objectProperty(t.identifier(name), value));
+  });
+  return genInlineCode(t.objectExpression(properties)).code;
+}
+
+describe('Transform JSXElement', () => {
+  describe('JSXExpressionContainer Types', () => {
+    it('identifier', () => {
+      const sourceCode = '<View foo={bar}>{ bar }</View>';
+      const ast = parseExpression(sourceCode);
+      const dynamicValue = new DynamicBinding('d');
+      _transform({
+        templateAST: ast,
+        dynamicValue
+      }, sourceCode);
+      const code = genInlineCode(ast).code;
+      expect(code).toEqual('<View foo="{{d0}}">{{ d0 }}</View>');
+      expect(genDynamicValue(dynamicValue)).toEqual('{ d0: bar }');
+    });
+
+    it('should handle literial types', () => {
+      const sourceCode = `
+        <View
+          bool={true}
+          str={'string'}
+          num={8}
+          undef={undefined}
+          nil={null}
+          regexp={/a-z/}
+          tpl={\`hello world \${exp}\`}
+        >{false}{'string'}{8}{}{undefined}{null}{/a-z/}</View>
+      `;
+      const ast = parseExpression(sourceCode);
+      const dynamicValue = new DynamicBinding('d');
+      _transform({
+        templateAST: ast,
+        dynamicValue
+      }, sourceCode);
+
+      expect(genInlineCode(ast).code).toEqual('<View bool="{{true}}" str=\'string\' num="{{8}}" nil="{{null}}" regexp="{{d0}}" tpl="hello world {{d1}}">string8{{ d0 }}</View>');
+
+      expect(genDynamicValue(dynamicValue)).toEqual('{ d0: /a-z/, d1: exp }');
+    });
+
+    it('should handle expression types in quickApp', () => {
+      const sourceCode = `
+        <View
+          onFn1={(event) => { console.log(event) }}
+          onFn2={(event) => console.log(event)}
+          onFn3={function(event) {console.log(event)}}
+          prop={this.props.foo}
+          state={this.state.bar}
+          member={foo.bar.c}
+          call1={fn()}
+          call2={foo.method()}
+          conditional={a ? 1 : 2}
+          conditionalComplex={a() ? 1 : 2}
+          compare={a >= 1}
+          math={a - 1}
+          bitwise={~a}
+          logical={a || b}
+          stringOp={'a' + c}
+          comma={a,c}
+          inst={new Foo()}
+          delete={delete foo.bar}
+          type={typeof aaa}
+          relation={'a' in b}
+          group={(a + 1)}
+          spread={{...{ a: 1 }}}
+        />
+      `;
+      const ast = parseExpression(sourceCode);
+      const dynamicValue = new DynamicBinding('d');
+      const { dynamicEvents } = _transform({
+        templateAST: ast,
+        dynamicValue
+      }, sourceCode, true);
+
+      expect(genDynamicValue(dynamicValue)).toEqual('{ d0: this.props.foo, d1: this.state.bar, d2: foo, d3: fn(), d4: foo.method(), d5: a, d6: a() ? 1 : 2, d7: ~a, d8: b, d9: c, d10: new Foo(), d11: delete foo.bar, d12: typeof aaa, d13: { ...{ a: 1 } } }');
+
+      expect(genDynamicEvents(dynamicEvents)).toEqual('{ e0: event => { console.log(event); }, e1: console.log, e2: function (event) { console.log(event); } }');
+
+      expect(genInlineCode(ast).code).toEqual('<View onFn1="{{e0}}" onFn2="{{e1}}" onFn3="{{e2}}" prop="{{d0}}" state="{{d1}}" member="{{d2.bar.c}}" call1="{{d3}}" call2="{{d4}}" conditional="{{d5 ? 1 : 2}}" conditionalComplex="{{d6}}" compare="{{d5 >= 1}}" math="{{d5 - 1}}" bitwise="{{d7}}" logical="{{d5 || d8}}" stringOp="{{\'a\' + d9}}" comma="{{d5, d9}}" inst="{{d10}}" delete="{{d11}}" type="{{d12}}" relation="{{\'a\' in d8}}" group="{{d5 + 1}}" spread="{{d13}}" />');
+    });
+
+    it('unsupported', () => {
+      const dynamicValue = new DynamicBinding('d');
+      expect(() => {
+        _transform({
+          templateAST: parseExpression('<View assign={a = 1} />'),
+          dynamicValue
+        });
+      }).toThrowError();
+    });
+
+    it('should handle MemberExpression', () => {
+      const sourceCode = '<View>{a.b.c}</View>';
+      const ast = parseExpression(sourceCode);
+      const dynamicValue = new DynamicBinding('d');
+      _transform({
+        templateAST: ast,
+        dynamicValue
+      }, sourceCode);
+      expect(genInlineCode(ast).code).toEqual('<View>{{ d0.b.c }}</View>');
+      expect(genDynamicValue(dynamicValue)).toEqual('{ d0: a }');
+    });
+
+    it('should handle nested MemberExpression', () => {
+      const sourceCode = '<View>{a ? a.b[c.d] : 1}</View>';
+      const ast = parseExpression(sourceCode);
+      const dynamicValue = new DynamicBinding('d');
+      _transform({
+        templateAST: ast,
+        dynamicValue
+      }, sourceCode);
+      expect(genInlineCode(ast).code).toEqual('<View>{{ d0 ? d0.b[d1.d] : 1 }}</View>');
+      expect(genDynamicValue(dynamicValue)).toEqual('{ d0: a, d1: c }');
+    });
+  });
+
+  describe('event handlers', () => {
+    it('class methods', () => {
+      const ast = parseExpression(`
+        <View
+          onClick={this.handleClick}
+        />
+      `);
+      /**
+       * { _e0: this.handleClick }
+       */
+      const { dynamicEvents } = _transform({
+        templateAST: ast,
+      });
+      expect(genDynamicEvents(dynamicEvents)).toEqual('{ e0: this.handleClick }');
+      expect(genInlineCode(ast).code).toEqual('<View onClick="{{e0}}" />');
+    });
+
+    it('prop methods', () => {
+      const ast = parseExpression(`
+        <View
+          onClick={props.onClick}
+        />
+      `);
+      const { dynamicEvents } = _transform({
+        templateAST: ast
+      });
+
+      expect(genInlineCode(ast).code).toEqual('<View onClick="{{e0}}" />');
+      expect(genDynamicEvents(dynamicEvents)).toEqual('{ e0: props.onClick }');
+    });
+
+    it('skip list', () => {
+      const sourceCode = `<View a:for="{{arr}}" a:for-item="item" a:for-index="index">
+        <Text>{{ item }} {{ index }}</Text>
+      </View>`;
+      const ast = parseExpression(sourceCode);
+      const dynamicValue = new DynamicBinding('d');
+      traverse(ast, {
+        JSXExpressionContainer(p) {
+          p.node.__transformed = true;
+        }
+      });
+      _transform({
+        templateAST: ast,
+        dynamicValue
+      }, sourceCode);
+      expect(genDynamicValue(dynamicValue)).toEqual('{}');
+    });
+
+    it('bind methods in quickApp', () => {
+      const sourceCode = `
+        <View
+          onClick={onClick.bind(this, { a: 1 })}
+          onKeyPress={this.handleClick.bind(this, 'hello')}
+        />
+      `;
+      const ast = parseExpression(sourceCode);
+      const { dynamicEvents } = _transform({
+        templateAST: ast
+      }, sourceCode, true);
+
+      expect(genInlineCode(ast).code).toEqual('<View onClick="{{e0}}" onKeyPress="{{e1}}" data-e0-arg-context="this" data-e0-arg-0="{{ { a: 1 } }}" data-e1-arg-context="this" data-e1-arg-0="{{\'hello\'}}" />');
+      expect(genDynamicEvents(dynamicEvents)).toEqual('{ e0: onClick, e1: this.handleClick }');
+    });
+  });
+
+  describe('list in quickApp', () => {
+    it('list type', () => {
+      const sourceCode = `<View>
+          <block for={array.map((val, index) => {
+      return {
+        val: val,
+        index: index
+      };
+    })}><View>{val}</View></block>
+        </View>`;
+      const ast = parseExpression(sourceCode);
+      traverse(ast, {
+        JSXElement(path) {
+          const { node, parentPath } = path;
+          if (node.openingElement.name.name === 'block') {
+            path._forParams = {
+              forItem: 'val',
+              forIndex: 'index',
+              forList: 'array'
+            };
+            node.__transformed = true;
+          }
+        }
+      });
+      const dynamicValue = new DynamicBinding('d');
+      _transform({
+        templateAST: ast,
+        dynamicValue
+      }, sourceCode, true);
+      expect(genInlineCode(ast).code).toEqual(`<View>
+          <block for="{{(index, val) in d0}}"><View>{{ d1 }}</View></block>
+        </View>`);
+    });
+  });
+
+
+  describe('element', () => {
+    it('should handle identifier', () => {
+      const ast = parseExpression('<View>{foo}</View>');
+      const dynamicValue = new DynamicBinding('d');
+      _transform({
+        templateAST: ast,
+        dynamicValue
+      });
+      const code = genInlineCode(ast).code;
+      expect(code).toEqual('<View>{{ d0 }}</View>');
+      expect(genDynamicValue(dynamicValue)).toEqual('{ d0: foo }');
+    });
+
+    it('should handle literial types', () => {
+      const sourceCode = `
+        <View>
+          {'string'}
+          {8}
+          {/a-z/}
+          {{ a: 1 }}
+          {[0, 1, 2]}
+        </View>
+      `;
+      const ast = parseExpression(sourceCode);
+      const dynamicValue = new DynamicBinding('d');
+      _transform({
+        templateAST: ast,
+        dynamicValue
+      }, sourceCode);
+
+      expect(genInlineCode(ast).code).toEqual(`<View>
+          string
+          8
+          {{ d0 }}
+          {{ d1 }}
+          {{ d2 }}
+        </View>`);
+      expect(genDynamicValue(dynamicValue)).toEqual('{ d0: /a-z/, d1: { a: 1 }, d2: [0, 1, 2] }');
+    });
+
+    it('should handle expressions', () => {
+      const sourceCode = `<View>
+        {this.props.foo}
+        {this.state.bar}
+        {foo.bar.c}
+        {fn()}
+        {foo.method()}
+        {a ? 1 : 2}
+        {a >= 1}
+        {a - 1}
+        {~a}
+        {a || b}
+        {'a' + c}
+        {a,c}
+        {new Foo()}
+        {delete foo.bar}
+        {typeof aaa}
+        {'a' in b}
+        {(a + 1)}
+        {{...{ a: 1 }}}
+      </View>`;
+      const ast = parseExpression(sourceCode);
+      const dynamicValue = new DynamicBinding('d');
+      _transform({
+        templateAST: ast,
+        dynamicValue
+      }, sourceCode);
+
+      expect(genInlineCode(ast).code).toEqual(`<View>
+        {{ d0 }}
+        {{ d1 }}
+        {{ d2.bar.c }}
+        {{ d3 }}
+        {{ d4 }}
+        {{ d5 ? 1 : 2 }}
+        {{ d5 >= 1 }}
+        {{ d5 - 1 }}
+        {{ d6 }}
+        {{ d5 || d7 }}
+        {{ 'a' + d8 }}
+        {{ d5, d8 }}
+        {{ d9 }}
+        {{ d10 }}
+        {{ d11 }}
+        {{ 'a' in d7 }}
+        {{ d5 + 1 }}
+        {{ d12 }}
+      </View>`);
+
+      expect(genDynamicValue(dynamicValue)).toEqual('{ d0: this.props.foo, d1: this.state.bar, d2: foo, d3: fn(), d4: foo.method(), d5: a, d6: ~a, d7: b, d8: c, d9: new Foo(), d10: delete foo.bar, d11: typeof aaa, d12: { ...{ a: 1 } } }');
+    });
+
+    it('should handle text', () => {
+      const sourceCode = '<Text style={styles.name}>{data && data.itemTitle ? data.itemTitle : \'\'}</Text>';
+      const ast = parseExpression(sourceCode);
+      const dynamicValue = new DynamicBinding('d');
+      _transform({
+        templateAST: ast,
+        dynamicValue
+      }, sourceCode);
+      expect(genInlineCode(ast).code).toEqual('<Text style="{{d0.name}}">{{ d1 && d1.itemTitle ? d1.itemTitle : \'\' }}</Text>');
+      expect(genDynamicValue(dynamicValue)).toEqual('{ d0: styles, d1: data }');
+    });
+
+    it('should collect object expression', () => {
+      const sourceCode = '<Image style={{...styles.avator, ...styles[\`\${rank}Avator\`]}} source={{ uri: avator }}></Image>';
+      const ast = parseExpression(sourceCode);
+      const dynamicValue = new DynamicBinding('d');
+      _transform({
+        templateAST: ast,
+        dynamicValue
+      }, sourceCode);
+      expect(genInlineCode(ast).code).toEqual('<Image style="{{d0}}" source="{{ { uri: d1 } }}"></Image>');
+      expect(genDynamicValue(dynamicValue)).toEqual('{ d0: { ...styles.avator, ...styles[`${rank}Avator`] }, d1: avator }');
+    });
+
+    it('unsupported', () => {
+      expect(() => {
+        _transform({
+          templateAST: parseExpression('<View>{a = 1}</View>')
+        });
+      }).toThrowError();
+    });
+  });
+});

--- a/packages/jsx2qa-compiler/src/modules/__tests__/jsx-plus.js
+++ b/packages/jsx2qa-compiler/src/modules/__tests__/jsx-plus.js
@@ -1,0 +1,259 @@
+const {
+  _transformCondition,
+  _transformList,
+  _transformClass,
+  _transformFragment,
+  _transformSlotDirective
+} = require('../jsx-plus');
+const { parseExpression } = require('../../parser');
+const genExpression = require('../../codegen/genExpression');
+
+let count = 0;
+let id = 0;
+
+describe('Directives', () => {
+  describe('list', () => {
+    it('simple', () => {
+      const code = `
+      <View>
+        <View x-for={val in array}>{val}</View>
+      </View>
+    `;
+      const ast = parseExpression(code);
+      _transformList({
+        templateAST: ast
+      }, code);
+      const index = 'index' + count++;
+      expect(genExpression(ast))
+        .toEqual(`<View>
+        <View for={array.map((val, ${index}) => {
+    return {
+      val: val,
+      ${index}: ${index}
+    };
+  })}>{{
+      val.val
+    }}</View>
+      </View>`);
+    });
+
+    it('nested', () => {
+      const code = `
+      <View>
+        <View x-for={item in array}>
+          <View x-for={item2 in item}>{item2}</View>
+      </View>
+</View>
+    `;
+      const ast = parseExpression(code);
+      _transformList({
+        templateAST: ast
+      }, code);
+      const index1 = 'index' + count++;
+      const index2 = 'index' + count++;
+      expect(genExpression(ast))
+        .toEqual(`<View>
+        <View for={array.map((item, ${index1}) => {
+    return {
+      item: item.map((item2, ${index2}) => {
+        return {
+          item2: item2,
+          ${index2}: ${index2}
+        };
+      }),
+      ${index1}: ${index1}
+    };
+  })}>
+          <View for={item}>{{
+        item2.item2
+      }}</View>
+      </View>
+</View>`);
+    });
+
+    it('difficult nested', () => {
+      const code = `
+      <View className="rxpi-coupon">
+        <View
+          x-for={(row, rowIndex) in testList}
+          className="rxpi-coupon-row"
+          key={'test_' + rowIndex}
+        >
+          <View x-for={(col, colIndex) in row} >
+            <Text key={colIndex}>{colIndex}</Text>
+          </View>
+        </View>
+      </View>
+    `;
+      const ast = parseExpression(code);
+      _transformList({
+        templateAST: ast
+      }, code);
+      const index1 = 'index' + count++;
+      const index2 = 'index' + count++;
+      expect(genExpression(ast))
+        .toEqual(`<View className="rxpi-coupon">
+        <View className="rxpi-coupon-row" key="{{row.d0}}" for={testList.map((row, ${index1}) => {
+    return {
+      row: row.map((col, ${index2}) => {
+        return {
+          col: col,
+          ${index2}: ${index2}
+        };
+      }),
+      ${index1}: ${index1},
+      d0: 'test_' + ${index1}
+    };
+  })}>
+          <View for={row}>
+            <Text key="{{col.${index2}}}">{{
+          col.${index2}
+        }}</Text>
+          </View>
+        </View>
+      </View>`);
+    });
+
+    it('use format function in x-for', () => {
+      const code = `
+      <View>
+        <View x-for={val in array}>{format(val)}</View>
+      </View>
+    `;
+      const ast = parseExpression(code);
+      _transformList({
+        templateAST: ast
+      }, code);
+      const index = 'index' + count++;
+      expect(genExpression(ast))
+        .toEqual(`<View>
+        <View for={array.map((val, ${index}) => {
+    return {
+      val: val,
+      ${index}: ${index},
+      d0: format(val)
+    };
+  })}>{{
+      val.d0
+    }}</View>
+      </View>`);
+    });
+  });
+
+  describe('condition', () => {
+    it('simple', () => {
+      const ast = parseExpression(`
+        <View x-if={value}></View>
+      `);
+      _transformCondition(ast);
+      expect(genExpression(ast)).toEqual('<View if={value}></View>');
+    });
+  });
+
+  describe('fragment', () => {
+    it('simple', () => {
+      const ast = parseExpression(`
+        <Fragment foo="bar"></Fragment>
+      `);
+      _transformFragment(ast);
+      expect(genExpression(ast)).toEqual('<block foo="bar"></block>');
+    });
+  });
+
+  describe('class', () => {
+    it('simple', () => {
+      const ast = parseExpression(`
+        <View x-class={classNames}></View>
+      `);
+      _transformClass(ast);
+      expect(genExpression(ast)).toEqual('<View className={__classnames__(classNames)}></View>');
+    });
+
+    it('combine', () => {
+      const ast = parseExpression(`
+        <View className="home" x-class={classNames}></View>
+      `);
+      _transformClass(ast);
+      expect(genExpression(ast)).toEqual('<View className={`home${" "}${__classnames__(classNames)}`}></View>');
+    });
+  });
+
+  describe('slot in quickApp', () => {
+    it('should transform ali slot', () => {
+      const code = '<View x-slot:item="props">{props.text}</View>';
+      const ast = parseExpression(code);
+      _transformSlotDirective(ast, code);
+      expect(genExpression(ast)).toEqual('<View slot="item">{props.text}</View>');
+    });
+  });
+
+  describe('ref', () => {
+    it('should transform ref in x-for', () => {
+      const code = `<View>
+        <View x-for={(item, index) in data} ref={refs[index]}>test</View>
+      </View>`;
+      const ast = parseExpression(code);
+      _transformList({
+        templateAST: ast
+      }, code);
+      const index = 'index' + count++;
+      expect(genExpression(ast)).toEqual(`<View>
+        <View ref="{{item.d0}}" id="id_${id}{{${index}}}" for={data.map((item, ${index}) => {
+    this._registerRefs([{
+      "name": "${id}" + ${index},
+      "method": refs[${index}],
+      "type": "native",
+      "id": "id_${id}" + ${index}
+    }]);
+
+    return {
+      item: item,
+      ${index}: ${index},
+      d0: "${id}" + ${index}
+    };
+  })}>test</View>
+      </View>`);
+    });
+  });
+
+  it('should transform ref in nested x-for', () => {
+    const code = `<View>
+        <View x-for={(item, index) in data}>
+            <View x-for={(item, idx) in item.list} ref={refs[idx]}>test</View>
+        </View>
+      </View>`;
+    const ast = parseExpression(code);
+    _transformList({
+      templateAST: ast
+    }, code);
+    id++;
+    const index1 = 'index' + count++;
+    const index2 = 'index' + count++;
+    expect(genExpression(ast)).toEqual(`<View>
+        <View for={data.map((item, ${index1}) => {
+    return {
+      item: { ...item,
+        list: item.list.map((item, ${index2}) => {
+          this._registerRefs([{
+            "name": "${id}" + ${index2},
+            "method": refs[${index2}],
+            "type": "native",
+            "id": "id_${id}" + ${index2}
+          }]);
+
+          return {
+            item: item,
+            ${index2}: ${index2},
+            d0: "${id}" + ${index2}
+          };
+        })
+      },
+      ${index1}: ${index1}
+    };
+  })}>
+            <View ref="{{item.d0}}" id="id_${id}{{${index2}}}" for={item.list}>test</View>
+        </View>
+      </View>`);
+    id++;
+  });
+});

--- a/packages/jsx2qa-compiler/src/modules/__tests__/list.js
+++ b/packages/jsx2qa-compiler/src/modules/__tests__/list.js
@@ -1,0 +1,455 @@
+const { _transformList } = require('../list');
+const { parseExpression } = require('../../parser');
+const genCode = require('../../codegen/genCode');
+
+
+let count = 0;
+
+describe('Transform list', () => {
+  it('transform array.map in JSXContainer with inline return', () => {
+    const code = `
+    <View>{arr.map((val, idx) => <item data-value={val} data-key={idx} />)}</View>
+  `;
+    const ast = parseExpression(code);
+    _transformList({
+      templateAST: ast
+    }, code);
+    const index = 'index' + count++;
+    expect(genCode(ast).code).toEqual(`<View><block for={arr.map((val, ${index}) => {
+    return {
+      val: val,
+      ${index}: ${index}
+    };
+  })}><item data-value="{{val.val}}" data-key="{{val.${index}}}" /></block></View>`);
+  });
+
+  it('transform array.map in JSXContainer', () => {
+    const code = `
+    <View>{arr.map((val, idx) => {
+      return <item data-value={val} data-key={idx} />
+    })}</View>
+  `;
+    const ast = parseExpression(code);
+    _transformList({
+      templateAST: ast
+    }, code);
+    const index = 'index' + count++;
+    expect(genCode(ast).code).toEqual(`<View><block for={arr.map((val, ${index}) => {
+    return {
+      val: val,
+      ${index}: ${index}
+    };
+  })}><item data-value="{{val.val}}" data-key="{{val.${index}}}" /></block></View>`);
+  });
+
+  it('bind list variable', () => {
+    const code = `
+    <View>{arr.map((item, idx) => <View>{item.title}<image source={{ uri: item.picUrl }} resizeMode={resizeMode} /></View>)}</View>
+  `;
+    const ast = parseExpression(code);
+    _transformList({
+      templateAST: ast
+    }, code);
+    const index = 'index' + count++;
+    expect(genCode(ast).code).toEqual(`<View><block for={arr.map((item, ${index}) => {
+    return {
+      item: item,
+      ${index}: ${index},
+      d0: item.title,
+      d1: {
+        uri: item.picUrl
+      }
+    };
+  })}><View>{{
+        item.d0
+      }}<image source="{{item.d1}}" resizeMode={resizeMode} /></View></block></View>`);
+  });
+
+  it('list elements', () => {
+    const code = `<View>{[1,2,3].map((val, idx) => {
+      return <Text>{idx}</Text>;
+    })}</View>`;
+    const ast = parseExpression(code);
+    _transformList({
+      templateAST: ast
+    }, code);
+    const index = 'index' + count++;
+    expect(genCode(ast, { concise: true }).code).toEqual(`<View><block for={[1, 2, 3].map((val, ${index}) => { return { val: val, ${index}: ${index} }; })}><Text>{{ val.${index} }}</Text></block></View>`);
+  });
+
+  it('nested list', () => {
+    const code = `
+<View
+  className="header"
+  onClick={() => {
+    setWorkYear(workYear + 1);
+  }}
+>
+  <View style={{ color: 'red' }}>workYear: {workYear}</View>
+  <View style={{ color: 'red' }}>count: {count}</View>
+  {arr.map(l1 => {
+    return (
+      <View>
+        {l1.map(l2 => {
+          return <View>{l2}</View>;
+        })}
+      </View>
+    );
+  })}
+  <Loading count={count} />
+  {props.children}
+</View>`;
+    const ast = parseExpression(code);
+    _transformList({
+      templateAST: ast
+    }, code);
+    const index1 = 'index' + count++;
+    const index2 = 'index' + count++;
+    expect(genCode(ast).code).toEqual(`<View className="header" onClick={() => {
+  setWorkYear(workYear + 1);
+}}>
+  <View style={{
+    color: 'red'
+  }}>workYear: {workYear}</View>
+  <View style={{
+    color: 'red'
+  }}>count: {count}</View>
+  <block for={arr.map((l1, ${index1}) => {
+    return {
+      l1: l1.map((l2, ${index2}) => {
+        return {
+          l2: l2,
+          ${index2}: ${index2}
+        };
+      }),
+      ${index1}: ${index1}
+    };
+  })}><View>
+        <block for={l1}><View>{{
+            l2.l2
+          }}</View></block>
+      </View></block>
+  <Loading count={count} />
+  {props.children}
+</View>`);
+  });
+
+  it('nested list without relation', () => {
+    const code = `
+<View
+  className="header"
+  onClick={() => {
+    setWorkYear(workYear + 1);
+  }}
+>
+  <View style={{ color: 'red' }}>workYear: {workYear}</View>
+  <View style={{ color: 'red' }}>count: {count}</View>
+  {arr.map(l1 => {
+    return (
+      <View>
+        {list[l1].map(l2 => {
+          return <View>{l2}</View>;
+        })}
+      </View>
+    );
+  })}
+  <Loading count={count} />
+  {props.children}
+</View>`;
+    const ast = parseExpression(code);
+    _transformList({
+      templateAST: ast
+    }, code);
+    const index1 = 'index' + count++;
+    const index2 = 'index' + count++;
+    expect(genCode(ast).code).toEqual(`<View className="header" onClick={() => {
+  setWorkYear(workYear + 1);
+}}>
+  <View style={{
+    color: 'red'
+  }}>workYear: {workYear}</View>
+  <View style={{
+    color: 'red'
+  }}>count: {count}</View>
+  <block for={arr.map((l1, ${index1}) => {
+    return {
+      l1: l1,
+      ${index1}: ${index1},
+      d0: list[l1].map((l2, ${index2}) => {
+        return {
+          l2: l2,
+          ${index2}: ${index2}
+        };
+      })
+    };
+  })}><View>
+        <block for={d0}><View>{{
+            l2.l2
+          }}</View></block>
+      </View></block>
+  <Loading count={count} />
+  {props.children}
+</View>`);
+  });
+
+  it('nested list with item property', () => {
+    const code = `
+<View
+  className="header"
+  onClick={() => {
+    setWorkYear(workYear + 1);
+  }}
+>
+  <View style={{ color: 'red' }}>workYear: {workYear}</View>
+  <View style={{ color: 'red' }}>count: {count}</View>
+  {arr.map(l1 => {
+    return (
+      <View>
+        {l1.list.map(l2 => {
+          return <View>{l2}</View>;
+        })}
+      </View>
+    );
+  })}
+  <Loading count={count} />
+  {props.children}
+</View>`;
+    const ast = parseExpression(code);
+    _transformList({
+      templateAST: ast
+    }, code);
+    const index1 = 'index' + count++;
+    const index2 = 'index' + count++;
+    expect(genCode(ast).code).toEqual(`<View className="header" onClick={() => {
+  setWorkYear(workYear + 1);
+}}>
+  <View style={{
+    color: 'red'
+  }}>workYear: {workYear}</View>
+  <View style={{
+    color: 'red'
+  }}>count: {count}</View>
+  <block for={arr.map((l1, ${index1}) => {
+    return {
+      l1: { ...l1,
+        list: l1.list.map((l2, ${index2}) => {
+          return {
+            l2: l2,
+            ${index2}: ${index2}
+          };
+        })
+      },
+      ${index1}: ${index1}
+    };
+  })}><View>
+        <block for={l1.list}><View>{{
+            l2.l2
+          }}</View></block>
+      </View></block>
+  <Loading count={count} />
+  {props.children}
+</View>`);
+  });
+
+  it('nested list with temp variable in first list', () => {
+    const code = `
+<View
+  className="header"
+  onClick={() => {
+    setWorkYear(workYear + 1);
+  }}
+>
+  <View style={{ color: 'red' }}>workYear: {workYear}</View>
+  <View style={{ color: 'red' }}>count: {count}</View>
+  {arr.map(l1 => {
+    const a = l1 || [];
+    return (
+      <View>
+        {a.map(l2 => {
+          return <View>{l2}</View>;
+        })}
+      </View>
+    );
+  })}
+  <Loading count={count} />
+  {props.children}
+</View>`;
+    const ast = parseExpression(code);
+    _transformList({
+      templateAST: ast
+    }, code);
+    const index1 = 'index' + count++;
+    const index2 = 'index' + count++;
+    expect(genCode(ast).code).toEqual(`<View className="header" onClick={() => {
+  setWorkYear(workYear + 1);
+}}>
+  <View style={{
+    color: 'red'
+  }}>workYear: {workYear}</View>
+  <View style={{
+    color: 'red'
+  }}>count: {count}</View>
+  <block for={arr.map((l1, ${index1}) => {
+    const a = l1 || [];
+    return {
+      l1: l1,
+      ${index1}: ${index1},
+      a: a.map((l2, ${index2}) => {
+        return {
+          l2: l2,
+          ${index2}: ${index2}
+        };
+      })
+    };
+  })}><View>
+        <block for={a}><View>{{
+            l2.l2
+          }}</View></block>
+      </View></block>
+  <Loading count={count} />
+  {props.children}
+</View>`);
+  });
+
+  it('list default params', () => {
+    const code = `<View>{[1,2,3].map(() => {
+      return <Text>test</Text>;
+    })}</View>`;
+    const ast = parseExpression(code);
+    _transformList({
+      templateAST: ast
+    }, code);
+    const index = 'index' + count++;
+    expect(genCode(ast, { concise: true }).code).toEqual(`<View><block for={[1, 2, 3].map((item, ${index}) => { return { item: item, ${index}: ${index} }; })}><Text>test</Text></block></View>`);
+  });
+
+  it('list style', () => {
+    const code = `<View>{[1,2,3].map((item, index) => {
+      const style = {
+        height: index * 100 + 'rpx'
+      }
+      return <Text style={style}>test</Text>;
+    })}</View>`;
+    const ast = parseExpression(code);
+    _transformList({
+      templateAST: ast
+    }, code);
+    const index = 'index' + count++;
+    expect(genCode(ast).code).toEqual(`<View><block for={[1, 2, 3].map((item, ${index}) => {
+    const style = {
+      height: ${index} * 100 + 'rpx'
+    };
+    return {
+      item: item,
+      ${index}: ${index},
+      s0: __create_style__(style)
+    };
+  })}><Text style="{{item.s0}}">test</Text></block></View>`);
+  });
+
+  it('nested list style', () => {
+    const code = `<View>
+    {[
+      [1, 2],
+      [3, 4]
+    ].map((item, index) => {
+      return (
+        <View>
+          {item.map((it, idx) => {
+            const style = {
+              height: index * 100 + "rpx"
+            };
+            return <Text style={style}>{it}</Text>;
+          })}
+        </View>
+      );
+    })}
+  </View>`;
+    const ast = parseExpression(code);
+    _transformList({
+      templateAST: ast
+    }, code);
+    const index1 = 'index' + count++;
+    const index2 = 'index' + count++;
+    expect(genCode(ast).code).toEqual(`<View>
+    <block for={[[1, 2], [3, 4]].map((item, ${index1}) => {
+    return {
+      item: item.map((it, ${index2}) => {
+        const style = {
+          height: ${index1} * 100 + "rpx"
+        };
+        return {
+          it: it,
+          ${index2}: ${index2},
+          s0: __create_style__(style)
+        };
+      }),
+      ${index1}: ${index1}
+    };
+  })}><View>
+          <block for={item}><Text style="{{it.s0}}">{{
+            it.it
+          }}</Text></block>
+        </View></block>
+  </View>`);
+  });
+
+  it("map function hasn't return", () => {
+    const code = '<View>{[1,2,3].map((item, index) => (<Text>test</Text>))}</View>';
+    const ast = parseExpression(code);
+    _transformList({
+      templateAST: ast
+    }, code);
+    const index = 'index' + count++;
+    expect(genCode(ast).code).toEqual(`<View><block for={[1, 2, 3].map((item, ${index}) => {
+    return {
+      item: item,
+      ${index}: ${index}
+    };
+  })}><Text>test</Text></block></View>`);
+  });
+
+  it('use expression in map fn', () => {
+    const code = `<View>{[1,2,3].map((item, index) => {
+      const a = index * 2 + 10;
+      return <Text>{a}</Text>;
+    })}</View>`;
+    const ast = parseExpression(code);
+    _transformList({
+      templateAST: ast
+    }, code);
+    const index = 'index' + count++;
+    expect(genCode(ast).code).toEqual(`<View><block for={[1, 2, 3].map((item, ${index}) => {
+    const a = ${index} * 2 + 10;
+    return {
+      item: item,
+      ${index}: ${index},
+      d0: a
+    };
+  })}><Text>{{
+        item.d0
+      }}</Text></block></View>`);
+  });
+
+  it('use format function in loop', () => {
+    const code = `
+    <View>{arr.map((val, idx) => {
+      return <View data-value={val} data-key={idx}>{format(idx)}</View>
+    })}</View>
+  `;
+    const ast = parseExpression(code);
+    _transformList({
+      templateAST: ast
+    }, code);
+    const index = 'index' + count++;
+    expect(genCode(ast).code).toEqual(`<View><block for={arr.map((val, ${index}) => {
+    return {
+      val: val,
+      ${index}: ${index},
+      d0: format(${index})
+    };
+  })}><View data-value="{{val.val}}" data-key="{{val.${index}}}">{{
+        val.d0
+      }}</View></block></View>`);
+  });
+});

--- a/packages/jsx2qa-compiler/src/modules/__tests__/render-function.js
+++ b/packages/jsx2qa-compiler/src/modules/__tests__/render-function.js
@@ -1,0 +1,108 @@
+const t = require('@babel/types');
+const traverse = require('../../utils/traverseNodePath');
+const { _transformRenderFunction } = require('../render-function');
+const { parseCode } = require('../../parser/index');
+const getDefaultExportedPath = require('../../utils/getDefaultExportedPath');
+const createJSX = require('../../utils/createJSX');
+const createBinding = require('../../utils/createBinding');
+const genExpression = require('../../codegen/genExpression');
+const isClassComponent = require('../../utils/isClassComponent');
+const isFunctionComponent = require('../../utils/isFunctionComponent');
+const getReturnElementPath = require('../../utils/getReturnElementPath');
+
+
+const TEMPLATE_AST = 'templateAST';
+const RENDER_FN_PATH = 'renderFunctionPath';
+
+function _transformTemplate(defaultExportedPath, code, options) {
+  const renderFnPath = isFunctionComponent(defaultExportedPath)
+    ? defaultExportedPath
+    : isClassComponent(defaultExportedPath)
+      ? getRenderMethodPath(defaultExportedPath)
+      : undefined;
+  if (!renderFnPath) return;
+
+  const returnPath = getReturnElementPath(renderFnPath);
+  if (!returnPath) throw new Error('Can not find JSX Statements in ' + options.resourcePath);
+  let returnArgument = returnPath.get('argument').node;
+  if (t.isArrayExpression(returnPath.get('argument'))) {
+    returnArgument = createJSX('div', {
+      class: t.stringLiteral('__rax-view')
+    }, returnPath.get('argument').node.elements);
+  }
+  if (!['JSXText', 'JSXExpressionContainer', 'JSXSpreadChild', 'JSXElement', 'JSXFragment'].includes(returnArgument.type)) {
+    returnArgument = t.jsxExpressionContainer(returnArgument);
+  }
+  returnPath.remove();
+  const result = {};
+  const template = createJSX('div', { class: t.stringLiteral('page-container __rax-view') }, [returnArgument]);
+  result[TEMPLATE_AST] = createJSX('template', { pagePath: t.stringLiteral('true') }, [template]);
+  result[RENDER_FN_PATH] = renderFnPath;
+  return result;
+}
+/**
+ * Get the render function path from class component declaration..
+ * @param path {NodePath} A nodePath that contains a render function.
+ * @return {NodePath} Path to render function.
+ */
+function getRenderMethodPath(path) {
+  let renderMethodPath = null;
+
+  traverse(path, {
+    /**
+     * Example:
+     *   class {
+     *     render() {}
+     *   }
+     */
+    ClassMethod(classMethodPath) {
+      const { node } = classMethodPath;
+      if (t.isIdentifier(node.key, { name: 'render' })) {
+        renderMethodPath = classMethodPath;
+      }
+    },
+    /**
+     * Example:
+     *   class {
+     *     render = function() {}
+     *     render = () => {}
+     *   }
+     */
+    ClassProperty(path) {
+      // TODO: support class property defined render function.
+    },
+  });
+
+  return renderMethodPath;
+}
+
+describe('Render item function', () => {
+  it('should transform this.renderItem function', () => {
+    const ast = parseCode(`
+       import { createElement, Component } from 'rax';
+       export default class Home extends Component {
+         renderItem(x) {
+           b = 2;
+           return <View onClick={this.handleClick}>{x}</View>;
+         }
+         handleClick() {}
+         render() {
+           return (
+             <View>
+               <View>{this.renderItem(1)}</View>
+               <View>{this.renderItem(2)}</View>
+             </View>
+           );
+         }
+       }
+    `);
+    const defaultExportedPath = getDefaultExportedPath(ast);
+    const { templateAST, renderFunctionPath } = _transformTemplate(defaultExportedPath);
+    const { renderItemFunctions } = _transformRenderFunction(templateAST, renderFunctionPath);
+    expect(renderItemFunctions.map(fn => ({
+      name: fn.name,
+      originName: fn.originName
+    }))).toEqual([{'name': 'renderItemStateTemp0', 'originName': 'renderItem'},
+      {'name': 'renderItemStateTemp1', 'originName': 'renderItem'}]);
+  });
+});

--- a/packages/jsx2qa-compiler/src/modules/__tests__/style.js
+++ b/packages/jsx2qa-compiler/src/modules/__tests__/style.js
@@ -1,0 +1,33 @@
+const t = require('@babel/types');
+const { _transform } = require('../style');
+const { parseExpression } = require('../../parser');
+const genExpression = require('../../codegen/genExpression');
+const genCode = require('../../codegen/genCode');
+
+function genInlineCode(ast) {
+  return genCode(ast, {
+    comments: false, // Remove template comments.
+    concise: true, // Reduce whitespace, but not to disable all.
+  });
+}
+
+function genDynamicValue(dynamicValue) {
+  const properties = [];
+  const store = dynamicValue.getStore();
+  store.map(({name, value}) => {
+    properties.push(t.objectProperty(t.identifier(name), value));
+  });
+  return genInlineCode(t.objectExpression(properties)).code;
+}
+
+describe('Transform style', () => {
+  it('should transform style props', () => {
+    const raw = '<Text style={styles.name}>hello</Text>';
+    const expected = '<Text style="{{s0}}">hello</Text>';
+    const expectedDynamicValue = '{ s0: __create_style__(styles.name) }';
+    const ast = parseExpression(raw);
+    const { dynamicStyle } = _transform(ast);
+    expect(genExpression(ast)).toEqual(expected);
+    expect(genDynamicValue(dynamicStyle)).toEqual(expectedDynamicValue);
+  });
+});

--- a/packages/jsx2qa-compiler/src/modules/__tests__/tag.js
+++ b/packages/jsx2qa-compiler/src/modules/__tests__/tag.js
@@ -1,0 +1,50 @@
+const { _transformTag } = require('../tag');
+const { parseExpression } = require('../../parser/index');
+const genCode = require('../../codegen/genCode');
+
+describe('Transform tag', () => {
+  it('view add text', () => {
+    const ast = parseExpression(`
+      <rax-view>
+        hello
+      </rax-view>
+    `);
+    _transformTag(ast);
+    expect(genCode(ast).code).toEqual(`<rax-view><text>
+        hello
+      </text></rax-view>`);
+  });
+  it('link add text', () => {
+    const ast = parseExpression(`
+      <rax-link>
+        hello
+      </rax-link>
+    `);
+    _transformTag(ast);
+    expect(genCode(ast).code).toEqual(`<rax-link><text>
+        hello
+      </text></rax-link>`);
+  });
+  it('view expression add text', () => {
+    const ast = parseExpression(`
+      <rax-view>
+        {item.name}
+      </rax-view>
+    `);
+    _transformTag(ast);
+    expect(genCode(ast).code).toEqual(`<rax-view>
+        <text>{item.name}</text>
+      </rax-view>`);
+  });
+  it('view expression add text', () => {
+    const ast = parseExpression(`
+      <rax-link>
+        {item.name}
+      </rax-link>
+    `);
+    _transformTag(ast);
+    expect(genCode(ast).code).toEqual(`<rax-link>
+        <text>{item.name}</text>
+      </rax-link>`);
+  });
+});

--- a/packages/jsx2qa-compiler/src/modules/attribute.js
+++ b/packages/jsx2qa-compiler/src/modules/attribute.js
@@ -1,0 +1,82 @@
+const t = require('@babel/types');
+const traverse = require('../utils/traverseNodePath');
+const genExpression = require('../codegen/genExpression');
+const CodeError = require('../utils/CodeError');
+const compiledComponents = require('../getCompiledComponents');
+const DynamicBinding = require('../utils/DynamicBinding');
+const generateId = require('../utils/generateId');
+const quickappConst = require('../const');
+
+function transformAttribute(ast, code) {
+  const refs = [];
+  const dynamicRef = new DynamicBinding('r');
+  traverse(ast, {
+    JSXAttribute(path) {
+      const { node, parentPath } = path;
+      const attrName = node.name.name;
+      switch (attrName) {
+        case 'key':
+          node.name.name = quickappConst.key;
+          break;
+        case 'className':
+          node.name.name = 'class';
+          break;
+        case 'style':
+          if (!isNativeComponent(path)) {
+            node.name.name = 'styleSheet';
+          }
+          break;
+        case 'ref':
+          if (t.isJSXExpressionContainer(node.value) && !t.isStringLiteral(node.value.expression)) {
+            node.name.name = 'id';
+            const childExpression = node.value.expression;
+            // For this.xxx = createRef();
+            node.value = t.stringLiteral(genExpression(childExpression));
+            const refInfo = {
+              name: node.value,
+              method: childExpression
+            };
+            const attributes = path.parent.attributes;
+            const componentNameNode = path.parent.name;
+            refInfo.type = t.stringLiteral('native');
+            // Get all attributes
+            let idAttr = attributes.find(attr => t.isJSXIdentifier(attr.name, { name: 'id' }));
+            if (!idAttr) {
+              // Insert progressive increase id
+              idAttr = t.jsxAttribute(t.jsxIdentifier('id'), t.stringLiteral(generateId()));
+              attributes.push(idAttr);
+            }
+            refInfo.id = idAttr.value;
+            refs.push(refInfo);
+          } else {
+            throw new CodeError(code, node, path.loc, "Ref's type must be JSXExpressionContainer, like <View ref = { scrollRef }/>");
+          }
+          break;
+        default:
+          path.skip();
+      }
+    }
+  });
+  return {
+    refs,
+    dynamicRef
+  };
+}
+
+function isNativeComponent(path) {
+  const {
+    node: { name: tagName }
+  } = path.parentPath.get('name');
+  return !!compiledComponents[tagName];
+}
+
+module.exports = {
+  parse(parsed, code, options) {
+    const { refs, dynamicRef } = transformAttribute(parsed.templateAST, code);
+    parsed.refs = refs;
+    // Set global dynamic ref value
+    parsed.dynamicRef = dynamicRef;
+  },
+  // For test cases.
+  _transformAttribute: transformAttribute
+};

--- a/packages/jsx2qa-compiler/src/modules/code.js
+++ b/packages/jsx2qa-compiler/src/modules/code.js
@@ -1,0 +1,607 @@
+const t = require('@babel/types');
+const { join, relative, dirname, resolve, extname } = require('path');
+const resolveModule = require('resolve');
+const { parseExpression } = require('../parser');
+const isClassComponent = require('../utils/isClassComponent');
+const isFunctionComponent = require('../utils/isFunctionComponent');
+const traverse = require('../utils/traverseNodePath');
+const { readJSONSync } = require('fs-extra');
+const genExpression = require('../codegen/genExpression');
+const { isNpmModule } = require('../utils/checkModule');
+const { getNpmName, normalizeFileName, addRelativePathPrefix, normalizeOutputFilePath } = require('../utils/pathHelper');
+const { BINDING_REG } = require('../utils/checkAttr');
+
+const RAX_PACKAGE = 'rax';
+const SUPER_COMPONENT = 'Component';
+const SHARED = 'shared';
+const MEMO = 'memo';
+
+const CREATE_COMPONENT = 'createComponent';
+const CREATE_PAGE = 'createPage';
+const CREATE_STYLE = 'createStyle';
+const CLASSNAMES = 'classnames';
+const CREATE_CONTEXT = 'createContext';
+const FORWARD_REF = 'forwardRef';
+const CREATE_REF = 'createRef';
+
+const SAFE_SUPER_COMPONENT = '__component__';
+const SAFE_CREATE_COMPONENT = '__create_component__';
+const SAFE_CREATE_PAGE = '__create_page__';
+const SAFE_CREATE_STYLE = '__create_style__';
+const SAFE_CLASSNAMES = '__classnames__';
+const SAFT_DEFAULT_NAME = '__default_name__';
+
+const USE_EFFECT = 'useEffect';
+const USE_STATE = 'useState';
+const USE_CONTEXT = 'useContext';
+const USE_REF = 'useRef';
+const USE_REDUCER = 'useReducer';
+const USE_LAYOUT_EFFECT = 'useLayoutEffect';
+const USE_IMPERATIVEHANDLE = 'useImperativeHandle';
+const USE_MEMO = 'useMemo';
+const USE_CALLBACK = 'useCallback';
+
+const EXPORTED_DEF = '__def__';
+const RUNTIME = 'jsx2mp-runtime';
+
+const coreMethodList = [USE_EFFECT, USE_STATE, USE_CONTEXT, USE_REF, CREATE_REF,
+  USE_REDUCER, USE_LAYOUT_EFFECT, USE_IMPERATIVEHANDLE, FORWARD_REF, CREATE_CONTEXT, SHARED,
+  USE_CALLBACK, USE_MEMO, MEMO];
+
+const getRuntimeByPlatform = (platform) => `${RUNTIME}/dist/jsx2mp-runtime.${platform}.esm`;
+const isAppRuntime = (mod) => mod === 'rax-app';
+const isFileModule = (mod) => /\.(png|jpe?g|gif|bmp|webp)$/.test(mod);
+const isRelativeImport = (mod) => mod[0] === '.';
+
+function getConstructor(type) {
+  switch (type) {
+    case 'app': return 'App';
+    case 'page': return 'Page';
+    case 'component':
+    default: return 'Component';
+  }
+}
+/**
+ * Module code transform.
+ * 1. Add import declaration of helper lib.
+ * 2. Rename scope's Component to other id.
+ * 3. Add Component call expression.
+ * 4. Transform 'rax' to 'rax/dist/rax.min.js' in case of 小程序开发者工具 not support `process`.
+ */
+module.exports = {
+  parse(parsed, code, options) {
+    const { ast, programPath, defaultExportedPath, exportComponentPath, renderFunctionPath,
+      useCreateStyle, useClassnames, dynamicValue, dynamicRef, dynamicStyle, dynamicEvents, imported,
+      contextList, refs, componentDependentProps, renderItemFunctions, eventHandler, eventHandlers = [] } = parsed;
+    const { platform, type, cwd, outputPath, sourcePath, resourcePath, disableCopyNpm } = options;
+    if (type !== 'app' && (!defaultExportedPath || !defaultExportedPath.node)) {
+      // Can not found default export, otherwise app.js is excluded.
+      return;
+    }
+    let userDefineType;
+
+    if (type === 'app') {
+      userDefineType = 'function';
+      addExportDefault(ast);
+    } else {
+      const replacer = getReplacer(exportComponentPath);
+      let { id, body } = exportComponentPath.node;
+      if (!id) {
+        // Check fn is anonymous
+        if (exportComponentPath.parentPath.isVariableDeclarator()) {
+          id = exportComponentPath.parent.id;
+        } else {
+          id = t.identifier(SAFT_DEFAULT_NAME);
+        }
+      }
+      if (isFunctionComponent(exportComponentPath)) { // replace with class def.
+        userDefineType = 'function';
+        const { generator, async, params } = exportComponentPath.node;
+        if (replacer) {
+          replacer.replaceWith(
+            t.functionDeclaration(id, params, body, generator, async)
+          );
+        }
+      } else if (isClassComponent(exportComponentPath)) {
+        userDefineType = 'class';
+        if (id.name === SAFT_DEFAULT_NAME) {
+          // Suport export default class extends Component {}
+          exportComponentPath.node.id = id;
+        }
+        // Replace Component use __component__
+        renameComponentClassDeclaration(ast);
+      }
+      replacer.insertAfter(t.variableDeclaration('let', [
+        t.variableDeclarator(
+          t.identifier(EXPORTED_DEF), id)
+      ]));
+    }
+    const exportedVariables = collectCoreMethods(imported[RAX_PACKAGE] || []);
+    const targetFileDir = dirname(join(outputPath, relative(sourcePath, resourcePath)));
+    const runtimePath = getRuntimePath(outputPath, targetFileDir, platform, disableCopyNpm);
+    removeRaxImports(ast);
+    ensureIndexPathInImports(ast, resourcePath); // In quickapp, `require` can't get index file if index is omitted
+    renameCoreModule(ast, runtimePath);
+    renameFileModule(ast);
+    // const inputEl = useRef(null) => const inputEl = useRef(null, 'inputEl');
+    renameUseRef(parsed.ast);
+    renameAppConfig(ast, sourcePath, resourcePath);
+
+
+    if (!disableCopyNpm) {
+      const currentNodeModulePath = join(sourcePath, 'npm');
+      const npmRelativePath = relative(dirname(resourcePath), currentNodeModulePath);
+      renameNpmModules(ast, npmRelativePath, resourcePath, cwd);
+    }
+
+
+    if (type !== 'app') {
+      removeDefaultImports(ast);
+      addDefine(programPath, type, userDefineType, eventHandlers, useCreateStyle, useClassnames, exportedVariables, runtimePath);
+    }
+
+    /**
+     * updateChildProps: collect props dependencies.
+     */
+    if (type !== 'app' && renderFunctionPath) {
+      const fnBody = renderFunctionPath.node.body.body;
+      let firstReturnStatementIdx = -1;
+      for (let i = 0, l = fnBody.length; i < l; i++) {
+        if (t.isReturnStatement(fnBody[i])) firstReturnStatementIdx = i;
+      }
+
+      const updateProps = t.memberExpression(t.identifier('this'), t.identifier('_updateChildProps'));
+      const componentsDependentProps = componentDependentProps || {};
+
+      Object.keys(componentsDependentProps).forEach((tagId) => {
+        const { props, tagIdExpression, parentNode } = componentsDependentProps[tagId];
+
+        // Setup propMaps.
+        const propMaps = [];
+        props && Object.keys(props).forEach(key => {
+          const value = props[key];
+          propMaps.push(t.objectProperty(
+            t.stringLiteral(key),
+            value
+          ));
+        });
+
+        let argPIDExp = tagIdExpression
+          ? genTagIdExp(tagIdExpression)
+          : t.stringLiteral(tagId);
+
+        const updatePropsArgs = [
+          argPIDExp,
+          t.objectExpression(propMaps)
+        ];
+        const callUpdateProps = t.expressionStatement(t.callExpression(updateProps, updatePropsArgs));
+        if (propMaps.length > 0) {
+          const targetNode = parentNode || fnBody;
+          if (t.isReturnStatement(targetNode[targetNode.length - 1])) {
+            targetNode.splice(targetNode.length - 1, 0, callUpdateProps);
+          } else {
+            targetNode.push(callUpdateProps);
+          }
+        } else if ((parentNode || fnBody).length === 0) {
+          // Remove empty loop exp.
+          parentNode && parentNode.remove && parentNode.remove();
+        }
+      });
+      addUpdateData(dynamicValue, dynamicRef, dynamicStyle, renderItemFunctions, renderFunctionPath);
+      addUpdateEvent(dynamicEvents, eventHandler, renderFunctionPath);
+      addProviderIniter(contextList, renderFunctionPath);
+      addRegisterRefs(refs, renderFunctionPath);
+    }
+  },
+};
+
+function addExportDefault(ast) {
+  traverse(ast, {
+    ExpressionStatement(path) {
+      const { expression } = path.node;
+      const { callee } = expression;
+      if (t.isCallExpression(expression) && t.isIdentifier(callee) && callee.name === 'runApp') {
+        path.replaceWith(
+          t.exportDefaultDeclaration(
+            expression
+          ));
+      }
+    }
+  });
+}
+
+function genTagIdExp(expressions) {
+  let ret = '';
+  for (let i = 0, l = expressions.length; i < l; i++) {
+    if (expressions[i] && expressions[i].isExpression) {
+      ret += expressions[i];
+    } else {
+      ret += JSON.stringify(expressions[i]);
+    }
+    if (i !== l - 1) ret += ' + "-" + ';
+  }
+  return parseExpression(ret);
+}
+
+function getRuntimePath(outputPath, targetFileDir, platform, disableCopyNpm) {
+  let runtimePath = getRuntimeByPlatform(platform.type);
+  if (!disableCopyNpm) {
+    runtimePath = addRelativePathPrefix(normalizeOutputFilePath(relative(targetFileDir, join(outputPath, 'npm', RUNTIME))));
+  }
+  return runtimePath;
+}
+
+function renameCoreModule(ast, runtimePath) {
+  traverse(ast, {
+    ImportDeclaration(path) {
+      const source = path.get('source');
+      if (source.isStringLiteral() && isAppRuntime(source.node.value)) {
+        source.replaceWith(t.stringLiteral(runtimePath));
+      }
+    }
+  });
+}
+
+function renameComponentClassDeclaration(ast) {
+  traverse(ast, {
+    ClassDeclaration(path) {
+      const superClassPath = path.get('superClass');
+      if (superClassPath && t.isIdentifier(superClassPath.node, {
+        name: SUPER_COMPONENT
+      })) {
+        superClassPath.replaceWith(t.identifier(SAFE_SUPER_COMPONENT));
+      }
+    }
+  });
+}
+
+// import img from '../assets/img.png' => const img = '../assets/img.png'
+function renameFileModule(ast) {
+  traverse(ast, {
+    ImportDeclaration(path) {
+      const source = path.get('source');
+      if (source.isStringLiteral() && isFileModule(source.node.value)) {
+        source.parentPath.replaceWith(t.variableDeclaration('const', [
+          t.variableDeclarator(
+            t.identifier(path.get('specifiers')[0].node.local.name),
+            t.stringLiteral(source.node.value)
+          )
+        ]));
+      }
+    }
+  });
+}
+
+function renameUseRef(ast) {
+  traverse(ast, {
+    CallExpression(path) {
+      const { node, parentPath } = path;
+      const { callee } = node;
+      if (t.isVariableDeclarator(parentPath) && t.isIdentifier(callee) && callee.name === 'useRef') {
+        node.arguments.push(t.stringLiteral(parentPath.node.id.name));
+      }
+    }
+  });
+}
+
+/**
+ * Rename app.json to app.config.js, for prev is compiled to adapte miniapp.
+ * eg:
+ *   import appConfig from './app.json' => import appConfig from './app.config.js'
+ * @param ast Babel AST.
+ * @param sourcePath Folder path to source.
+ * @param resourcePath Current handling file source path.
+ */
+function renameAppConfig(ast, sourcePath, resourcePath) {
+  traverse(ast, {
+    ImportDeclaration(path) {
+      const source = path.get('source');
+      if (source.isStringLiteral()) {
+        const appConfigSourcePath = join(resourcePath, '..', source.node.value);
+        if (appConfigSourcePath === join(sourcePath, 'app.json')) {
+          const replacement = source.node.value.replace(/app\.json/, 'appConfig.js');
+          source.replaceWith(t.stringLiteral(replacement));
+        }
+      }
+    }
+  });
+}
+
+function ensureIndexPathInImports(ast, resourcePath) {
+  traverse(ast, {
+    ImportDeclaration(path) {
+      const source = path.get('source');
+      if (source.isStringLiteral() && isRelativeImport(source.node.value)) {
+        const replacement = ensureIndexInPath(source.node.value, resourcePath);
+        source.replaceWith(t.stringLiteral(replacement));
+      }
+    }
+  });
+}
+
+function renameNpmModules(ast, npmRelativePath, filename, cwd) {
+  const source = (value, prefix, filename, rootContext) => {
+    const npmName = getNpmName(value);
+    const nodeModulePath = join(rootContext, 'node_modules');
+    const searchPaths = [nodeModulePath];
+    let target = require.resolve(npmName, { paths: searchPaths });
+    // In tnpm, target will be like following (symbol linked path):
+    // ***/_universal-toast_1.0.0_universal-toast/lib/index.js
+    let packageJSONPath;
+    try {
+      packageJSONPath = require.resolve(join(npmName, 'package.json'), { paths: searchPaths });
+    } catch (err) {
+      throw new Error(`You may not have npm installed: "${npmName}"`);
+    }
+
+    const packageJSON = readJSONSync(packageJSONPath);
+
+    const moduleBasePath = join(packageJSONPath, '..');
+    // TODO remove quickappConfig
+    if (packageJSON.quickappConfig) {
+      target = join(moduleBasePath, packageJSON.quickappConfig.main);
+    }
+    const realNpmName = relative(nodeModulePath, moduleBasePath);
+    const modulePathSuffix = relative(moduleBasePath, target);
+
+    let ret;
+    if (npmName === value) {
+      ret = join(prefix, realNpmName, modulePathSuffix);
+    } else {
+      ret = join(prefix, value.replace(npmName, realNpmName));
+    }
+    ret = addRelativePathPrefix(normalizeOutputFilePath(ret));
+    // ret => '../npm/_ali/universal-toast/lib/index.js
+
+    return t.stringLiteral(normalizeFileName(ret));
+  };
+
+  traverse(ast, {
+    ImportDeclaration(path) {
+      const { value } = path.node.source;
+      if (isNpmModule(value)) {
+        path.node.source = source(value, npmRelativePath, filename, cwd);
+      }
+    }
+  });
+}
+
+function addDefine(programPath, type, userDefineType, eventHandlers, useCreateStyle, useClassnames, exportedVariables, runtimePath) {
+  let safeCreateInstanceId;
+  let importedIdentifier;
+  switch (type) {
+    case 'page':
+      safeCreateInstanceId = SAFE_CREATE_PAGE;
+      importedIdentifier = CREATE_PAGE;
+      break;
+    case 'component':
+      safeCreateInstanceId = SAFE_CREATE_COMPONENT;
+      importedIdentifier = CREATE_COMPONENT;
+      break;
+  }
+  const localIdentifier = t.identifier(safeCreateInstanceId);
+  // Component(__create_component__(__class_def__));
+  const args = [t.identifier(EXPORTED_DEF)];
+
+  // import { createComponent as __create_component__ } from "/__helpers/component";
+  const specifiers = [t.importSpecifier(localIdentifier, t.identifier(importedIdentifier))];
+  if ((type === 'page' || type === 'component') && userDefineType === 'class') {
+    specifiers.push(t.importSpecifier(
+      t.identifier(SAFE_SUPER_COMPONENT),
+      t.identifier(SUPER_COMPONENT)
+    ));
+  }
+
+  if (Array.isArray(exportedVariables)) {
+    exportedVariables.forEach(id => {
+      specifiers.push(t.importSpecifier(t.identifier(id), t.identifier(id)));
+    });
+  }
+  if (useCreateStyle) {
+    specifiers.push(t.importSpecifier(
+      t.identifier(SAFE_CREATE_STYLE),
+      t.identifier(CREATE_STYLE)
+    ));
+  }
+
+  if (useClassnames) {
+    specifiers.push(t.importSpecifier(
+      t.identifier(SAFE_CLASSNAMES),
+      t.identifier(CLASSNAMES)
+    ));
+  }
+
+  programPath.node.body.unshift(
+    t.importDeclaration(
+      specifiers,
+      t.stringLiteral(runtimePath)
+    )
+  );
+
+  // __create_component__(__class_def__, { events: ['_e*']})
+  if (eventHandlers.length > 0) {
+    args.push(
+      t.objectExpression([
+        t.objectProperty(t.identifier('events'), t.arrayExpression(eventHandlers.map(e => t.stringLiteral(e))))
+      ])
+    );
+  }
+
+  programPath.node.body.push(
+    t.exportDefaultDeclaration(
+      t.callExpression(
+        t.identifier(safeCreateInstanceId),
+        args
+      )
+    )
+  );
+}
+
+function removeRaxImports(ast) {
+  traverse(ast, {
+    ImportDeclaration(path) {
+      if (t.isStringLiteral(path.node.source, { value: RAX_PACKAGE })) {
+        path.remove();
+      }
+    },
+  });
+}
+
+function removeDefaultImports(ast) {
+  traverse(ast, {
+    ExportDefaultDeclaration(path) {
+      const { node: { declaration } } = path;
+      if (/Expression$/.test(declaration.type)) {
+        path.replaceWith(t.assignmentExpression('=', t.identifier(EXPORTED_DEF), declaration));
+      } else {
+        path.replaceWith(declaration);
+      }
+    },
+  });
+}
+
+function getReplacer(exportComponentPath) {
+  if (exportComponentPath.parentPath.isExportDefaultDeclaration()) {
+    /**
+     * export default class {};
+     */
+    return exportComponentPath.parentPath;
+  } else if (exportComponentPath.parentPath.isProgram()) {
+    /**
+     * class Foo {}
+     * export default Foo;
+     */
+    return exportComponentPath;
+  } else if (exportComponentPath.parentPath.isVariableDeclarator()) {
+    /**
+     * var Foo = class {}
+     * export default Foo;
+     */
+    return exportComponentPath.parentPath.parentPath;
+  } else {
+    return null;
+  }
+}
+
+/**
+ * Collect core methods, like createContext or createRef
+ * */
+function collectCoreMethods(raxExported) {
+  const vaildList = [];
+  raxExported.forEach(exported => {
+    if (coreMethodList.indexOf(exported.local) > -1) {
+      vaildList.push(exported.local);
+    }
+  });
+  return vaildList;
+}
+
+function addUpdateData(dynamicValue, dynamicRef, dynamicStyle, renderItemFunctions, renderFunctionPath) {
+  const dataProperties = [];
+  const dataStore = dynamicValue.getStore();
+  const refStore = dynamicRef.getStore();
+  const styleStore = dynamicStyle.getStore();
+  [...dataStore, ...refStore, ...styleStore].forEach(({name, value}) => {
+    dataProperties.push(t.objectProperty(t.stringLiteral(name), value));
+  });
+
+  renderItemFunctions.map(renderItemFn => {
+    dataProperties.push(t.objectProperty(t.stringLiteral(renderItemFn.name), renderItemFn.node));
+  });
+
+  const updateData = t.memberExpression(
+    t.thisExpression(),
+    t.identifier('_updateData')
+  );
+
+  const fnBody = renderFunctionPath.node.body.body;
+  fnBody.push(t.expressionStatement(t.callExpression(updateData, [
+    t.objectExpression(dataProperties)
+  ])));
+}
+
+function addUpdateEvent(dynamicEvent, eventHandlers = [], renderFunctionPath) {
+  const methodsProperties = [];
+  dynamicEvent.forEach(({ name, value }) => {
+    eventHandlers.push(name);
+    methodsProperties.push(t.objectProperty(t.stringLiteral(name), value));
+  });
+
+  const updateMethods = t.memberExpression(
+    t.thisExpression(),
+    t.identifier('_updateMethods')
+  );
+  const fnBody = renderFunctionPath.node.body.body;
+
+  fnBody.push(t.expressionStatement(t.callExpression(updateMethods, [
+    t.objectExpression(methodsProperties)
+  ])));
+}
+
+function addProviderIniter(contextList, renderFunctionPath) {
+  if (contextList) {
+    contextList.forEach(ctx => {
+      const ProviderIniter = t.memberExpression(
+        t.identifier(ctx.contextName),
+        t.identifier('Provider')
+      );
+      const fnBody = renderFunctionPath.node.body.body;
+      const args = ctx.contextInitValue ? [ctx.contextInitValue] : [];
+      fnBody.push(t.expressionStatement(t.callExpression(ProviderIniter, args)));
+    });
+  }
+}
+
+/**
+ * Insert register ref method
+ * @param {Array} refs
+ * @param {Object} renderFunctionPath
+ * */
+function addRegisterRefs(refs, renderFunctionPath) {
+  const registerRefsMethods = t.memberExpression(
+    t.thisExpression(),
+    t.identifier('_registerRefs')
+  );
+  const fnBody = renderFunctionPath.node.body.body;
+  /**
+   * this._registerRefs([
+   *  {
+   *    name: 'scrollViewRef',
+   *    method: scrollViewRef
+   *  }
+   * ])
+   * */
+  if (refs.length > 0) {
+    fnBody.push(t.expressionStatement(t.callExpression(registerRefsMethods, [
+      t.arrayExpression(refs.map(ref => {
+        return t.objectExpression([t.objectProperty(t.stringLiteral('name'), ref.name),
+          t.objectProperty(t.stringLiteral('method'), ref.method ),
+          t.objectProperty(t.stringLiteral('type'), ref.type ),
+          t.objectProperty(t.stringLiteral('id'), ref.id )]);
+      }))
+    ])));
+  }
+}
+
+/**
+ * add index if it's omitted
+ *
+ * @param {string} value  imported value
+ * @param {string} resourcePath current file path
+ * @returns
+ */
+function ensureIndexInPath(value, resourcePath) {
+  const target = resolveModule.sync(resolve(dirname(resourcePath), value), {
+    extensions: ['.js', '.ts']
+  });
+  const result = relative(dirname(resourcePath), target);
+  return removeJSExtension(addRelativePathPrefix(normalizeOutputFilePath(result)));
+};
+
+function removeJSExtension(filePath) {
+  const ext = extname(filePath);
+  if (ext === '.js' || ext === '.ts') {
+    return filePath.slice(0, filePath.length - ext.length);
+  }
+  return filePath;
+}

--- a/packages/jsx2qa-compiler/src/modules/components.js
+++ b/packages/jsx2qa-compiler/src/modules/components.js
@@ -1,0 +1,525 @@
+const { join, relative, dirname, resolve, sep } = require('path');
+const { readJSONSync } = require('fs-extra');
+const resolveModule = require('resolve');
+const t = require('@babel/types');
+const { _transform: transformTemplate } = require('./element');
+const genExpression = require('../codegen/genExpression');
+const traverse = require('../utils/traverseNodePath');
+const { moduleResolve, multipleModuleResolve } = require('../utils/moduleResolve');
+const createJSX = require('../utils/createJSX');
+const createBinding = require('../utils/createBinding');
+const Expression = require('../utils/Expression');
+const compiledComponents = require('../getCompiledComponents');
+const replaceComponentTagName = require('../utils/replaceComponentTagName');
+const { getNpmName, normalizeFileName, addRelativePathPrefix, normalizeOutputFilePath } = require('../utils/pathHelper');
+
+const RELATIVE_COMPONENTS_REG = /^\..*(\.jsx?)?$/i;
+const PKG_NAME_REG = new RegExp(`^.*\\${sep}node_modules\\${sep}([^\\${sep}]*).*$`);
+const GROUP_PKG_NAME_REG = new RegExp(`^.*\\${sep}node_modules\\${sep}([^\\${sep}]*?\\${sep}[^\\${sep}]*).*$`);
+
+let tagCount = 0;
+let iconFontIndex = 0;
+
+/**
+ * Transform the component name is identifier
+ * @param {Object} path
+ * @param {Object} alias
+ * @param {Object} dynamicValue
+ * @param {Object} parsed
+ * @param {Object} options
+ */
+function transformIdentifierComponentName(path, alias, dynamicValue, parsed, options) {
+  const componentConfig = 'quickappConfig';
+  const tagIdKey = 'tag-id';
+  const tagIdValue = 'tagId';
+  const { node, parentPath } = path;
+  const {
+    renderFunctionPath,
+    componentDependentProps,
+  } = parsed;
+  // Miniapp template tag name does not support special characters.
+  const aliasName = alias.name.replace(/@|\//g, '_');
+  const componentTag = alias.default ? aliasName : `${aliasName}-${alias.local.toLowerCase()}`;
+  replaceComponentTagName(path, t.jsxIdentifier(componentTag));
+  node.isCustomEl = alias.isCustomEl;
+  node.name.isCustom = true;
+
+  if (!compiledComponents[componentTag]) {
+    // <tag __tagId="tagId" />
+
+    let tagId;
+
+    if (!node.__slotChildEl) {
+      tagId = '' + tagCount;
+
+      const parentsJSXList = findParentsJSXListEl(path);
+      if (parentsJSXList.length > 0) {
+        parentPath.node.__tagIdExpression = [];
+        for (let i = parentsJSXList.length - 1; i >= 0; i--) {
+          const { args } = parentsJSXList[i].node.__jsxlist;
+          const indexValue = args.length > 1 ? genExpression(args[1]) : 'index';
+          parentPath.node.__tagIdExpression.push(new Expression(indexValue));
+          tagId += `-{{${indexValue}}}`;
+        }
+        parentPath.node.__tagIdExpression.unshift(tagCount);
+      }
+      tagCount++;
+      parentPath.node.__tagId = tagId;
+      componentDependentProps[tagId] = componentDependentProps[tagId] || {};
+      if (parentPath.node.__tagIdExpression) {
+        componentDependentProps[tagId].tagIdExpression =
+          parentPath.node.__tagIdExpression;
+
+        if (renderFunctionPath) {
+          const { loopFnBody } = parentsJSXList[0].node.__jsxlist;
+          componentDependentProps[tagId].parentNode = loopFnBody.body;
+        }
+      }
+
+      tagId = `{{${tagIdValue}}}-` + tagId;
+    } else {
+      tagId = createBinding(tagIdValue);
+    }
+
+    node.attributes.push(
+      t.jsxAttribute(t.jsxIdentifier(tagIdKey), t.stringLiteral(tagId)),
+    );
+
+    if (componentTag === 'slot') return;
+
+    if (componentTag.indexOf('rax-icon') > -1) {
+      const fontAttr = {};
+      node.attributes.forEach((attr) => {
+        if (attr.name.name === 'fontFamily') {
+          fontAttr.fontFamily = attr.value.value;
+        }
+        if (attr.name.name === 'source') {
+          attr.value.expression.properties.forEach(property => {
+            if (property.key.name === 'uri') {
+              fontAttr.url = property.value.value;
+            }
+          });
+        }
+      });
+      const index = iconFontIndex++;
+      if (!fontAttr.fontFamily) {
+        fontAttr.fontFamily = `iconfont${index}`;
+      }
+      fontAttr.iconClass = `icon-font-${index}`;
+      node.attributes.push(t.jsxAttribute(t.jsxIdentifier('class-name'), t.stringLiteral(fontAttr.iconClass)));
+      if (!parsed.iconfontMap.some(iconFont => iconFont.url === fontAttr.url)) {
+        parsed.iconfontMap.push(fontAttr);
+      }
+    }
+
+    /**
+     * Handle with special attrs &&
+     * Judge whether the component is from component library
+     */
+    if (!RELATIVE_COMPONENTS_REG.test(alias.from)) {
+      const packageName = getNpmName(alias.from);
+      if (packageName === alias.from) {
+        const pkg = getComponentConfig(alias.default ? alias.from : alias.name, options.resourcePath);
+        if (pkg && pkg[componentConfig]) {
+          if (Array.isArray(pkg[componentConfig].renderSlotProps)) {
+            path.traverse({
+              JSXAttribute(attrPath) {
+                const { node } = attrPath;
+                if (
+                  pkg[componentConfig].renderSlotProps.indexOf(node.name.name) > -1
+                ) {
+                  if (t.isJSXExpressionContainer(node.value)) {
+                    let fnExp;
+                    if (t.isFunction(node.value.expression)) {
+                      fnExp = node.value.expression;
+                    } else if (t.isIdentifier(node.value.expression)) {
+                      const binding = attrPath.scope.getBinding(
+                        node.value.expression.name,
+                      );
+                      fnExp = binding.path.node;
+                    } else if (t.isMemberExpression(node.value.expression)) {
+                      throw new Error(
+                        `NOT_SUPPORTED: Not support MemberExpression at render function: "${genExpression(
+                          node,
+                        )}", please use anonymous function instead.`,
+                      );
+                    }
+
+                    if (fnExp) {
+                      const { params, body } = fnExp;
+                      let jsxEl = body;
+                      if (t.isBlockStatement(body)) {
+                        const returnEl = body.body.filter(el =>
+                          t.isReturnStatement(el),
+                        )[0];
+                        if (returnEl) jsxEl = returnEl.argument;
+                      }
+                      const {
+                        node: slotComponentNode,
+                        dynamicValue: slotComponentDynamicValue,
+                      } = createSlotComponent(jsxEl, node.name.name, params);
+                      Object.assign(dynamicValue, slotComponentDynamicValue);
+                      path.parentPath.node.children.push(slotComponentNode);
+                    }
+                    attrPath.remove();
+                  }
+                }
+              },
+            });
+          }
+
+          if (pkg[componentConfig].subPackages) {
+            parsed.imported[alias.from].forEach(importedComponent => {
+              importedComponent.isFromComponentLibrary = true;
+            });
+          }
+        }
+      }
+    }
+    return componentTag;
+  }
+}
+
+function transformComponents(parsed, options) {
+  const { ast, templateAST, imported } = parsed;
+  const dynamicValue = {};
+  const contextList = [];
+  const componentsAlias = {};
+  const componentConfig = 'quickappConfig';
+  traverse(templateAST, {
+    JSXOpeningElement(path) {
+      const { node } = path;
+      if (t.isJSXIdentifier(node.name)) {
+        // <View/>
+        const componentTag = node.name.name;
+        const alias = getComponentAlias(componentTag, imported);
+        if (alias) {
+          removeImport(ast, alias);
+          const componentTag = transformIdentifierComponentName(path, alias, dynamicValue, parsed, options);
+          if (componentTag) {
+            // Collect renamed component tag & path info
+            componentsAlias[componentTag] = alias;
+          }
+        } else if (componentTag === 'slot') {
+          transformIdentifierComponentName(
+            path,
+            {
+              name: 'slot',
+              default: true
+            },
+            dynamicValue,
+            parsed,
+            options
+          );
+        }
+      } else if (t.isJSXMemberExpression(node.name)) {
+        // <RecyclerView.Cell /> or <Context.Provider>
+        const { object, property } = node.name;
+        if (t.isJSXIdentifier(object) && t.isJSXIdentifier(property)) {
+          if (property.name === 'Provider') {
+            // <Context.Provider>
+            const valueAttribute = node.attributes.find(a =>
+              t.isJSXIdentifier(a.name, { name: 'value' }),
+            );
+            const contextInitValue = valueAttribute && valueAttribute.value.expression;
+            const contextItem = {
+              contextInitValue,
+              contextName: object.name,
+            };
+            contextList.push(contextItem);
+            replaceComponentTagName(path, t.jsxIdentifier('block'));
+            node.attributes = [];
+          } else {
+            // <RecyclerView.Cell />
+            const alias = getComponentAlias(object.name, imported);
+            removeImport(parsed.ast, alias);
+            if (alias) {
+              const pkg = getComponentConfig(alias.from, options.resourcePath);
+              const isSingleComponent = pkg[componentConfig] && pkg[componentConfig].subComponents && pkg[componentConfig].subComponents[property.name];
+              const isComponentLibrary = pkg[componentConfig] && pkg[componentConfig].subPackages && pkg[componentConfig].subPackages[alias.local] && pkg[componentConfig].subPackages[alias.local].subComponents && pkg[componentConfig].subPackages[alias.local].subComponents[property.name];
+
+              if (isSingleComponent) {
+                let subComponent = pkg[componentConfig].subComponents[property.name];
+                replaceComponentTagName(
+                  path,
+                  t.jsxIdentifier(subComponent.tagNameMap),
+                );
+                // subComponent default style
+                if (subComponent.attributes && subComponent.attributes.style) {
+                  node.attributes.push(
+                    t.jsxAttribute(
+                      t.jsxIdentifier('style'),
+                      t.stringLiteral(subComponent.attributes.style),
+                    ),
+                  );
+                }
+              } else if (isComponentLibrary) {
+                let subComponent = pkg[componentConfig].subPackages[alias.local].subComponents[property.name];
+                const componentTag = subComponent.tagNameMap || `${alias.name}-${object.name}-${property.name}`.toLowerCase().replace(/@|\//g, '_');
+                replaceComponentTagName(
+                  path,
+                  t.jsxIdentifier(componentTag)
+                );
+                componentsAlias[componentTag] = Object.assign({
+                  isSubComponent: true,
+                  subComponentName: property.name
+                }, alias);
+              }
+            }
+          }
+        } else {
+          throw new Error(
+            `NOT_SUPPORTED: Unsupported type of sub components. ${genExpression(
+              node,
+            )}`,
+          );
+        }
+      }
+    },
+    JSXExpressionContainer(path) {
+      const { node, parentPath } = path;
+      // Only process under JSXEelement
+      if (parentPath.isJSXElement()) {
+        if (
+          ['this.props.children', 'props.children', 'children'].indexOf(
+            genExpression(node.expression),
+          ) > -1
+        ) {
+          path.replaceWith(createJSX('slot'));
+        }
+      }
+    },
+    JSXFragment(path) {
+      // Transform <></> => <block></block>
+      const blockNode = t.jsxIdentifier('block');
+      const { children = [] } = path.node;
+      path.replaceWith(t.jsxElement(t.jsxOpeningElement(blockNode, []), t.jsxClosingElement(blockNode), children));
+    }
+  });
+  return {
+    contextList,
+    dynamicValue,
+    componentsAlias
+  };
+}
+function transformDataset(parsed, options) {
+  const { ast, templateAST, imported } = parsed;
+  traverse(templateAST, {
+    JSXElement: {
+      exit(path) {
+        const { node } = path;
+        const openEle = node.openingElement;
+        const openTagName = openEle.name;
+        if (t.isJSXIdentifier(openTagName)
+        && (typeof openEle.isCustomEl !== 'undefined' && !openEle.isCustomEl)
+        && !compiledComponents[openTagName.name]
+        && !node.__transformDataset
+        && openEle.attributes.some(x => x.name.name.indexOf('data-') > -1)) {
+          node.__transformDataset = true;
+          let attr = {
+            class: t.stringLiteral('__rax-view')
+          };
+          node.openingElement.attributes.forEach(v => {
+            if (v.name.name.indexOf('data-') > -1) {
+              attr[ v.name.name ] = v.value;
+            }
+            if (v.name.name.indexOf('onClick') > -1) {
+              attr[ v.name.name ] = v.value;
+            }
+          });
+          if (attr.onClick) {
+            node.openingElement.attributes = node.openingElement.attributes.filter(x => x.name.name !== 'onClick');
+          }
+          path.replaceWith(createJSX('div', attr, [path.node]));
+        }
+      }
+    }
+  });
+}
+/**
+ * Rax components.
+ */
+module.exports = {
+  parse(parsed, code, options) {
+    if (!parsed.componentDependentProps) {
+      parsed.componentDependentProps = {};
+    }
+    if (!parsed.iconfontMap) {
+      parsed.iconfontMap = [];
+    }
+    const { contextList, dynamicValue, componentsAlias, iconfontMap } = transformComponents(parsed, options);
+    transformDataset(parsed, options);
+    // Collect used components
+    Object.keys(componentsAlias).forEach(componentTag => {
+      if (!parsed.usingComponents) {
+        parsed.usingComponents = {};
+      }
+      parsed.usingComponents[componentTag] = getComponentPath(componentsAlias[componentTag], options);
+    });
+    // Assign used context
+    parsed.contextList = contextList;
+    // Collect dynamicValue
+    if (parsed.dynamicValue) {
+      Object.assign(parsed.dynamicValue, dynamicValue);
+    } else {
+      parsed.dynamicValue = dynamicValue;
+    }
+  },
+  generate(ret, parsed, options) {
+    ret.usingComponents = parsed.usingComponents;
+    ret.iconfontMap = parsed.iconfontMap;
+  },
+  // For test case.
+  _transformComponents: transformComponents,
+  _transformDataset: transformDataset
+};
+
+function getComponentAlias(tagName, imported) {
+  if (imported) {
+    for (let [key, value] of Object.entries(imported)) {
+      for (let i = 0, l = value.length; i < l; i++) {
+        if (value[i].local === tagName)
+          return Object.assign({ from: key }, value[i]);
+      }
+    }
+  }
+}
+
+function getComponentConfig(pkgName, resourcePath) {
+  const pkgPath = moduleResolve(resourcePath, join(pkgName, 'package.json'));
+  if (!pkgPath) {
+    throw new Error(
+      `MODULE_NOT_RESOLVE: Can not resolve rax component "${pkgName}", please check you have this module installed.`,
+    );
+  }
+  return readJSONSync(pkgPath);
+}
+
+// for tnpm, the package name will be like _rax-image@1.1.2@rax-image
+function getRealNpmPkgName(filePath, pkgName) {
+  const isGroupPkg = pkgName.indexOf('/') !== -1;
+
+  const result = isGroupPkg ? GROUP_PKG_NAME_REG.exec(filePath) : PKG_NAME_REG.exec(filePath);
+  return result && result[1];
+}
+
+function getComponentPath(alias, options) {
+  if (RELATIVE_COMPONENTS_REG.test(alias.from)) {
+    // alias.local
+    if (!options.resourcePath) {
+      throw new Error('`resourcePath` must be passed to calc dependency path.');
+    }
+
+    const filename = multipleModuleResolve(options.resourcePath, alias.from, [
+      '.jsx', '.js', '.tsx', '.ts'
+    ]);
+    return filename;
+  } else {
+    const { disableCopyNpm } = options;
+    const realNpmFile = resolveModule.sync(alias.from, { basedir: dirname(options.resourcePath), preserveSymlinks: false });
+    const pkgName = getNpmName(alias.from);
+    const realPkgName = getRealNpmPkgName(realNpmFile, pkgName);
+    const targetFileDir = dirname(join(options.outputPath, relative(options.sourcePath, options.resourcePath)));
+    const npmRelativePath = relative(targetFileDir, join(options.outputPath, 'npm'));
+
+    // Use specific path to import native miniapp component
+    if (pkgName !== alias.from) {
+      return normalizeFileName(addRelativePathPrefix(normalizeOutputFilePath(join(npmRelativePath, alias.from.replace(pkgName, realPkgName)))));
+    }
+    // Use miniappConfig in package.json to import native miniapp component
+    const pkg = getComponentConfig(alias.from, options.resourcePath);
+    let mainName = 'main';
+    // if (options.platform.type !== 'ali' && !adapter.singleFileComponent) {
+    //   mainName += `:${options.platform.type}`;
+    // }
+    // todo remove quickappConfig
+    const componentConfig = 'quickappConfig';
+
+    const isSingleComponent = pkg[componentConfig] && pkg[componentConfig][mainName];
+    const isComponentLibrary = pkg[componentConfig] && pkg[componentConfig].subPackages;
+    if (!isSingleComponent && !isComponentLibrary) {
+      console.warn(
+        'Can not found compatible rax miniapp component "' + pkg.name + '".',
+      );
+      return;
+    } else {
+      const quickappComponentPath = isSingleComponent ?
+        pkg[componentConfig][mainName] :
+        alias.isSubComponent ?
+          pkg[componentConfig].subPackages[alias.local].subComponents[alias.subComponentName][mainName] :
+          pkg[componentConfig].subPackages[alias.local][mainName];
+      if (disableCopyNpm) {
+        return normalizeOutputFilePath(join(pkg.name, quickappComponentPath));
+      }
+      const quickappConfigRelativePath = relative(pkg.main, quickappComponentPath);
+      const realquickappAbsPath = resolve(realNpmFile, quickappConfigRelativePath);
+      const realquickappRelativePath = realquickappAbsPath.slice(realquickappAbsPath.indexOf(realPkgName) + realPkgName.length);
+      return normalizeFileName(addRelativePathPrefix(normalizeOutputFilePath(join(npmRelativePath, realPkgName, realquickappRelativePath))));
+    }
+  }
+}
+
+function removeImport(ast, alias) {
+  if (!alias) return;
+  traverse(ast, {
+    ImportDeclaration(path) {
+      const { node } = path;
+      if (t.isStringLiteral(node.source) && node.source.value === alias.from) {
+        node.specifiers = (node.specifiers || []).filter(function(s) {
+          return !(s.local && s.local.name === alias.local);
+        });
+        if (!node.specifiers.length) path.remove();
+      }
+    },
+  });
+}
+
+function createSlotComponent(jsxEl, slotName, args) {
+  const params = {};
+  if (Array.isArray(args)) {
+    args.forEach(id => params[id.name] = true);
+  }
+
+  let enableScopeSlot = false;
+
+  traverse(jsxEl, {
+    Identifier(path) {
+      if (params[path.node.name]) {
+        path.replaceWith(t.identifier(`props.${path.node.name}`));
+        enableScopeSlot = true;
+      }
+    },
+  });
+
+  const dynamicValue = transformTemplate(jsxEl, slotName);
+  // Remove dynamicValue that created by params.
+  Object.keys(dynamicValue).forEach(key => {
+    if (params.hasOwnProperty(key) || /^props\./.test(key))
+      delete dynamicValue[key];
+  });
+
+  if (enableScopeSlot) {
+    // Add scope slot
+    jsxEl.openingElement.attributes.push(
+      t.jsxAttribute(t.jsxIdentifier('slot-scope'), t.stringLiteral('props')),
+    );
+  }
+
+  // Add slot attr
+  jsxEl.openingElement.attributes.push(
+    t.jsxAttribute(t.jsxIdentifier('slot'), t.stringLiteral(slotName)),
+  );
+
+  return { dynamicValue, node: jsxEl };
+}
+
+
+function findParentsJSXListEl(path, parentList = []) {
+  const parentJSXListEl = path.findParent(p => p.node.__jsxlist);
+  if (parentJSXListEl) {
+    parentList.push(parentJSXListEl);
+    return findParentsJSXListEl(parentJSXListEl, parentList);
+  } else {
+    return parentList;
+  }
+}

--- a/packages/jsx2qa-compiler/src/modules/condition.js
+++ b/packages/jsx2qa-compiler/src/modules/condition.js
@@ -1,0 +1,393 @@
+const t = require('@babel/types');
+
+const traverse = require('../utils/traverseNodePath');
+const createJSX = require('../utils/createJSX');
+const CodeError = require('../utils/CodeError');
+const handleValidIdentifier = require('../utils/handleValidIdentifier');
+const genExpression = require('../codegen/genExpression');
+const quickappConst = require('../const');
+
+const TEMPLATE_AST = 'templateAST';
+const RENDER_FN_PATH = 'renderFunctionPath';
+
+function transformRenderFunction(renderPath) {
+  // Identifier name & jsx map
+  const templateMap = {};
+  traverse(renderPath, {
+    IfStatement: {
+      enter(path) {
+        const consequentPath = path.get('consequent');
+        const alternatePath = path.get('alternate');
+        const consequentBodyPath = consequentPath.get('body');
+        // parse consequent
+        if (consequentBodyPath.length > 0) {
+          consequentBodyPath.map((statementPath) => {
+            handleConsequent(
+              path,
+              statementPath.get('expression'),
+              templateMap,
+              renderPath.scope
+            );
+          });
+        } else {
+          if (consequentPath.isExpressionStatement()) {
+            handleConsequent(
+              path,
+              consequentPath.get('expression'),
+              templateMap,
+              renderPath.scope
+            );
+          } else {
+            handleConsequent(path, consequentPath, templateMap, renderPath.scope);
+          }
+        }
+
+        if (!alternatePath.isIfStatement() && alternatePath.node) {
+          const alternateBodyPath = alternatePath.get('body');
+          if (alternateBodyPath) {
+            alternateBodyPath.map((statementPath) => {
+              handleAlternate(
+                statementPath.get('expression'),
+                templateMap
+              );
+            });
+          } else {
+            if (alternatePath.isExpressionStatement()) {
+              handleConsequent(
+                path,
+                alternatePath.get('expression'),
+                templateMap,
+                renderPath.scope
+              );
+            } else {
+              handleConsequent(path, alternatePath, templateMap, renderPath.scope);
+            }
+          }
+        }
+      },
+    },
+  });
+  return templateMap;
+}
+
+function transformTemplate(ast, templateMap, code) {
+  traverse(ast, {
+    JSXExpressionContainer(path) {
+      const { node, parentPath } = path;
+      if (parentPath.isJSXAttribute()) {
+        path.skip();
+        return;
+      }
+
+      if (node.expression.type === 'ConditionalExpression') {
+        const { replacement } = transformConditionalExpression(path, node.expression, { code });
+        path.replaceWithMultiple(replacement);
+      }
+
+      path.traverse({
+        Identifier(innerPath) {
+          const template = templateMap[innerPath.node.name];
+          if (template) {
+            path.replaceWith(template);
+          }
+        }
+      });
+    },
+    LogicalExpression(path) {
+      if (path.parentPath.isJSXExpressionContainer()) {
+        const { right, left, operator } = path.node;
+        let replacement = [];
+        if (isJSX(left)) {
+          if (operator === '&&') {
+            replacement.push(right);
+          } else if (operator === '||') {
+            replacement.push(left);
+          } else {
+            throw new CodeError(code, path.node, path.node.loc, 'Logical operator only support && or ||');
+          }
+        } else {
+          let test;
+          if (operator === '||') {
+            test = t.unaryExpression('!', left);
+          } else if (operator === '&&') {
+            test = left;
+          } else {
+            throw new CodeError(code, path.node, path.node.loc, 'Logical operator only support && or ||');
+          }
+          const children = [];
+          if (isJSX(right)) {
+            children.push(right);
+          } else {
+            children.push(t.jsxExpressionContainer(right));
+          }
+          replacement.push(createJSX('block', {
+            [quickappConst.if]: generateConditionValue(test)
+          }, children));
+          replacement.push(createJSX('block', {
+            [quickappConst.else]: null,
+          }, [t.jsxExpressionContainer(left)]));
+        }
+        path.parentPath.replaceWithMultiple(replacement);
+      } else {
+        path.skip();
+      }
+    }
+  });
+}
+
+/**
+ * @param {Object} path
+ *        jsxExpressionContainer
+ * @param {Object} expression
+ *        Condition Expression
+ * @param {{ code: String }} options
+ * @returns {{ replacement: Object }}
+ * */
+function transformConditionalExpression(path, expression, options) {
+  let { test, consequent, alternate } = expression;
+  const { parentPath } = path;
+
+  const replacement = [];
+  let consequentReplacement = [];
+  let alternateReplacement = [];
+
+  let openTag = 'block';
+
+  if (t.isJSXElement(parentPath) && t.isJSXIdentifier(parentPath.node.openingElement.name, { name: 'Text' })) {
+    openTag = 'span';
+  } else if (!isAllJsxElement(expression)) {
+    openTag = 'View';
+  }
+
+  if (t.isExpression(consequent)) {
+    if (t.isConditionalExpression(consequent)) {
+      consequentReplacement = transformConditionalExpression(
+        path,
+        consequent,
+        options
+      ).replacement;
+    } else if (/Literal$/.test(consequent.type)) {
+      // Transform from literal type to JSXText Node
+      const value = consequent.value ? String(consequent.value) : '';
+      consequentReplacement.push(t.jsxText(value));
+    } else if (t.isJSXElement(consequent)) {
+      consequentReplacement.push(consequent);
+    } else {
+      consequentReplacement.push(t.jsxExpressionContainer(consequent));
+    }
+  }
+
+  if (t.isExpression(alternate)) {
+    if (t.isConditionalExpression(alternate)) {
+      alternateReplacement = transformConditionalExpression(
+        path,
+        alternate,
+        options
+      ).replacement;
+    } else if (t.isNullLiteral(alternate)) {
+      // Ignore null
+    } else if (/Literal$/.test(alternate.type)) {
+      alternateReplacement.push(t.jsxText(String(alternate.value)));
+    } else if (t.isJSXElement(alternate)) {
+      alternateReplacement.push(alternate);
+    } else {
+      alternateReplacement.push(t.jsxExpressionContainer(alternate));
+    }
+  }
+
+  if (consequentReplacement.length > 0) {
+    replacement.push(
+      createJSX(
+        openTag,
+        {
+          [quickappConst.if]: generateConditionValue(test),
+        },
+        consequentReplacement,
+      ),
+    );
+  }
+  if (alternateReplacement.length > 0) {
+    replacement.push(
+      createJSX(
+        openTag,
+        {
+          [quickappConst.else]: null,
+        },
+        alternateReplacement,
+      ),
+    );
+  }
+  return { replacement };
+}
+
+module.exports = {
+  parse(parsed, code, options) {
+    if (parsed[RENDER_FN_PATH]) {
+      const templateMap = transformRenderFunction(
+        parsed[RENDER_FN_PATH]
+      );
+      transformTemplate(parsed[TEMPLATE_AST], templateMap, code);
+    }
+  },
+
+  // For test cases.
+  _transformRenderFunction: transformRenderFunction,
+  _transformTemplate: transformTemplate,
+};
+
+function needRecursion(nodePath) {
+  return t.isConditionalExpression(nodePath) || t.isJSXElement(nodePath);
+}
+
+function isAllJsxElement(expression) {
+  const { consequent, alternate } = expression;
+  // { need ? 1 : 2 }
+  if (!needRecursion(consequent) && !needRecursion(alternate)) return false;
+  // { need ? <Demo /> : <Test /> }
+  if (t.isJSXElement(consequent) && t.isJSXElement(alternate)) return true;
+  // { need ? bar ? <Bar /> : <View /> : <Demo /> }
+  if (t.isConditionalExpression(consequent)) {
+    return isAllJsxElement(consequent);
+  }
+  return isAllJsxElement(alternate);
+}
+
+function generateConditionValue(test) {
+  let conditionValue;
+  if (t.isStringLiteral(test)) {
+    conditionValue = test;
+  } else {
+    // Other types.
+    conditionValue = t.jsxExpressionContainer(test);
+  }
+  return conditionValue;
+}
+
+function isJSX(node) {
+  return ['JSXElement', 'JSXText', 'JSXFragment'].indexOf(node.type) > -1;
+}
+
+/**
+ * @param path IfStatement
+ * @param expressionPath consequent expression path
+ * @param templateMap variable => jsx template
+ * @param renderScope render function scope
+ * */
+function handleConsequent(path, expressionPath, templateMap, renderScope) {
+  const testPath = path.get('test');
+  let shouldTransfrom = true;
+  // This expression can be replaced only if the identifiers in test expression exist in the render scope
+  if (testPath.isIdentifier()) {
+    if (renderScope && !renderScope.hasBinding(testPath.node.name)) {
+      shouldTransfrom = false;
+    }
+  } else {
+    testPath.traverse({
+      Identifier(innerPath) {
+        handleValidIdentifier(innerPath, () => {
+          if (renderScope && !renderScope.hasBinding(innerPath.node.name)) {
+            shouldTransfrom = false;
+          }
+        });
+      }
+    });
+  }
+
+  if (shouldTransfrom) {
+    const { node } = path;
+    const { test, start, end } = node;
+    const expression = expressionPath.node;
+    if (
+      t.isAssignmentExpression(expression) &&
+      expression.operator === '=' &&
+      t.isIdentifier(expression.left)
+    ) {
+      const rightPath = expressionPath.get('right');
+      const varName = expression.left.name;
+      if (!templateMap[varName]) {
+        templateMap[varName] = createJSX('block');
+      }
+      let testAttrName = quickappConst.if;
+      const parentPathAlternate = path.parent.alternate;
+      /**
+       * Condition:
+       * 1. parentPath is IfStatement
+       * 2. parentNode's alternate start & end is same as current path start & end
+       */
+      if (
+        path.parentPath.isIfStatement() &&
+          t.isIfStatement(parentPathAlternate) &&
+          parentPathAlternate.start === start &&
+          parentPathAlternate.end === end
+      ) {
+        testAttrName = quickappConst.elseif;
+      }
+      const rightNode = rightPath.node;
+      const containerNode = createJSX(
+        'block',
+        {
+          [testAttrName]: t.jsxExpressionContainer(Object.assign({}, test)),
+        },
+        [isJSX(rightNode) ? rightNode : t.jsxExpressionContainer(rightNode)],
+      );
+
+      templateMap[varName].children.push(containerNode);
+      if (isJSX(rightNode) || hasJSX(rightPath)) {
+        // Remove only if the expression contains JSX
+        expressionPath.remove();
+      }
+    }
+  }
+}
+
+/**
+ * @param expressionPath alternate expression path
+ * @param templateMap variable => jsx template
+ * */
+function handleAlternate(expressionPath, templateMap) {
+  const expression = expressionPath.node;
+  if (
+    t.isAssignmentExpression(expression) &&
+    expression.operator === '=' &&
+    t.isIdentifier(expression.left)
+  ) {
+    const varName = expression.left.name;
+    const rightPath = expressionPath.get('right');
+    const rightNode = rightPath.node;
+    const containerNode = createJSX(
+      'block',
+      {
+        [quickappConst.else]: null,
+      },
+      [hasJSX(rightPath) ? rightNode : t.jsxExpressionContainer(rightNode) ],
+    );
+
+    if (templateMap[varName]) {
+      templateMap[varName].children.push(containerNode);
+    } else {
+      templateMap[varName] = containerNode;
+    }
+    if (hasJSX(rightPath)) {
+      expressionPath.remove();
+    }
+  }
+}
+
+/**
+ * @param target path
+ * */
+function hasJSX(path) {
+  let exist = false;
+  path.traverse({
+    JSXElement() {
+      exist = true;
+    },
+    JSXText() {
+      exist = true;
+    },
+    JSXFragment() {
+      exist = true;
+    }
+  });
+  return exist;
+}

--- a/packages/jsx2qa-compiler/src/modules/css.js
+++ b/packages/jsx2qa-compiler/src/modules/css.js
@@ -1,0 +1,64 @@
+const t = require('@babel/types');
+const { readFileSync } = require('fs-extra');
+const { moduleResolve } = require('../utils/moduleResolve');
+const traverse = require('../utils/traverseNodePath');
+
+/**
+ * Add and convert style file to result.
+ * 1. convert `rem` directly to `rpx`
+ * 2. if named imported:
+ *    import styles from './style.css';
+ *    ->
+ *    Transform and generate style.css to style.css.js
+ * 3. if anoymous imported
+ *    import './style.css';
+ *    ->
+ *    Transform rpx and generate same name css files.
+ * ---
+ */
+module.exports = {
+  parse(parsed, code, options) {
+    const { imported } = parsed;
+    const cssFileMap = {};
+    parsed.cssFiles = parsed.cssFiles || [];
+
+    Object.keys(imported).forEach(rawPath => {
+      if (isFilenameCSS(rawPath)) {
+        const resolvedPath = moduleResolve(options.resourcePath, rawPath);
+        if (resolvedPath) {
+          const isAnomyousImport = imported[rawPath].length === 0;
+          parsed.cssFiles.push({
+            rawPath,
+            filename: resolvedPath,
+            content: readFileSync(resolvedPath, 'utf-8'),
+            type: isAnomyousImport ? 'cssFile' : 'cssObject',
+          });
+          if (isAnomyousImport) cssFileMap[rawPath] = true; // For removing import statement.
+        }
+      }
+    });
+
+    // Remove import css declaration
+    traverse(parsed.ast, {
+      ImportDeclaration(path) {
+        const { node } = path;
+        if (t.isStringLiteral(node.source) && cssFileMap[node.source.value.replace(/\\/g, '/')]) {
+          path.remove();
+        }
+      }
+    });
+  },
+  generate(ret, parsed, options) {
+    ret.cssFiles = parsed.cssFiles;
+    ret.dependencies = ret.dependencies || [];
+    if (parsed.cssFiles) {
+      parsed.cssFiles.forEach((cssFile) => {
+        ret.dependencies.push(cssFile.filename);
+      });
+    }
+  }
+};
+
+function isFilenameCSS(path) {
+  return /\.(css|sass|less|scss|styl)$/i.test(path);
+}

--- a/packages/jsx2qa-compiler/src/modules/element.js
+++ b/packages/jsx2qa-compiler/src/modules/element.js
@@ -1,0 +1,864 @@
+const t = require('@babel/types');
+const traverse = require('../utils/traverseNodePath');
+const genExpression = require('../codegen/genExpression');
+const createBinding = require('../utils/createBinding');
+const createJSXBinding = require('../utils/createJSXBinding');
+const CodeError = require('../utils/CodeError');
+const DynamicBinding = require('../utils/DynamicBinding');
+const compiledComponents = require('../getCompiledComponents');
+const baseComponents = require('../baseComponents');
+const replaceComponentTagName = require('../utils/replaceComponentTagName');
+const { parseExpression } = require('../parser/index');
+const { isDirectiveAttr, isEventHandlerAttr, BINDING_REG } = require('../utils/checkAttr');
+const handleValidIdentifier = require('../utils/handleValidIdentifier');
+const quickappConst = require('../const');
+
+const ATTR = Symbol('attribute');
+const ELE = Symbol('element');
+const renderFuncReg = /StateTemp[0-9]+/;
+
+/**
+ * 1. Normalize jsxExpressionContainer to binding var.
+ * 2. Collect dynamicValue (dependent identifiers)
+ * 3. Normalize function bounds.
+ * @param parsed
+ * @param scope
+ * @param sourceCode
+ */
+function transformTemplate(
+  {
+    templateAST: ast,
+    componentDependentProps = {},
+    dynamicValue
+  },
+  sourceCode
+) {
+  const dynamicEvents = new DynamicBinding('e');
+  function handleJSXExpressionContainer(path) {
+    const { parentPath, node } = path;
+    if (node.__transformed) return;
+    const type = parentPath.isJSXAttribute()
+      ? ATTR // <View foo={bar} />
+      : ELE; // <View>{xxx}</View>
+    let { expression } = node;
+    let attributeName = null;
+    let isDirective;
+    if (type === ATTR) {
+      attributeName = parentPath.node.name.name;
+      isDirective = isDirectiveAttr(attributeName);
+      collectComponentDependentProps(parentPath, expression, path.get('expression'), componentDependentProps);
+    } else {
+      isDirective = isDirectiveAttr(attributeName);
+    }
+
+    const isEventHandler = isEventHandlerAttr(attributeName);
+
+    switch (expression.type) {
+      // <div foo={'string'} /> -> <div foo="string" />
+      // <div>{'hello world'}</div> -> <div>hello world</div>
+      case 'StringLiteral':
+        if (type === ATTR) path.replaceWith(expression);
+        else if (type === ELE) path.replaceWith(t.jsxText(expression.value));
+        break;
+
+      // <div foo={100} /> -> <div foo="{{100}}" />
+      // <div>{100}</div>  -> <div>100</div>
+      case 'NumericLiteral':
+        if (type === ATTR) path.replaceWith(t.stringLiteral(createBinding(expression.value)));
+        else if (type === ELE) path.replaceWith(t.jsxText(String(expression.value)));
+        break;
+
+      // <div foo={true} /> -> <div foo="{{true}}" />
+      // <div>{true}</div>  -> <div></div>
+      case 'BooleanLiteral':
+        if (type === ATTR)
+          path.replaceWith(t.stringLiteral(createBinding(expression.value)));
+        else if (type === ELE) path.remove();
+        break;
+
+      // <div foo={null} /> -> <div foo="{{null}}" />
+      // <div>{null}</div>  -> <div></div>
+      case 'NullLiteral':
+        if (type === ATTR)
+          path.replaceWith(t.stringLiteral(createBinding('null')));
+        else if (type === ELE) path.remove();
+        break;
+
+      // <div foo={/foo/} /> -> <div foo="{{_dx}}" />
+      // <div>/regexp/</div>  -> <div>{{ _dx }}</div>
+      case 'RegExpLiteral':
+        const dynamicName = dynamicValue.add({
+          expression,
+          isDirective,
+        });
+        if (type === ATTR) {
+          path.replaceWith(t.stringLiteral(createBinding(dynamicName)));
+        } else if (type === ELE) {
+          path.replaceWith(createJSXBinding(dynamicName));
+        }
+        break;
+
+      // <div foo={`hello ${exp}`} /> -> <div foo="hello {{exp}}" />
+      // <div>/regexp/</div>  -> <div>{{ _dx }}</div>
+      case 'TemplateLiteral':
+        if (type === ELE)
+          throw new CodeError(
+            sourceCode,
+            node,
+            node.loc,
+            'Unsupported TemplateLiteral in JSXElement Children:',
+          );
+
+        if (path.isTaggedTemplateExpression()) break;
+
+        const { quasis, expressions } = node.expression;
+        const nodes = [];
+        let index = 0;
+
+        for (const elem of quasis) {
+          if (elem.value.cooked) {
+            nodes.push(t.stringLiteral(elem.value.cooked));
+          }
+
+          if (index < expressions.length) {
+            const expr = expressions[index++];
+            if (!t.isStringLiteral(expr, { value: '' })) {
+              nodes.push(expr);
+            }
+          }
+        }
+
+        if (!t.isStringLiteral(nodes[0]) && !t.isStringLiteral(nodes[1])) {
+          nodes.unshift(t.stringLiteral(''));
+        }
+
+        let retString = '';
+        for (let i = 0; i < nodes.length; i++) {
+          if (t.isStringLiteral(nodes[i])) {
+            retString += nodes[i].value;
+          } else {
+            const name = dynamicValue.add({
+              expression: nodes[i],
+              isDirective,
+            });
+            retString += createBinding(name);
+          }
+        }
+
+        path.replaceWith(t.stringLiteral(retString));
+        break;
+
+      // <div foo={bar} /> -> <div foo="{{bar}}" />
+      // <div>{bar}</div>  -> <div>{{ bar }}</div>
+      case 'Identifier':
+        if (type === ATTR) {
+          if (expression.name === 'undefined') {
+            parentPath.remove(); // Remove jsxAttribute
+            break;
+          } else if (isEventHandler) {
+            const name = dynamicEvents.add({
+              expression,
+              isDirective,
+            });
+            path.replaceWith(t.stringLiteral(createBinding(name)));
+          } else {
+            const replaceNode = transformIdentifier(
+              expression,
+              dynamicValue,
+              isDirective,
+            );
+            path.replaceWith(
+              t.stringLiteral(createBinding(genExpression(replaceNode))),
+            );
+          }
+        } else if (type === ELE) {
+          if (expression.name === 'undefined') {
+            path.remove(); // Remove expression
+            break;
+          } else {
+            const replaceNode = transformIdentifier(
+              expression,
+              dynamicValue,
+              isDirective,
+            );
+            path.replaceWith(createJSXBinding(genExpression(replaceNode)));
+          }
+        }
+        break;
+
+      // Remove no usage.
+      case 'JSXEmptyExpression':
+        path.remove();
+        break;
+
+      // <tag onClick={() => {}} /> => <tag onClick="_e0" />
+      // <tag>{() => {}}</tag> => throw Error
+      case 'ArrowFunctionExpression':
+      case 'FunctionExpression':
+        if (type === ELE)
+          throw new CodeError(
+            sourceCode,
+            node,
+            node.loc,
+            'Unsupported Function in JSXElement:',
+          );
+
+        if (!isEventHandler)
+          throw new CodeError(
+            sourceCode,
+            node,
+            node.loc,
+            `Only EventHandlers are supported in Mini Program, eg: onClick/onChange, instead of "${attributeName}".`,
+          );
+        const params = (expression.params || []).map(param => {
+          // Compatibility (event = {}) => handleClick(event)
+          if (t.isAssignmentPattern(param)) {
+            return param.left;
+          }
+          return param;
+        });
+        const callExp = expression.body;
+        const args = callExp.arguments;
+        const { attributes } = parentPath.parentPath.node;
+        const fnExpression = t.isCallExpression(callExp) ? callExp.callee : expression;
+        const name = dynamicEvents.add({
+          expression: fnExpression,
+          isDirective,
+        });
+        const formatName = formatEventName(name);
+        if (Array.isArray(args)) {
+          const fnFirstParam = expression.params[0];
+          if (!(args.length === 1 && t.isIdentifier(args[0], {
+            name: fnFirstParam && fnFirstParam.name
+          }))) {
+            args.forEach((arg, index) => {
+              const transformedArg = transformCallExpressionArg(arg, params, dynamicValue, isDirective);
+              if (transformedArg.__dataset) {
+                attributes.push(
+                  t.jsxAttribute(
+                    t.jsxIdentifier(`data-${formatName}-arg-` + index),
+                    t.stringLiteral(
+                      createBinding(
+                        genExpression(transformedArg, {
+                          concise: true,
+                          comments: false,
+                        })
+                      ),
+                    ),
+                  ),
+                );
+              }
+            });
+          }
+        }
+        path.replaceWith(t.stringLiteral(createBinding(name)));
+        break;
+
+      // <tag key={this.props.name} key2={a.b} /> => <tag key="{{_d0.name}}" key2="{{_d1.b}}" />
+      // <tag>{ foo.bar }</tag> => <tag>{{ _d0.bar }}</tag>
+      case 'MemberExpression':
+        if (type === ATTR) {
+          const openNode = parentPath.parentPath.node;
+          const nativeRaxComponent = typeof openNode.isCustomEl !== 'undefined' && !openNode.isCustomEl;
+          if (isEventHandler && !nativeRaxComponent) {
+            const name = dynamicEvents.add({
+              expression,
+              isDirective,
+            });
+            const replaceNode = t.stringLiteral(createBinding(name));
+            replaceNode.__transformed = true;
+            path.replaceWith(replaceNode);
+          } else {
+            // this.xxx() => <View>{count}</View> => <View>{{xxxStateTemp1.count}}</View>
+            const expressionName = getExpressionName(expression);
+            if (renderFuncReg.test(expressionName)) {
+              path.replaceWith(t.stringLiteral(createBinding(genExpression(expression))));
+              break;
+            }
+            const replaceNode = transformMemberExpression(
+              expression,
+              dynamicValue,
+              isDirective,
+            );
+            replaceNode.__transformed = true;
+            const forParams = isForList(path);
+            const isForAttr = path.parent && path.parent.name && path.parent.name.name === 'for';
+            const code = genExpression(replaceNode);
+            path.replaceWith(
+              t.stringLiteral(createBinding(forParams && isForAttr ? `(${forParams.forIndex}, ${forParams.forItem}) in ${code}` : code)),
+            );
+          }
+        } else if (type === ELE) {
+          const expressionName = getExpressionName(expression);
+          if (renderFuncReg.test(expressionName)) {
+            path.replaceWith(createJSXBinding(genExpression(expression)));
+            break;
+          }
+          const replaceNode = transformMemberExpression(
+            expression,
+            dynamicValue,
+            isDirective,
+          );
+          path.replaceWith(createJSXBinding(genExpression(replaceNode)));
+        }
+        break;
+
+      // <tag foo={fn()} /> => <tag foo="{{_d0}} /> _d0 = fn();
+      // <tag>{fn()}</tag> => <tag>{{ _d0 }}</tag> _d0 = fn();
+      case 'CallExpression':
+        if (type === ATTR) {
+          if (isEventHandler) {
+            const isBindCallExpression = t.isMemberExpression(expression.callee) &&
+            t.isIdentifier(expression.callee.property, { name: 'bind' });
+            // function bounds
+            const callExp = node.expression;
+            const args = callExp.arguments;
+            const { attributes } = parentPath.parentPath.node;
+            const name = dynamicEvents.add({
+              expression: isBindCallExpression ? callExp.callee.object : callExp.callee,
+              isDirective,
+            });
+            const formatName = formatEventName(name);
+            if (Array.isArray(args)) {
+              args.forEach((arg, index) => {
+                // If is handleClick.bind(this, 1), valid args index should subtract 1
+                const argsIndex = isBindCallExpression ? index - 1 : index;
+                if (isBindCallExpression && index === 0) {
+                  // first arg is `this` context.
+                  const strValue = t.isThisExpression(arg)
+                    ? 'this'
+                    : createBinding(
+                      genExpression(arg, {
+                        concise: true,
+                        comments: false,
+                      })
+                    );
+                  attributes.push(
+                    t.jsxAttribute(
+                      t.jsxIdentifier(`data-${formatName}-arg-context`),
+                      t.stringLiteral(strValue),
+                    ),
+                  );
+                } else {
+                  const transformedArg = transformCallExpressionArg(arg, [], dynamicValue, isDirective);
+                  attributes.push(
+                    t.jsxAttribute(
+                      t.jsxIdentifier(`data-${formatName}-arg-${argsIndex}`),
+                      t.stringLiteral(
+                        createBinding(
+                          genExpression(transformedArg, {
+                            concise: true,
+                            comments: false,
+                          })
+                        ),
+                      ),
+                    ),
+                  );
+                }
+              });
+            }
+
+            path.replaceWith(t.stringLiteral(createBinding(name)));
+          } else {
+            if (!expression.callee.property || expression.callee.property !== 'map') {
+              let name = dynamicValue.add({
+                expression,
+                isDirective,
+              });
+              const forParams = isForList(path);
+              if (forParams) {
+                name = `(${forParams.forIndex}, ${forParams.forItem}) in ${name}`;
+              }
+              path.replaceWith(t.stringLiteral(createBinding(name)));
+            }
+          }
+        } else if (type === ELE) {
+          // Skip `array.map(iterableFunction)`.
+          const name = dynamicValue.add({
+            expression,
+            isDirective,
+          });
+          path.replaceWith(createJSXBinding(name));
+        }
+        break;
+
+      case 'ConditionalExpression':
+      case 'BinaryExpression':
+      case 'UnaryExpression':
+      case 'LogicalExpression':
+      case 'SequenceExpression':
+      case 'NewExpression':
+      case 'ObjectExpression':
+      case 'ArrayExpression':
+        if (hasComplexExpression(path)) {
+          const expressionName = dynamicValue.add({
+            expression,
+            isDirective,
+          });
+          if (type === ATTR)
+            path.replaceWith(t.stringLiteral(createBinding(expressionName)));
+          else if (type === ELE)
+            path.replaceWith(createJSXBinding(expressionName));
+        } else {
+          path.traverse({
+            Identifier(innerPath) {
+              if (
+                innerPath.node.__transformed ||
+                innerPath.parentPath.isMemberExpression() ||
+                innerPath.parentPath.isObjectProperty() ||
+                innerPath.node.__listItem && !innerPath.node.__listItem.item
+              )
+                return;
+              const replaceNode = transformIdentifier(
+                innerPath.node,
+                dynamicValue,
+                isDirective,
+              );
+              replaceNode.__transformed = true;
+              innerPath.replaceWith(replaceNode);
+            },
+            // <tag>{a ? a.b[c.d] : 1}</tag> => <tag>{{_d0 ? _d0.b[_d1.d] : 1}}</tag>
+            MemberExpression(innerPath) {
+              if (innerPath.node.__transformed) return;
+              const replaceNode = transformMemberExpression(
+                innerPath.node,
+                dynamicValue,
+                isDirective,
+              );
+              replaceNode.__transformed = true;
+              innerPath.replaceWith(replaceNode);
+            },
+            ObjectExpression(innerPath) {
+              if (innerPath.node.__transformed) return;
+              const replaceProperties = transformObjectExpression(
+                innerPath.node,
+                dynamicValue,
+                isDirective,
+              );
+              const replaceNode = t.objectExpression(replaceProperties);
+              replaceNode.__transformed = true;
+              innerPath.replaceWith(replaceNode);
+              expression = innerPath.node;
+            },
+          });
+
+          if (type === ATTR)
+            path.replaceWith(
+              t.stringLiteral(
+                createBinding(
+                  genExpression(expression, {
+                    concise: true,
+                    comments: false,
+                  })
+                ),
+              ),
+            );
+          else if (type === ELE)
+            path.replaceWith(createJSXBinding(genExpression(expression)));
+        }
+        break;
+      default: {
+        throw new CodeError(
+          sourceCode,
+          node,
+          node.loc,
+          `Unsupported Stynax in JSX Elements, ${expression.type}:`,
+        );
+      }
+    }
+    if (parentPath.isJSXAttribute() && !parentPath.parentPath.node.attributes.some(x => {
+      return t.isJSXIdentifier(x.name) && x.name.name.indexOf('data-') > -1;
+    })) {
+      node.__transformed = true;
+    }
+  }
+
+  traverse(ast, {
+    JSXAttribute(path) {
+      const attrName = path.node.name.name;
+      if (['tag-id'].indexOf(attrName) > -1) {
+        return;
+      }
+      const originalAttrValue = path.node.value;
+      if (t.isStringLiteral(originalAttrValue)) {
+        let clearBindAttrValue;
+        clearBindAttrValue = dynamicValue.getExpression(originalAttrValue.value.replace(BINDING_REG, ''))
+        || originalAttrValue.__originalExpression;
+        const attrValue = clearBindAttrValue || originalAttrValue;
+        collectComponentDependentProps(path, attrValue, null, componentDependentProps);
+      }
+    },
+    JSXExpressionContainer: handleJSXExpressionContainer,
+    JSXOpeningElement: {
+      exit(path) {
+        const { node } = path;
+        const componentTagNode = node.name;
+        if (t.isJSXIdentifier(componentTagNode)) {
+          const name = componentTagNode.name;
+          const replaceName = compiledComponents[name];
+          // Handle native components needTransformAttr
+          if (typeof node.isCustomEl !== 'undefined'
+            && !node.isCustomEl) {
+            node.attributes.forEach((attr) => {
+              let attrName = attr.name.name;
+              if (replaceName) {
+                attr.name.name = attrName.toLowerCase();
+              } else {
+                if (attrName.slice(0, 2) === 'on') {
+                  attr.name.name = attrName.replace('on', 'bind');
+                }
+                // bindChange => bind-change
+                const newAttrName = attr.name.name;
+                if (/[A-Z]+/g.test(newAttrName) && newAttrName !== 'className') {
+                  attr.name.name = newAttrName.replace(/[A-Z]+/g, (v, i) => {
+                    if (i !== 0) {
+                      return `-${v.toLowerCase()}`;
+                    }
+                    return v;
+                  });
+                }
+              }
+            });
+          }
+          // Handle rax-view
+          if (replaceName) {
+            replaceComponentTagName(path, t.jsxIdentifier(replaceName));
+            const propsMap = quickappConst[replaceName];
+            let hasClassName = false;
+            node.attributes.forEach(attr => {
+              if (t.isJSXIdentifier(attr.name)) {
+                const attrName = attr.name.name;
+                if (attrName === 'class') {
+                  attr.value.value = propsMap.className + ' ' + attr.value.value;
+                  hasClassName = true;
+                }
+                if (propsMap[attrName] && attrName !== 'className') {
+                  attr.name.name = propsMap[attrName];
+                }
+              }
+            });
+            if (!hasClassName && propsMap.className) {
+              node.attributes.push(
+                t.jsxAttribute(
+                  t.jsxIdentifier('class'),
+                  t.stringLiteral(propsMap.className),
+                ),
+              );
+            }
+          }
+        }
+      },
+    },
+  });
+
+  return {
+    dynamicEvents: dynamicEvents.getStore(),
+  };
+}
+
+function getExpressionName(expression) {
+  if (t.isIdentifier(expression.object)) {
+    return expression.object.name;
+  }
+  if (t.isMemberExpression(expression.object)) {
+    return getExpressionName(expression.object);
+  }
+}
+
+function hasComplexExpression(path) {
+  let complex = false;
+  if (path.isCallExpression()) return true;
+  if (path.isTemplateLiteral()) return true;
+  if (path.isUnaryExpression() && path.node.operator !== '!') return true;
+
+  function isComplex(p) {
+    complex = true;
+    p.stop();
+  }
+  traverse(path, {
+    NewExpression: isComplex,
+    CallExpression: isComplex,
+    TemplateLiteral: isComplex,
+    // It's hard to process objectExpression nested, same as arrayExp.
+    UnaryExpression(innerPath) {
+      if (innerPath.node.operator !== '!') {
+        isComplex(innerPath);
+      }
+    },
+    ObjectExpression(innerPath) {
+      const { properties } = innerPath.node;
+      const checkNested = properties.some(property => {
+        const { value } = property;
+        return (
+          !t.isIdentifier(value) &&
+          !t.isMemberExpression(value) &&
+          !t.isBinaryExpression(value)
+        );
+      });
+      if (checkNested) {
+        isComplex(innerPath);
+      }
+    },
+    ArrayExpression: isComplex,
+    TaggedTemplateExpression: isComplex,
+  });
+
+  return complex;
+}
+
+/**
+ * Transform MemberExpression
+ * */
+function transformMemberExpression(expression, dynamicBinding, isDirective) {
+  if (checkMemberHasThis(expression)) {
+    const name = dynamicBinding.add({
+      expression,
+      isDirective,
+    });
+    return t.identifier(name);
+  }
+  const { object, property } = expression;
+  let { computed } = expression;
+  let objectReplaceNode = object;
+  let propertyReplaceNode = property;
+  if (!object.__transformed) {
+    // if object is ThisExpression, replace thw whole expression with _d0
+    if (t.isThisExpression(object)) {
+      const name = dynamicBinding.add({
+        expression,
+        isDirective,
+      });
+      const replaceNode = t.identifier(name);
+      replaceNode.__transformed = true;
+      return replaceNode;
+    }
+    if (t.isIdentifier(object)) {
+      objectReplaceNode = transformIdentifier(
+        object,
+        dynamicBinding,
+        isDirective,
+      );
+      objectReplaceNode.__transformed = true;
+    }
+    if (t.isMemberExpression(object)) {
+      objectReplaceNode = transformMemberExpression(
+        object,
+        dynamicBinding,
+        isDirective,
+      );
+    }
+  }
+
+  if (!property.__transformed) {
+    if (t.isMemberExpression(property)) {
+      propertyReplaceNode = transformMemberExpression(
+        property,
+        dynamicBinding,
+        isDirective,
+      );
+    }
+    if (computed) { // others[index] => others[item.index]
+      switch (property.type) {
+        case 'Identifier':
+          propertyReplaceNode = transformIdentifier(
+            property,
+            dynamicBinding,
+            isDirective,
+          );
+          break;
+        case 'MemberExpression':
+          propertyReplaceNode = transformMemberExpression(
+            property,
+            dynamicBinding,
+            isDirective,
+          );
+          break;
+        default:
+          const name = dynamicBinding.add({
+            expression: property,
+            isDirective,
+          });
+          propertyReplaceNode = t.identifier(name);
+          break;
+      }
+      propertyReplaceNode.__transformed = true;
+    }
+  }
+
+  return t.memberExpression(objectReplaceNode, propertyReplaceNode, computed);
+}
+
+/**
+ * Path has for
+ * */
+function isForList(path) {
+  if (path._forParams) return path._forParams;
+  if (!path.parentPath) return false;
+  return isForList(path.parentPath);
+}
+
+/**
+ * Transform Identifier
+ * */
+function transformIdentifier(expression, dynamicBinding, isDirective) {
+  let replaceNode;
+  if (
+    expression.__listItem && !expression.__listItem.item
+    || expression.__templateVar
+    || expression.__slotScope
+  ) {
+    // The identifier is x-for args or template variable or map's index
+    replaceNode = expression;
+  } else if (expression.__listItem && expression.__listItem.item) {
+    const itemNode = t.identifier(expression.__listItem.item);
+    itemNode.__listItem = {
+      jsxplus: expression.__listItem.jsxplus,
+    };
+    replaceNode = t.memberExpression(itemNode, expression);
+  } else {
+    const name = dynamicBinding.add({
+      expression,
+      isDirective,
+    });
+    replaceNode = t.identifier(name);
+  }
+  return replaceNode;
+}
+
+/**
+ * Transform ObjectExpression
+ * */
+function transformObjectExpression(expression, dynamicBinding, isDirective) {
+  const { properties } = expression;
+  return properties.map(property => {
+    const { key, value } = property;
+    let replaceNode = value;
+    if (t.isIdentifier(value)) {
+      replaceNode = transformIdentifier(value, dynamicBinding, isDirective);
+    }
+    if (t.isMemberExpression(value)) {
+      replaceNode = transformMemberExpression(
+        value,
+        dynamicBinding,
+        isDirective,
+      );
+    }
+    if (t.isObjectExpression(value)) {
+      replaceNode = transformObjectExpression(
+        value,
+        dynamicBinding,
+        isDirective,
+      );
+    }
+    return t.objectProperty(key, replaceNode);
+  });
+}
+
+/**
+ * Transform CallExpression arg
+ * @param {object} ast - arguments node
+ * @param {Array} params - ArrowFunctionExpression's params, like event in event => handleClick()
+ * @param {object} dynamicValue
+ * @param {boolean} isDirective
+ */
+function transformCallExpressionArg(ast, params, dynamicValue, isDirective) {
+  switch (ast.type) {
+    case 'Identifier':
+      // Exclude the event object
+      if (!params.some(param => param.name === ast.name)) {
+        ast = transformIdentifier(ast, dynamicValue, isDirective);
+        ast.__dataset = true;
+      }
+      break;
+    default:
+      traverse(ast, {
+        Identifier(innerPath) {
+          handleValidIdentifier(innerPath, () => {
+            const { node: innerNode } = innerPath;
+            if (!innerNode.__transformed) {
+              // Exclude the event object
+              if (!params.some(param => param.name === ast.name)) {
+                const replaceNode = transformIdentifier(innerNode, dynamicValue, isDirective);
+                innerPath.replaceWith(replaceNode);
+              }
+              innerPath.node.__transformed = true;
+            }
+          });
+        },
+      });
+      ast.__dataset = true;
+      break;
+  }
+
+  return ast;
+}
+
+function checkMemberHasThis(expression) {
+  const { object, property } = expression;
+  let hasThisExpression = false;
+  if (t.isThisExpression(object)) {
+    hasThisExpression = true;
+  }
+  if (t.isIdentifier(object)) {
+    hasThisExpression = false;
+  }
+  if (t.isMemberExpression(object)) {
+    hasThisExpression = checkMemberHasThis(object);
+  }
+  return hasThisExpression;
+}
+
+/**
+ * JSXAttribute path
+ * */
+function collectComponentDependentProps(path, attrValue, attrPath, componentDependentProps) {
+  const { node } = path;
+  const attrName = node.name.name;
+  const jsxEl = path.findParent(p => p.isJSXElement()).node;
+  const isDirective = isDirectiveAttr(attrName);
+  if (
+    !isDirective
+    && attrValue.type
+    && jsxEl.__tagId
+  ) {
+    // Replace list render replaced node
+    traverse(attrPath, {
+      StringLiteral(innerPath) {
+        if (BINDING_REG.test(innerPath.node.value)) {
+          attrValue = innerPath.node.__originalExpression;
+        }
+      }
+    });
+    if (attrPath) {
+      attrValue = parseExpression('(' + attrPath.toString() + ')'); // deep clone
+    }
+    componentDependentProps[jsxEl.__tagId].props =
+      componentDependentProps[jsxEl.__tagId].props || {};
+    componentDependentProps[jsxEl.__tagId].props[
+      attrName
+    ] = attrValue;
+  }
+}
+
+// _e0 -> e0
+function formatEventName(name) {
+  return name.replace('_', '');
+}
+
+module.exports = {
+  parse(parsed, code, options) {
+    if (parsed.renderFunctionPath) {
+      // Set global dynamic value
+      parsed.dynamicValue = new DynamicBinding('d');
+      const { dynamicEvents } = transformTemplate(
+        parsed,
+        code
+      );
+
+      parsed.dynamicEvents = dynamicEvents;
+      parsed.eventHandlers = dynamicEvents.map(e => e.name);
+    }
+  },
+  // For test export.
+  _transform: transformTemplate,
+};

--- a/packages/jsx2qa-compiler/src/modules/index.js
+++ b/packages/jsx2qa-compiler/src/modules/index.js
@@ -1,0 +1,30 @@
+/**
+ * Attention:
+ *   The later registered module is called early in parse, but later in generate.
+ */
+module.exports = [
+  // Extract css from files.
+  require('./css'),
+  // Handle js code.
+  require('./code'),
+  // Handle template attrs
+  require('./element'),
+  // Handle quickApp tag
+  require('./tag'),
+  // Handle jsx attribute
+  require('./attribute'),
+  // Handle template style attr
+  require('./style'),
+  // Handle Rax base components.
+  require('./components'),
+  // Directive a:for
+  require('./list'),
+  // JSX+ Directives
+  require('./jsx-plus'),
+  // Directive a:if
+  require('./condition'),
+  // Handle render function
+  require('./render-function'),
+  // Parse and generate template.
+  require('./template')
+];

--- a/packages/jsx2qa-compiler/src/modules/jsx-plus.js
+++ b/packages/jsx2qa-compiler/src/modules/jsx-plus.js
@@ -1,0 +1,363 @@
+const t = require('@babel/types');
+const DynamicBinding = require('../utils/DynamicBinding');
+const traverse = require('../utils/traverseNodePath');
+const CodeError = require('../utils/CodeError');
+const createListIndex = require('../utils/createListIndex');
+const handleParentListReturn = require('../utils/handleParentListReturn');
+const handleValidIdentifier = require('../utils/handleValidIdentifier');
+const handleListStyle = require('../utils/handleListStyle');
+const handleListProps = require('../utils/handleListProps');
+const handleListJSXExpressionContainer = require('../utils/handleListJSXExpressionContainer');
+const getParentListPath = require('../utils/getParentListPath');
+const quickAppConst = require('../const');
+
+const directiveIf = 'x-if';
+const directiveElseif = 'x-elseif';
+const directiveElse = 'x-else';
+const conditionTypes = {
+  [directiveIf]: quickAppConst.if,
+  [directiveElseif]: quickAppConst.elseif,
+  [directiveElse]: quickAppConst.else,
+};
+
+/**
+ * Get condition type, enum of {if|elseif|else|null}
+ */
+function getCondition(jsxElement) {
+  if (t.isJSXOpeningElement(jsxElement.openingElement)) {
+    const { attributes } = jsxElement.openingElement;
+    for (let i = 0, l = attributes.length; i < l; i++) {
+      if (t.isJSXAttribute(attributes[i])) {
+        switch (attributes[i].name.name) {
+          case directiveIf:
+          case directiveElseif:
+          case directiveElse:
+            return {
+              type: conditionTypes[attributes[i].name.name],
+              value: t.isJSXExpressionContainer(attributes[i].value)
+                ? attributes[i].value.expression
+                : attributes[i].value,
+              index: i,
+            };
+        }
+      }
+    }
+  }
+  return null;
+}
+
+
+function transformDirectiveCondition(ast) {
+  traverse(ast, {
+    JSXElement(path) {
+      const { node } = path;
+      const condition = getCondition(node);
+      if (condition !== null && condition.value !== null && condition.type === conditionTypes[directiveIf]) {
+        const { type, value, index } = condition;
+        const conditions = [];
+        node.openingElement.attributes.splice(index, 1);
+        conditions.push({
+          type,
+          value,
+          jsxElement: node,
+        });
+
+        let continueSearch = false;
+        let nextJSXElPath = path;
+        let nextJSXElCondition;
+        do {
+          nextJSXElPath = nextJSXElPath.getSibling(nextJSXElPath.key + 1);
+          if (nextJSXElPath.isJSXText() && nextJSXElPath.node.value.trim() === '') {
+            continueSearch = true;
+          } else if (nextJSXElPath.isJSXElement()
+            && (nextJSXElCondition = getCondition(nextJSXElPath.node))) {
+            conditions.push({
+              type: nextJSXElCondition.type,
+              value: nextJSXElCondition.value,
+              jsxElement: nextJSXElPath.node,
+            });
+            nextJSXElPath.node.openingElement.attributes.splice(nextJSXElCondition.index, 1);
+            continueSearch = true;
+          } else {
+            continueSearch = false;
+          }
+        } while (continueSearch);
+
+        conditions.forEach(({ type, value, jsxElement }) => {
+          const { attributes } = jsxElement.openingElement;
+          const attr = type === conditionTypes[directiveElse]
+            ? t.jsxAttribute(t.jsxIdentifier(type))
+            : t.jsxAttribute(
+              t.jsxIdentifier(type),
+              t.jsxExpressionContainer(value)
+            );
+          attributes.push(attr);
+        });
+      }
+    }
+  });
+}
+
+// babel-plugin-transform-jsx-class
+function transformDirectiveClass(ast, parsed) {
+  let useClassnames = false;
+
+  traverse(ast, {
+    Program(path) {
+      path.__classHelperImported = false;
+    },
+    JSXOpeningElement(parentPath) {
+      const attributePaths = parentPath.get('attributes') || [];
+      const attributes = parentPath.node.attributes || [];
+
+      attributePaths.some(function(path) {
+        const { node } = path;
+        if (t.isJSXIdentifier(node.name, { name: 'x-class' })) {
+          const params = [];
+          if (t.isJSXExpressionContainer(node.value)) params.push(node.value.expression);
+          else if (t.isStringLiteral(node.value)) params.push(node.value);
+
+          const callExp = t.callExpression(t.identifier('__classnames__'), params);
+
+          let classNameAttribute;
+          for (let i = 0, l = attributes.length; i < l; i++) {
+            if (t.isJSXIdentifier(attributes[i].name, { name: 'className' })) classNameAttribute = attributes[i];
+          }
+
+          const spaceNode = t.stringLiteral(' ');
+          if (classNameAttribute) {
+            if (t.isJSXExpressionContainer(classNameAttribute.value)) {
+              // ClassName is {'container-el'} => className={`${'container-el'}${' '}${x-class-value}`}
+              classNameAttribute.value =
+                t.jsxExpressionContainer(t.templateLiteral(
+                  [createHolderTemplateEl(), createHolderTemplateEl(),
+                    createHolderTemplateEl(), createHolderTemplateEl()],
+                  [classNameAttribute.value.expression, spaceNode, callExp]));
+            } else {
+              // ClassName is "container-el" => className={`container-el ${x-class-value}`}
+              const prevVal = t.isStringLiteral(classNameAttribute.value) ? classNameAttribute.value.value : '';
+              classNameAttribute.value =
+                t.jsxExpressionContainer(t.templateLiteral(
+                  [t.templateElement(
+                    { raw: prevVal, cooked: prevVal }, true
+                  ), createHolderTemplateEl(), createHolderTemplateEl()],
+                  [spaceNode, callExp]));
+            }
+          } else {
+            attributes.push(t.jsxAttribute(
+              t.jsxIdentifier('className'),
+              t.jsxExpressionContainer(callExp)
+            ));
+          }
+
+          path.remove();
+          useClassnames = true;
+
+          return true;
+        }
+      });
+    },
+  });
+
+  if (parsed) {
+    parsed.useClassnames = useClassnames;
+  }
+}
+
+function transformDirectiveList(parsed, code) {
+  const ast = parsed.templateAST;
+  traverse(ast, {
+    JSXAttribute(path) {
+      const { node } = path;
+      if (t.isJSXIdentifier(node.name, { name: 'x-for' })) {
+        // Check stynax.
+        if (!t.isJSXExpressionContainer(node.value)) {
+          throw new CodeError(code, node, node.loc, 'Invalid x-for usage');
+        }
+        const dynamicStyle = new DynamicBinding('s');
+        const dynamicValue = new DynamicBinding('d');
+        const { expression } = node.value;
+        let params = [];
+        let forNode;
+        // original index identifier
+        let originalIndex;
+        // create new index identifier
+        const forIndex = createListIndex();
+        if (t.isBinaryExpression(expression, { operator: 'in' })) {
+          // x-for={(item, index) in value}
+          const { left, right } = expression;
+          forNode = right;
+          if (t.isSequenceExpression(left)) {
+            // x-for={(item, key) in value}
+            params = left.expressions;
+            originalIndex = params[1].name;
+            // Repalce index identifier
+            params[1] = forIndex;
+          } else if (t.isIdentifier(left)) {
+            // x-for={item in value}
+            params = [left, forIndex];
+          } else {
+            // x-for={??? in value}
+            throw new Error('Stynax error of x-for.');
+          }
+        } else {
+          // x-for={value}, x-for={callExp()}, ...
+          forNode = expression;
+          params = [t.identifier('item'), forIndex];
+        }
+        const parentJSXEl = path.findParent(p => p.isJSXElement());
+        // Transform x-for forNode to map function
+        const properties = [
+          t.objectProperty(params[0], params[0]),
+          t.objectProperty(params[1], params[1])
+        ];
+        const loopFnBody = t.blockStatement([
+          t.returnStatement(
+            t.objectExpression(properties)
+          )
+        ]);
+        const mapCallExpression = t.callExpression(
+          t.memberExpression(forNode, t.identifier('map')),
+          [
+            t.arrowFunctionExpression(params, loopFnBody)
+          ]);
+
+        const parentListPath = getParentListPath(path);
+
+        const parentList = parentListPath && parentListPath.node.__jsxlist;
+        forNode = handleParentListReturn(mapCallExpression, forNode, parentList, dynamicValue, code);
+
+        // <Component x-for={(item in list)} /> => <Component a:for={list} a:for-item="item" />
+        parentJSXEl.node.__jsxlist = {
+          args: params,
+          forNode,
+          loopFnBody,
+          parentList,
+          originalIndex,
+          jsxplus: true
+        };
+        transformListJSXElement(parsed, parentJSXEl, dynamicStyle, dynamicValue, code);
+        parentJSXEl._forParams = {
+          forItem: params[0].name,
+          forIndex: params[1].name,
+          forList: expression.right.name
+        };
+        path.remove();
+      }
+    }
+  });
+}
+
+function transformComponentFragment(ast) {
+  function transformFragment(path) {
+    if (t.isJSXIdentifier(path.node.name, { name: 'Fragment' })) {
+      path.get('name').replaceWith(t.jsxIdentifier('block'));
+    }
+  }
+
+  traverse(ast, {
+    JSXOpeningElement: transformFragment,
+    JSXClosingElement: transformFragment,
+  });
+  return null;
+}
+
+function transformSlotDirective(ast) {
+  traverse(ast, {
+    JSXAttribute(path) {
+      const { node } = path;
+      if (t.isJSXNamespacedName(node.name) && t.isJSXIdentifier(node.name.namespace, { name: 'x-slot' })) {
+        const slotName = node.name.name;
+        path.replaceWith(t.jsxAttribute(t.jsxIdentifier('slot'), t.stringLiteral(slotName.name)));
+      }
+    }
+  });
+}
+
+function transformListJSXElement(parsed, path, dynamicStyle, dynamicValue, code) {
+  const { node } = path;
+  const { attributes } = node.openingElement;
+
+  if (node.__jsxlist && !node.__jsxlist.generated) {
+    const { args, forNode, originalIndex, loopFnBody } = node.__jsxlist;
+    const loopBody = loopFnBody.body;
+    const properties = loopBody[loopBody.length - 1].argument.properties;
+    path.traverse({
+      Identifier(innerPath) {
+        const { node: innerNode } = innerPath;
+        // Replace index identifier which is the same as original index in list
+        handleValidIdentifier(innerPath, () => {
+          if (originalIndex === innerNode.name) {
+            innerNode.name = args[1].name;
+          }
+        });
+        if (args.find(arg => arg.name === innerNode.name)) {
+          innerNode.__listItem = {
+            jsxplus: true,
+            item: args[0].name,
+            index: args[1].name,
+            parentList: node.__jsxlist
+          };
+        }
+      },
+      JSXAttribute: {
+        exit(innerPath) {
+          // Handle style
+          const useCreateStyle = handleListStyle(null, innerPath, args[0], originalIndex, args[1].name, properties, dynamicStyle, code);
+          if (!parsed.useCreateStyle) {
+            parsed.useCreateStyle = useCreateStyle;
+          }
+          // Handle props
+          handleListProps(innerPath, args[0], originalIndex, args[1].name, properties, dynamicValue, code);
+        }
+      },
+      JSXExpressionContainer: {
+        exit(innerPath) {
+          if (!innerPath.findParent(p => p.isJSXAttribute()) && !(innerPath.node.__index === args[1].name)) {
+            handleListJSXExpressionContainer(innerPath, args[0], originalIndex, args[1].name, properties, dynamicValue);
+          }
+        }
+      }
+    });
+    if (args.length === 3) {
+      args.splice(2);
+    }
+    attributes.push(
+      t.jsxAttribute(
+        t.jsxIdentifier(quickAppConst.for),
+        t.jsxExpressionContainer(forNode)
+      )
+    );
+    args.forEach((arg, index) => {
+      // Mark skip ids.
+      const skipIds = node.skipIds = node.skipIds || new Map();
+      skipIds.set(arg.name, true);
+    });
+    node.__jsxlist.generated = true;
+  }
+}
+
+module.exports = {
+  parse(parsed, code, options) {
+    if (parsed.renderFunctionPath) {
+      // x-for must be first.
+      transformDirectiveClass(parsed.templateAST, parsed);
+      transformDirectiveList(parsed, code);
+      transformDirectiveCondition(parsed.templateAST);
+      transformComponentFragment(parsed.templateAST);
+      transformSlotDirective(parsed.templateAST);
+    }
+  },
+  _transformList: transformDirectiveList,
+  _transformClass: transformDirectiveClass,
+  _transformCondition: transformDirectiveCondition,
+  _transformFragment: transformComponentFragment,
+  _transformSlotDirective: transformSlotDirective
+};
+
+// Create place holder template element
+function createHolderTemplateEl() {
+  return t.templateElement(
+    { raw: '' }, false
+  );
+}

--- a/packages/jsx2qa-compiler/src/modules/list.js
+++ b/packages/jsx2qa-compiler/src/modules/list.js
@@ -1,0 +1,241 @@
+const t = require('@babel/types');
+const traverse = require('../utils/traverseNodePath');
+const getReturnElementPath = require('../utils/getReturnElementPath');
+const createJSX = require('../utils/createJSX');
+const genExpression = require('../codegen/genExpression');
+const findIndex = require('../utils/findIndex');
+const createListIndex = require('../utils/createListIndex');
+const handleParentListReturn = require('../utils/handleParentListReturn');
+const DynamicBinding = require('../utils/DynamicBinding');
+const handleValidIdentifier = require('../utils/handleValidIdentifier');
+const handleListStyle = require('../utils/handleListStyle');
+const handleListProps = require('../utils/handleListProps');
+const handleListJSXExpressionContainer = require('../utils/handleListJSXExpressionContainer');
+const getParentListPath = require('../utils/getParentListPath');
+const quickAppConst = require('../const');
+/**
+ * Transfrom map method
+ * @param {NodePath} path function or CallExpression path
+ * @param {object} parsed render function items
+ * @param {string} code - original code
+ * @param {object} adapter
+ */
+function transformMapMethod(path, parsed, code) {
+  const dynamicStyle = new DynamicBinding('s');
+  const dynamicValue = new DynamicBinding('d');
+  const renderItemFunctions = parsed.renderItemFunctions;
+
+  // Avoid transfrom x-for result
+  if (path.findParent(p => p.isJSXAttribute())) return;
+
+  const { node, parentPath } = path;
+  if (node.__transformedList) return;
+  node.__transformedList = true;
+  const { callee } = node;
+  if (t.isMemberExpression(callee)) {
+    if (t.isIdentifier(callee.property, { name: 'map' })) {
+      const argumentsPath = path.get('arguments');
+      const mapCallbackFn = argumentsPath[0].node;
+      const mapCallbackFnBodyPath = argumentsPath[0].get('body');
+      /*
+      * params is item & index
+      * <block a:for-item="params[0]" a:for-index="params[1]" ></block>
+      */
+      if (t.isFunction(mapCallbackFn)) {
+        let { params, body } = mapCallbackFn;
+        // original index identifier
+        let originalIndex;
+        // If item or index doesn't exist， set default value to params
+        if (!params[0]) {
+          params[0] = t.identifier('item');
+        }
+        // Create increasing new index identifier
+        const renamedIndex = createListIndex();
+
+        // record original index identifier
+        if (params[1]) {
+          originalIndex = params[1].name;
+        } else {
+          params[1] = renamedIndex;
+        }
+
+
+        const forItem = params[0];
+        const forIndex = params[1];
+        const properties = [
+          t.objectProperty(params[0], params[0]),
+          t.objectProperty(renamedIndex, renamedIndex)
+        ];
+
+        const iterValue = callee.object;
+        // handle parentList
+        const parentListPath = getParentListPath(path);
+
+        const parentList = parentListPath && parentListPath.node.__jsxlist;
+
+        const forNode = handleParentListReturn(node, iterValue, parentList, dynamicValue, code);
+
+        if (!t.isBlockStatement(body)) {
+          // create a block return for inline return
+          body = t.blockStatement([t.returnStatement(body)]);
+          mapCallbackFnBodyPath.replaceWith(body);
+        }
+
+        // __jsxlist
+        const jsxList = {
+          args: [t.identifier(forItem.name), t.identifier(renamedIndex.name)],
+          iterValue,
+          jsxplus: false,
+          parentList,
+          loopFnBody: body
+        };
+
+        mapCallbackFnBodyPath.get('body').filter(p => !p.isReturnStatement()).map(statementPath => {
+          statementPath.traverse({
+            Identifier(innerPath) {
+              const innerNode = innerPath.node;
+              handleValidIdentifier(innerPath, () => {
+                // Ensure inner node's name is original name
+                if ((innerNode.loc && innerNode.loc.identifierName || innerNode.name) === forIndex.name) {
+                  // Use renamed index instead of original value
+                  innerNode.name = renamedIndex.name;
+                }
+                const declartorPath = innerPath.find(p => p.isVariableDeclarator());
+                // Handle variable declaration in map function
+                if (
+                  declartorPath
+                   && (declartorPath.node.id.start <= innerNode.start && declartorPath.node.id.end >= innerNode.end)
+                   && findIndex(properties, property => property.value.name === innerNode.name) < 0) {
+                  properties.push(t.objectProperty(innerNode, innerNode));
+                  // Mark as from map fn body statement
+                  innerNode.__isFromMapFn = true;
+                }
+              });
+            }
+          });
+        });
+
+        // map callback function return path;
+        const returnElPath = getReturnElementPath(body).get('argument');
+        returnElPath.traverse({
+          Identifier(innerPath) {
+            const innerNode = innerPath.node;
+            if (innerPath.findParent(p => p.node.__bindEvent)) return;
+            handleValidIdentifier(innerPath, () => {
+              const isScope = returnElPath.scope.hasBinding(innerNode.name);
+              const isItem = innerNode.name === forItem.name;
+              // Ensure inner node's name is original name
+              const isIndex = (innerNode.loc && innerNode.loc.identifierName || innerNode.name) === forIndex.name;
+              if (isScope || isItem || isIndex) {
+                innerNode.__listItem = {
+                  jsxplus: false,
+                  item: forItem.name,
+                  parentList: jsxList
+                };
+
+                if (isIndex) {
+                  // Use renamed index instead of original value
+                  innerNode.name = renamedIndex.name;
+                }
+              }
+            });
+          },
+          JSXAttribute: {
+            exit(innerPath) {
+              const { node } = innerPath;
+              // Handle renderItem
+              if (node.name.name === 'data'
+                  && t.isStringLiteral(node.value)
+              ) {
+                const fnIdx = findIndex(renderItemFunctions || [], (fn) => node.value.value === `{{...${fn.name}}}`);
+                if (fnIdx > -1) {
+                  const renderItem = renderItemFunctions[fnIdx];
+                  node.value = t.stringLiteral(`${node.value.value.replace('...', `...${forItem.name}.`)}`);
+                  properties.push(t.objectProperty(t.identifier(renderItem.name), renderItem.node));
+                  renderItemFunctions.splice(fnIdx, 1);
+                }
+              }
+              // Handle style
+              const useCreateStyle = handleListStyle(mapCallbackFnBodyPath, innerPath, forItem, originalIndex, renamedIndex.name, properties, dynamicStyle, code);
+              if (!parsed.useCreateStyle) {
+                parsed.useCreateStyle = useCreateStyle;
+              }
+              // Handle props
+              handleListProps(innerPath, forItem, originalIndex, renamedIndex.name, properties, dynamicValue, code);
+            }
+          },
+          JSXExpressionContainer: {
+            exit(innerPath) {
+              if (!innerPath.findParent(p => p.isJSXAttribute()) && !(innerPath.node.__index === renamedIndex.name)) {
+                handleListJSXExpressionContainer(innerPath, forItem, originalIndex, renamedIndex.name, properties, dynamicValue);
+              }
+            }
+          }
+        });
+
+        const listAttr = {
+          [quickAppConst.for]: t.jsxExpressionContainer(forNode)
+        };
+
+        // Use renamed index instead of original params[1]
+        params[1] = renamedIndex;
+        const listBlock = createJSX('block', listAttr, [returnElPath.node]);
+
+        // Mark forItem __listItem
+        forItem.__listItem = {
+          jsxplus: false,
+          item: forItem.name,
+          parentList: jsxList
+        };
+
+        // Mark jsx list meta for generate by code.
+        jsxList.generated = true;
+        listBlock.__jsxlist = jsxList;
+
+        parentPath.replaceWith(listBlock);
+        parentPath._forParams = {
+          forItem: forItem.name,
+          forIndex: renamedIndex.name,
+          forList: callee.object
+        };
+        returnElPath.replaceWith(t.objectExpression(properties));
+      } else if (t.isIdentifier(mapCallbackFn) || t.isMemberExpression(mapCallbackFn)) {
+        // { foo.map(this.xxx) }
+        throw new Error(`The syntax conversion for ${genExpression(node)} is currently not supported. Please use inline functions.`);
+      }
+    }
+  }
+}
+
+function transformList(parsed, code) {
+  const ast = parsed.templateAST;
+  traverse(ast, {
+    ArrowFunctionExpression(path) {
+      transformMapMethod(path, parsed, code);
+    },
+    FunctionExpression(path) {
+      transformMapMethod(path, parsed, code);
+    },
+    CallExpression: {
+      enter(path) {
+        const { node, parentPath } = path;
+        const { callee } = node;
+        if (parentPath.parentPath.isJSXAttribute()) {
+          if (t.isMemberExpression(callee) && t.isIdentifier(callee.property, { name: 'bind' })) {
+            path.node.__bindEvent = true;
+          }
+        }
+        transformMapMethod(path, parsed, code);
+      }
+    }
+  });
+}
+
+module.exports = {
+  parse(parsed, code, options) {
+    transformList(parsed, code);
+  },
+
+  // For test cases.
+  _transformList: transformList,
+};

--- a/packages/jsx2qa-compiler/src/modules/render-function.js
+++ b/packages/jsx2qa-compiler/src/modules/render-function.js
@@ -1,0 +1,96 @@
+const t = require('@babel/types');
+const traverse = require('../utils/traverseNodePath');
+const getReturnElementPath = require('../utils/getReturnElementPath');
+const createJSX = require('../utils/createJSX');
+const genExpression = require('../codegen/genExpression');
+const { parseCode } = require('../parser/index');
+const createBinding = require('../utils/createBinding');
+
+function transformRenderFunction(ast, renderFnPath, code, options) {
+  const renderItemList = [];
+  const renderItemFunctions = [];
+  const renderItem = {};
+  let tempId = 0;
+  traverse(ast, {
+    CallExpression: {
+      enter(path) {
+        const { node } = path;
+        const renderFnParentPath = renderFnPath.parentPath;
+        const returnProperties = [];
+        // Class component
+        if (renderFnParentPath.isClassBody()) {
+          const callee = node.callee;
+          // Handle this.xxxx()
+          if (t.isThisExpression(callee.object) && t.isIdentifier(callee.property)) {
+            const methodName = callee.property.name;
+            const tempDataName = `${methodName}StateTemp${tempId++}`;
+            // const templateName = t.stringLiteral(methodName);
+            const renderFunctionPath = renderFnParentPath.get('body').find(path => path.isClassMethod()
+              && path.node.key.name === methodName);
+            const returnStatementPath = getReturnElementPath(renderFunctionPath);
+            const returnArgumentPath = returnStatementPath.get('argument');
+            if (!renderItemFunctions.some(fn => fn.originName === methodName)) {
+              if (!returnArgumentPath.isJSXElement()) {
+                path.skip();
+                return;
+              }
+              // Collect identifier in return Element
+              returnStatementPath.traverse({
+                Identifier(innerPath) {
+                  const { node: identifierNode } = innerPath;
+                  if (renderFunctionPath.scope.hasBinding(identifierNode.name)) {
+                    // Avoid repeat push
+                    if (!returnProperties.some(
+                      pty => pty.key.name === identifierNode.name)) {
+                      returnProperties.push(t.objectProperty(identifierNode, identifierNode));
+                    }
+                    // Tag as template variable
+                    identifierNode.__templateVar = true;
+                  }
+                }
+              });
+              // collect template tagName
+              renderItem[ methodName ] = returnArgumentPath.node;
+              renderItemList.push(renderItem);
+              // Return used variables
+              returnArgumentPath.replaceWith(t.objectExpression(returnProperties));
+            }
+
+            // Collect this.xxxx()
+            renderItemFunctions.push({
+              name: tempDataName,
+              originName: methodName,
+              node,
+            });
+            const targetNode = renderItem[ methodName ];
+            targetNode.__renderParams = {
+              tempDataName,
+              objectExpression: returnArgumentPath.node
+            };
+
+            const targetAttr = {};
+            returnProperties.forEach((v) => {
+              targetAttr[v.key.name] = t.stringLiteral(createBinding(`${tempDataName}.${v.value.name}`));
+            });
+            const targetPath = path.parentPath.isJSXExpressionContainer() ? path.parentPath : path;
+            targetNode && targetPath.replaceWith(targetNode);
+          }
+        }
+      }
+    }
+  });
+  return { renderItemFunctions, renderItemList };
+}
+
+module.exports = {
+  parse(parsed, code, options) {
+    const { renderItemFunctions, renderItemList } = transformRenderFunction(parsed.templateAST, parsed.renderFunctionPath, code, options);
+    parsed.renderItemFunctions = renderItemFunctions;
+    parsed.renderItems = renderItemList;
+  },
+  generate(ret, parsed, options) {
+    ret.renderItems = parsed.renderItems;
+  },
+  // For test cases.
+  _transformRenderFunction: transformRenderFunction,
+};

--- a/packages/jsx2qa-compiler/src/modules/style.js
+++ b/packages/jsx2qa-compiler/src/modules/style.js
@@ -1,0 +1,59 @@
+const t = require('@babel/types');
+const traverse = require('../utils/traverseNodePath');
+
+const TEMPLATE_AST = 'templateAST';
+const DynamicBinding = require('../utils/DynamicBinding');
+const getListItem = require('../utils/getListItem');
+
+/**
+ * Transform style object.
+ *  input:  <view style={{width: 100}}/>
+ *  output: <view style="{{_style0}}">
+ *          var _style0 = { width: 100 };
+ *          return { _style0 };
+ */
+function transformStyle(ast) {
+  const dynamicStyle = new DynamicBinding('s');
+  let useCreateStyle = false;
+  traverse(ast, {
+    JSXAttribute(path) {
+      const { node } = path;
+      if (shouldReplace(path)) {
+        const styleObjectExpression = node.value.expression;
+        // <tag style="{{ _s0 }}" />
+        const name = dynamicStyle.add({
+          expression: t.callExpression(t.identifier('__create_style__'), [styleObjectExpression]),
+        });
+        node.value = t.stringLiteral('{{' + name + '}}');
+        // Record original expression
+        node.value.__originalExpression = styleObjectExpression;
+        useCreateStyle = true;
+      }
+    },
+  });
+  return {
+    useCreateStyle,
+    dynamicStyle
+  };
+}
+
+function shouldReplace(path) {
+  const { node } = path;
+  if (t.isJSXExpressionContainer(node.value) && node.name.name === 'style') {
+    return !getListItem(node.value.expression);
+  }
+  return false;
+}
+
+module.exports = {
+  parse(parsed, code, options) {
+    const { useCreateStyle, dynamicStyle } = transformStyle(parsed[TEMPLATE_AST]);
+    if (!parsed.useCreateStyle) {
+      parsed.useCreateStyle = useCreateStyle;
+    }
+    // Set global dynamic style value
+    parsed.dynamicStyle = dynamicStyle;
+  },
+
+  _transform: transformStyle,
+};

--- a/packages/jsx2qa-compiler/src/modules/tag.js
+++ b/packages/jsx2qa-compiler/src/modules/tag.js
@@ -1,0 +1,38 @@
+const t = require('@babel/types');
+const traverse = require('../utils/traverseNodePath');
+const createJSX = require('../utils/createJSX');
+
+const TEMPLATE_AST = 'templateAST';
+
+function transformTag(ast) {
+  traverse(ast, {
+    JSXText(path) {
+      // <View>hello</View> => <View><text>hello</text></View>
+      const { node, parentPath } = path;
+      if (t.isJSXElement(parentPath) && path.node.value && path.node.value.trim().length) {
+        const openTagName = parentPath.node.openingElement.name;
+        if (t.isJSXIdentifier(openTagName, { name: 'rax-view' }) || t.isJSXIdentifier(openTagName, { name: 'rax-link' })) {
+          path.replaceWith(createJSX('text', {}, [path.node]));
+        }
+      }
+    },
+    JSXExpressionContainer(path) {
+      // <View>{'hello'}</View> => <View><text>hello</text></View>
+      const { node, parentPath } = path;
+      if (t.isJSXElement(parentPath) && (t.isIdentifier(node.expression) || t.isMemberExpression(node.expression))) {
+        const openTagName = parentPath.node.openingElement.name;
+        if (t.isJSXIdentifier(openTagName, { name: 'rax-view' }) || t.isJSXIdentifier(openTagName, { name: 'rax-link' })) {
+          path.replaceWith(createJSX('text', {}, [path.node]));
+        }
+      }
+    },
+  });
+}
+
+module.exports = {
+  parse(parsed, code, options) {
+    transformTag(parsed[TEMPLATE_AST]);
+  },
+
+  _transformTag: transformTag,
+};

--- a/packages/jsx2qa-compiler/src/modules/template.js
+++ b/packages/jsx2qa-compiler/src/modules/template.js
@@ -1,0 +1,92 @@
+const t = require('@babel/types');
+const { NodePath } = require('@babel/traverse');
+const isFunctionComponent = require('../utils/isFunctionComponent');
+const isClassComponent = require('../utils/isClassComponent');
+const traverse = require('../utils/traverseNodePath');
+const getReturnElementPath = require('../utils/getReturnElementPath');
+const genExpression = require('../codegen/genExpression');
+const createJSX = require('../utils/createJSX');
+const getExportComponentPath = require('../utils/getExportComponentPath');
+const getProgramPath = require('../utils/getProgramPath');
+const quickappConst = require('../const');
+
+const TEMPLATE_AST = 'templateAST';
+const RENDER_FN_PATH = 'renderFunctionPath';
+/**
+ * Extract JSXElement path.
+ */
+module.exports = {
+  parse(parsed, code, options) {
+    const { defaultExportedPath, ast } = parsed;
+    if (!defaultExportedPath) return;
+    const exportComponentPath = parsed.exportComponentPath = getExportComponentPath(defaultExportedPath, getProgramPath(ast), code);
+    const renderFnPath = isFunctionComponent(exportComponentPath)
+      ? exportComponentPath
+      : isClassComponent(exportComponentPath)
+        ? getRenderMethodPath(exportComponentPath)
+        : undefined;
+    if (!renderFnPath) return;
+
+    const returnPath = getReturnElementPath(renderFnPath);
+    if (!returnPath) throw new Error('Can not find JSX Statements in ' + options.resourcePath);
+    let returnArgument = returnPath.get('argument').node;
+    // support render mulit elements
+    if (t.isArrayExpression(returnPath.get('argument'))) {
+      returnArgument = createJSX(quickappConst.baseComponent, {
+        class: t.stringLiteral('__rax-view')
+      }, returnPath.get('argument').node.elements);
+    }
+    if (!['JSXText', 'JSXExpressionContainer', 'JSXSpreadChild', 'JSXElement', 'JSXFragment'].includes(returnArgument.type)) {
+      returnArgument = t.jsxExpressionContainer(returnArgument);
+    }
+    returnPath.remove();
+    const template = createJSX(quickappConst.baseComponent, { class: t.stringLiteral('page-container __rax-view') }, [returnArgument]);
+    parsed[TEMPLATE_AST] = createJSX('template', { pagePath: t.stringLiteral('true') }, [template]);
+    parsed[RENDER_FN_PATH] = renderFnPath;
+  },
+  generate(ret, parsed, options) {
+    if (parsed[TEMPLATE_AST]) {
+      ret.template = [
+        genExpression(parsed[TEMPLATE_AST], {
+          comments: false,
+          concise: true,
+        })
+      ].join('\n');
+    }
+  },
+};
+
+/**
+ * Get the render function path from class component declaration..
+ * @param path {NodePath} A nodePath that contains a render function.
+ * @return {NodePath} Path to render function.
+ */
+function getRenderMethodPath(path) {
+  let renderMethodPath = null;
+  traverse(path, {
+    /**
+     * Example:
+     *   class {
+     *     render() {}
+     *   }
+     */
+    ClassMethod(classMethodPath) {
+      const { node } = classMethodPath;
+      if (t.isIdentifier(node.key, { name: 'render' })) {
+        renderMethodPath = classMethodPath;
+      }
+    },
+    /**
+     * Example:
+     *   class {
+     *     render = function() {}
+     *     render = () => {}
+     *   }
+     */
+    ClassProperty(path) {
+      // TODO: support class property defined render function.
+    },
+  });
+
+  return renderMethodPath;
+}

--- a/packages/jsx2qa-compiler/src/options.js
+++ b/packages/jsx2qa-compiler/src/options.js
@@ -1,0 +1,8 @@
+exports.baseOptions = {
+  cwd: process.cwd(),
+  modules: require('./modules'),
+  /**
+   * Whether add whitespace between tags.
+   */
+  preserveWhitespace: false,
+};

--- a/packages/jsx2qa-compiler/src/parser/__tests__/importedAndExported.js
+++ b/packages/jsx2qa-compiler/src/parser/__tests__/importedAndExported.js
@@ -1,0 +1,63 @@
+const { parseCode, getImported, getExported } = require('../index');
+
+describe('Parse imported', () => {
+  it('should parse default imported', () => {
+    expect(getImported(parseCode(`
+      import Hello from './Hello';
+      import * as Env from 'universal-env';
+      import Rax, { Component } from 'rax';
+    `))).toEqual({
+      './Hello': [{ default: true, namespace: false, isCustomEl: true, local: 'Hello', name: 'c-702789' }],
+      'universal-env': [{ default: false, namespace: true, isCustomEl: false, local: 'Env', name: 'universal-env' }],
+      rax: [
+        {
+          default: true,
+          namespace: false,
+          isCustomEl: false,
+          local: 'Rax',
+          name: 'rax',
+        },
+        {
+          default: false,
+          namespace: false,
+          isCustomEl: false,
+          importFrom: 'Component',
+          local: 'Component',
+          name: 'rax'
+        }
+      ]
+    }
+    );
+  });
+});
+
+describe('Parse exported', () => {
+  it('should parse default exported', () => {
+    expect(getExported(parseCode(`
+      export default class Foo extends Component {}
+    `))).toEqual(['default']);
+  });
+
+  it('should parse default exported lines', () => {
+    expect(getExported(parseCode(`
+      class Foo extends Component {}
+      export default Foo;
+    `))).toEqual(['default']);
+  });
+
+  it('should parse named exported', () => {
+    expect(getExported(parseCode(`
+      const foo = 1;
+      const bar = 2;
+      export { foo, bar };
+    `))).toEqual(['foo', 'bar']);
+  });
+
+  it('should parse named exported inline', () => {
+    expect(getExported(parseCode(`
+      export function foo1() {};
+      export class foo2 {};
+      export var bar1 = 1, bar2 = 2;
+    `))).toEqual(['foo1', 'foo2', 'bar1', 'bar2']);
+  });
+});

--- a/packages/jsx2qa-compiler/src/parser/index.js
+++ b/packages/jsx2qa-compiler/src/parser/index.js
@@ -1,0 +1,148 @@
+const t = require('@babel/types');
+const babelParser = require('@babel/parser');
+const invokeModules = require('../utils/invokeModules');
+const traverse = require('../utils/traverseNodePath');
+const getDefaultExportedPath = require('../utils/getDefaultExportedPath');
+const getProgramPath = require('../utils/getProgramPath');
+const parserOption = require('./option');
+const md5 = require('md5');
+
+const RELATIVE_COMPONENTS_REG = /^\..*(\.jsx?)?$/i;
+
+function getTagName(str) {
+  return 'c-' + md5(str).slice(0, 6);
+}
+
+/**
+ * Parse JS code by babel parser.
+ * @param code {String} JS code.
+ */
+function parseCode(code) {
+  return babelParser.parse(code, parserOption);
+}
+
+/**
+ * Get imported modules.
+ * @param ast
+ */
+function getImported(ast) {
+  // { [source]: [{ local: String, imported: String, default: Boolean } }]
+  const imported = {};
+  traverse(ast, {
+    ImportDeclaration(path) {
+      const { specifiers } = path.node;
+      if (!Array.isArray(specifiers)) return;
+      const source = path.node.source.value;
+      imported[source] = [];
+
+      path.node.specifiers.forEach((specifier) => {
+        const local = specifier.local.name;
+        const ret = { local, default: t.isImportDefaultSpecifier(specifier), namespace: t.isImportNamespaceSpecifier(specifier) };
+        if (ret.default === false && ret.namespace === false) {
+          ret.importFrom = specifier.imported.name;
+        }
+
+        if (RELATIVE_COMPONENTS_REG.test(source)) {
+          // alias = 'c-xxxxx'
+          ret.name = getTagName(source);
+          ret.isCustomEl = true;
+        } else {
+          // alias = 'rax-view'
+          ret.name = source;
+          ret.isCustomEl = false;
+        }
+        imported[source].push(ret);
+      });
+    },
+  });
+  return imported;
+}
+
+/**
+ * Get exported modules.
+ * @param ast
+ */
+function getExported(ast) {
+  // { [localId]: { source: String, importFrom: String, default: Boolean } }
+  const exported = [];
+  traverse(ast, {
+    ExportDefaultDeclaration(path) {
+      exported.push('default');
+    },
+    ExportNamedDeclaration(path) {
+      const { node } = path;
+      if (node.specifiers.length > 0) {
+        node.specifiers.forEach((specifier) => {
+          exported.push(specifier.local.name);
+        });
+      }
+      if (node.declaration !== null) {
+        switch (node.declaration.type) {
+          case 'ClassDeclaration':
+          case 'FunctionDeclaration':
+            exported.push(node.declaration.id.name);
+            break;
+          case 'VariableDeclaration':
+            if (node.declaration.declarations.length > 0) {
+              node.declaration.declarations.forEach((declarator) => {
+                exported.push(declarator.id.name);
+              });
+            }
+            break;
+        }
+      }
+      if (t.isIdentifier(node.name)) {
+        exported.push(node.name.name);
+      }
+    },
+  });
+  return exported;
+}
+
+/**
+ * @param code
+ * @param options {Object} Parser options.
+ */
+function parse(code, options) {
+  if (!options) {
+    const { baseOptions } = require('../options');
+    options = baseOptions;
+  }
+
+  const ast = parseCode(code);
+  const imported = getImported(ast);
+  const exported = getExported(ast);
+  const programPath = getProgramPath(ast);
+  const defaultExportedPath = getDefaultExportedPath(ast);
+
+  const ret = {
+    ast,
+    imported,
+    exported,
+    defaultExportedPath,
+    programPath,
+    assets: {},
+  };
+
+  // Reverse to call parse.
+  invokeModules(reverse(options.modules), 'parse', ret, code, options);
+  return ret;
+}
+
+function parseExpression(code) {
+  return parseCode(code).program.body[0].expression;
+}
+
+/**
+ * Reverse an array without effects.
+ */
+function reverse(arr) {
+  const copied = Array.prototype.slice.call(arr);
+  return copied.reverse();
+}
+
+exports.parse = parse;
+exports.parseCode = parseCode;
+exports.parseExpression = parseExpression;
+exports.getImported = getImported;
+exports.getExported = getExported;

--- a/packages/jsx2qa-compiler/src/parser/option.js
+++ b/packages/jsx2qa-compiler/src/parser/option.js
@@ -1,0 +1,18 @@
+/**
+ * Babel parser option.
+ */
+module.exports = {
+  sourceType: 'module',
+  plugins: [
+    'classProperties',
+    'jsx',
+    'typescript',
+    'trailingFunctionCommas',
+    'asyncFunctions',
+    'exponentiationOperator',
+    'asyncGenerators',
+    'objectRestSpread',
+    ['decorators', { decoratorsBeforeExport: false }],
+    'dynamicImport'
+  ],
+};

--- a/packages/jsx2qa-compiler/src/utils/CodeError.js
+++ b/packages/jsx2qa-compiler/src/utils/CodeError.js
@@ -1,0 +1,20 @@
+const { codeFrameColumns } = require('@babel/code-frame');
+const { default: generate } = require('@babel/generator');
+
+function createErrorMessage(sourceCode, node, loc, extraMessage) {
+  const rawLines = sourceCode ? sourceCode : generate(node).code;
+  try {
+    return codeFrameColumns(rawLines, loc, { highlightCode: true, message: extraMessage });
+  } catch (err) {
+    return 'Failed to locate source code position.';
+  }
+}
+
+class CodeError extends Error {
+  constructor(sourceCode, node, loc, message) {
+    super('\n' + createErrorMessage(sourceCode, node, loc, message));
+    this.node = node;
+  }
+}
+
+module.exports = CodeError;

--- a/packages/jsx2qa-compiler/src/utils/DynamicBinding.js
+++ b/packages/jsx2qa-compiler/src/utils/DynamicBinding.js
@@ -1,0 +1,62 @@
+const genExpression = require('../codegen/genExpression');
+
+module.exports = class DynamicBinding {
+  constructor(prefix) {
+    this.prefix = prefix;
+    this._map = {};
+    this._store = [];
+  }
+
+  _generateDynamicName() {
+    return this.prefix + this._store.length;
+  }
+
+  _bindDynamicValue({
+    expression,
+    isDirective
+  }) {
+    const name = this._generateDynamicName();
+    this._store.push({
+      name,
+      value: expression,
+      isDirective
+    });
+    this._map[this._store.length - 1] = expression;
+    return name;
+  }
+
+  add({
+    expression,
+    isDirective = false
+  }) {
+    const keys = Object.keys(this._map);
+    if (keys.length === 0) {
+      return this._bindDynamicValue({
+        expression,
+        isDirective
+      });
+    } else {
+      let name;
+      keys.some(key => {
+        if (genExpression(expression) === genExpression(this._map[key])) {
+          name = this._store[key].name;
+          return true;
+        }
+        return false;
+      });
+      return name ? name : this._bindDynamicValue({
+        expression,
+        isDirective
+      });
+    }
+  }
+
+  getExpression(name) {
+    const target = this._store.find(dynamicItem => dynamicItem.name === name);
+    return target ? target.value : null;
+  }
+
+  getStore() {
+    return this._store;
+  }
+};

--- a/packages/jsx2qa-compiler/src/utils/Expression.js
+++ b/packages/jsx2qa-compiler/src/utils/Expression.js
@@ -1,0 +1,10 @@
+module.exports = class Expression {
+  constructor(descriptor) {
+    this.isExpression = true;
+    this.descriptor = descriptor || '';
+  }
+
+  toString() {
+    return this.descriptor;
+  }
+};

--- a/packages/jsx2qa-compiler/src/utils/__tests__/__snapshots__/codeError.js.snap
+++ b/packages/jsx2qa-compiler/src/utils/__tests__/__snapshots__/codeError.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Code Error should throw error 1`] = `
+"
+[0m [90m 1 | [39m[36mclass[39m [33mFoo[39m {[0m
+[0m[31m[1m>[22m[39m[90m 2 | [39m  constructor() {[0m
+[0m [90m   | [39m               [31m[1m^[22m[39m [31m[1mhello[22m[39m[0m
+[0m [90m 3 | [39m    console[33m.[39mlog([32m\\"hello\\"[39m)[33m;[39m[0m
+[0m [90m 4 | [39m  }[0m
+[0m [90m 5 | [39m}[0m"
+`;

--- a/packages/jsx2qa-compiler/src/utils/__tests__/codeError.js
+++ b/packages/jsx2qa-compiler/src/utils/__tests__/codeError.js
@@ -1,0 +1,13 @@
+const CodeError = require('../CodeError');
+
+describe('Code Error', () => {
+  it('should throw error', () => {
+    expect(() => {
+      throw new CodeError(`class Foo {
+  constructor() {
+    console.log("hello");
+  }
+}`, null, { start: { line: 2, column: 16 } }, 'hello');
+    }).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/packages/jsx2qa-compiler/src/utils/__tests__/getDefaultExportedPath.js
+++ b/packages/jsx2qa-compiler/src/utils/__tests__/getDefaultExportedPath.js
@@ -1,0 +1,83 @@
+const getDefaultExportedPath = require('../getDefaultExportedPath');
+const { parseCode } = require('../../parser');
+
+describe('getDefaultExportedPath', () => {
+  it('#1', () => {
+    const code = `
+      import { createElement, Component } from 'rax';
+      import View from 'rax-view';
+      import './index.css';
+      
+      class Foo extends Component {
+        render() {
+          return (
+            <View className="header">
+              {this.props.children}
+            </View>
+          );
+        }
+      }
+      
+      export default Foo;
+    `;
+
+    const defaultExportedPath = getDefaultExportedPath(parseCode(code));
+    expect(defaultExportedPath.node.type).toEqual('ClassDeclaration');
+  });
+
+  it('#2', () => {
+    const code = `
+      import { createElement, Component } from 'rax';
+      import View from 'rax-view';
+      import './index.css';
+      
+      function Foo() {}
+      
+      export default Foo;
+    `;
+
+    const defaultExportedPath = getDefaultExportedPath(parseCode(code));
+    expect(defaultExportedPath.node.type).toEqual('FunctionDeclaration');
+  });
+
+  it('#3', () => {
+    const code = `
+      import { createElement, Component } from 'rax';
+      import View from 'rax-view';
+      import './index.css';
+      
+      export default class {};
+    `;
+
+    const defaultExportedPath = getDefaultExportedPath(parseCode(code));
+    expect(defaultExportedPath.node.type).toEqual('ClassDeclaration');
+  });
+
+  it('#4', () => {
+    const code = `
+      import { createElement, Component } from 'rax';
+      import View from 'rax-view';
+      import './index.css';
+      
+      export default function() {}
+    `;
+
+    const defaultExportedPath = getDefaultExportedPath(parseCode(code));
+    expect(defaultExportedPath.node.type).toEqual('FunctionDeclaration');
+  });
+
+  it('#5', () => {
+    const code = `
+      import { createElement, Component } from 'rax';
+      import View from 'rax-view';
+      import './index.css';
+      
+      class Foo extends Component {}
+      
+      export default Foo;
+    `;
+
+    const defaultExportedPath = getDefaultExportedPath(parseCode(code));
+    expect(defaultExportedPath.node.type).toEqual('ClassDeclaration');
+  });
+});

--- a/packages/jsx2qa-compiler/src/utils/__tests__/isClassComponent.js
+++ b/packages/jsx2qa-compiler/src/utils/__tests__/isClassComponent.js
@@ -1,0 +1,78 @@
+const isClassComponent = require('../isClassComponent');
+const getDefaultExportedPath = require('../getDefaultExportedPath');
+const { parseCode } = require('../../parser');
+
+describe('isClassComponent', () => {
+  it('#1', () => {
+    const code = `
+      import { createElement, Component } from 'rax';
+      import View from 'rax-view';
+      import './index.css';
+
+      export default class extends Component {
+        render() {
+          return (
+            <View className="header">
+              {this.props.children}
+            </View>
+          );
+        }
+      }
+    `;
+
+    const defaultExportedPath = getDefaultExportedPath(parseCode(code));
+    expect(isClassComponent(defaultExportedPath)).toBeTruthy();
+  });
+
+  it('#2', () => {
+    const code = `
+      import RaxRef from 'rax';
+      export default class extends RaxRef.Component {}
+    `;
+
+    const defaultExportedPath = getDefaultExportedPath(parseCode(code));
+    expect(isClassComponent(defaultExportedPath)).toBeTruthy();
+  });
+
+  it('#3', () => {
+    const code = `
+      import React, { Component } from 'react';
+      export default class extends Component {}
+    `;
+
+    const defaultExportedPath = getDefaultExportedPath(parseCode(code));
+    expect(isClassComponent(defaultExportedPath)).toBeTruthy();
+  });
+
+  it('#4', () => {
+    const code = `
+      import React, { Component } from 'react';
+      export default class {}
+    `;
+
+    const defaultExportedPath = getDefaultExportedPath(parseCode(code));
+    expect(isClassComponent(defaultExportedPath)).toBeFalsy();
+  });
+
+  it('#5', () => {
+    const code = `
+      import Rax, { Component } from 'rax';
+      const foo = class extends Component {};
+      export default foo;
+    `;
+
+    const defaultExportedPath = getDefaultExportedPath(parseCode(code));
+    expect(isClassComponent(defaultExportedPath)).toBeTruthy();
+  });
+
+  it('#6', () => {
+    const code = `
+      import Rax, { Component } from 'rax';
+      class foo extends Component {}
+      export default foo;
+    `;
+
+    const defaultExportedPath = getDefaultExportedPath(parseCode(code));
+    expect(isClassComponent(defaultExportedPath)).toBeTruthy();
+  });
+});

--- a/packages/jsx2qa-compiler/src/utils/__tests__/isFunctionComponent.js
+++ b/packages/jsx2qa-compiler/src/utils/__tests__/isFunctionComponent.js
@@ -1,0 +1,45 @@
+const isFunctionComponent = require('../isFunctionComponent');
+const { parseCode } = require('../../parser');
+const getDefaultExportedPath = require('../getDefaultExportedPath');
+
+describe('isFunctionComponent', () => {
+  it('#1', () => {
+    const code = `
+      import Rax from 'rax';
+      export default function foo() {
+        return (<view></view>);
+      }
+    `;
+
+    const defaultExportedPath = getDefaultExportedPath(parseCode(code));
+    expect(isFunctionComponent(defaultExportedPath)).toBeTruthy();
+  });
+
+  it('#2', () => {
+    const code = `
+      function foo() {
+        return (<view></view>);
+      }
+      
+      export default foo;
+    `;
+
+    const defaultExportedPath = getDefaultExportedPath(parseCode(code));
+    expect(isFunctionComponent(defaultExportedPath)).toBeTruthy();
+  });
+
+  /**
+   * Support React Now.
+   */
+  it('#3', () => {
+    const code = `
+      import React from 'react';
+      
+      const foo = () => <view></view>;
+      export default foo;
+    `;
+
+    const defaultExportedPath = getDefaultExportedPath(parseCode(code));
+    expect(isFunctionComponent(defaultExportedPath)).toBeTruthy();
+  });
+});

--- a/packages/jsx2qa-compiler/src/utils/checkAttr.js
+++ b/packages/jsx2qa-compiler/src/utils/checkAttr.js
@@ -1,0 +1,9 @@
+const isDirectiveAttr = attr => /^(a:|wx:|x-)/.test(attr);
+const isEventHandlerAttr = propKey => /^on[A-Z]/.test(propKey);
+const BINDING_REG = /{{|}}/g;
+
+module.exports = {
+  isDirectiveAttr,
+  isEventHandlerAttr,
+  BINDING_REG
+};

--- a/packages/jsx2qa-compiler/src/utils/checkModule.js
+++ b/packages/jsx2qa-compiler/src/utils/checkModule.js
@@ -1,0 +1,7 @@
+function isNpmModule(value) {
+  return !(value[0] === '.' || value[0] === '/');
+}
+
+module.exports = {
+  isNpmModule
+};

--- a/packages/jsx2qa-compiler/src/utils/createBinding.js
+++ b/packages/jsx2qa-compiler/src/utils/createBinding.js
@@ -1,0 +1,7 @@
+module.exports = function createBinding(key) {
+  key = String(key).trim();
+  if (key[0] === '{' && key[key.length - 1] === '}') {
+    key = ' ' + key + ' '; // Add first and last char. QuickApp use { { a: 1 } } to represent an bindging object.
+  }
+  return '{{' + key + '}}';
+};

--- a/packages/jsx2qa-compiler/src/utils/createIncrement.js
+++ b/packages/jsx2qa-compiler/src/utils/createIncrement.js
@@ -1,0 +1,5 @@
+let id = 0;
+
+module.exports = function() {
+  return String(id++);
+};

--- a/packages/jsx2qa-compiler/src/utils/createJSX.js
+++ b/packages/jsx2qa-compiler/src/utils/createJSX.js
@@ -1,0 +1,17 @@
+const t = require('@babel/types');
+
+module.exports = function createJSX(tag, attrs = {}, children = []) {
+  const attributes = [];
+  Object.keys(attrs).forEach((key) => {
+    attributes.push(t.jsxAttribute(
+      t.jsxIdentifier(key),
+      attrs[key],
+    ));
+  });
+  const jsxOpeningElement = t.jsxOpeningElement(
+    t.jsxIdentifier(tag),
+    attributes
+  );
+  const jsxClosingElement = t.jsxClosingElement(t.jsxIdentifier(tag));
+  return t.jsxElement(jsxOpeningElement, jsxClosingElement, children);
+};

--- a/packages/jsx2qa-compiler/src/utils/createJSXBinding.js
+++ b/packages/jsx2qa-compiler/src/utils/createJSXBinding.js
@@ -1,0 +1,10 @@
+const t = require('@babel/types');
+
+module.exports = function createJSXBinding(string) {
+  const id = t.identifier(string);
+  const jsxExp = t.jsxExpressionContainer(t.objectExpression([
+    t.objectProperty(id, id, false, true)
+  ]));
+  jsxExp.__transformed = true; // In case of loop transform.
+  return jsxExp;
+};

--- a/packages/jsx2qa-compiler/src/utils/createListIndex.js
+++ b/packages/jsx2qa-compiler/src/utils/createListIndex.js
@@ -1,0 +1,8 @@
+const t = require('@babel/types');
+
+let listIndexCount = 0;
+
+// Create increasing index node
+module.exports = function() {
+  return t.identifier('index' + listIndexCount++);
+};

--- a/packages/jsx2qa-compiler/src/utils/findIndex.js
+++ b/packages/jsx2qa-compiler/src/utils/findIndex.js
@@ -1,0 +1,11 @@
+module.exports = function(arr, checkFn) {
+  let idx = -1;
+  arr.some((item, index) => {
+    if (checkFn(item, index)) {
+      idx = index;
+      return true;
+    }
+    return false;
+  });
+  return idx;
+};

--- a/packages/jsx2qa-compiler/src/utils/generateId.js
+++ b/packages/jsx2qa-compiler/src/utils/generateId.js
@@ -1,0 +1,6 @@
+let count = 0;
+
+// Generate id selector
+module.exports = function() {
+  return `id_${count++}`;
+};

--- a/packages/jsx2qa-compiler/src/utils/getDefaultExportedPath.js
+++ b/packages/jsx2qa-compiler/src/utils/getDefaultExportedPath.js
@@ -1,0 +1,25 @@
+const t = require('@babel/types');
+const traverse = require('./traverseNodePath');
+
+module.exports = function getDefaultExportedPath(ast) {
+  let exportedDeclaration = null;
+  traverse(ast, {
+    ExportDefaultDeclaration(path) {
+      exportedDeclaration = path.get('declaration');
+      if (t.isIdentifier(exportedDeclaration.node)) {
+        const id = exportedDeclaration.node.name;
+        const binding = exportedDeclaration.scope.getBinding(id);
+        if (binding) {
+          if (t.isVariableDeclarator(binding.path.node)) {
+            exportedDeclaration = binding.path.get('init');
+          } else {
+            exportedDeclaration = binding.path;
+          }
+        } else {
+          exportedDeclaration = null;
+        }
+      }
+    },
+  });
+  return exportedDeclaration;
+};

--- a/packages/jsx2qa-compiler/src/utils/getExportComponentPath.js
+++ b/packages/jsx2qa-compiler/src/utils/getExportComponentPath.js
@@ -1,0 +1,53 @@
+const t = require('@babel/types');
+const CodeError = require('../utils/CodeError');
+
+/**
+ * @param export default path
+ * @param program path
+ * @param source code
+ * @return should be replaced path
+ * */
+module.exports = function(defaultExportedPath, programPath, code) {
+  const exportedNodeType = defaultExportedPath.node.type;
+  if (['ClassExpression', 'ClassDeclaration', 'FunctionDeclaration',
+    'ArrowFunctionExpression', 'FunctionExpression' ].includes(exportedNodeType)) {
+    return defaultExportedPath;
+  }
+  if (exportedNodeType === 'CallExpression') {
+    let exportComponentPath = defaultExportedPath;
+    // Only first param is component
+    const componentNode = defaultExportedPath.get('arguments')[0].node;
+    const componentName = componentNode.name;
+    if (programPath.scope.hasBinding(componentName)) {
+      programPath.traverse({
+        VariableDeclarator(path) {
+          const target = getComponentPath(path, componentName);
+          if (target) exportComponentPath = target;
+        },
+        Declaration(path) {
+          const target = getComponentPath(path, componentName);
+          if (target) exportComponentPath = target;
+        }
+      });
+    } else {
+      throw new CodeError(code, componentNode, componentNode.loc, 'Exported component is undefined');
+    }
+    return exportComponentPath;
+  }
+};
+
+/**
+ * @param {NodePath} path - Declaration path
+ * @param {string} componentName - componentName
+ */
+function getComponentPath(path, componentName) {
+  const { node } = path;
+  if (node.id && t.isIdentifier(node.id, {
+    name: componentName
+  })) {
+    if (path.isFunctionDeclaration() || path.isClassDeclaration()) {
+      return path;
+    }
+    return path.get('init') || path;
+  }
+}

--- a/packages/jsx2qa-compiler/src/utils/getListItem.js
+++ b/packages/jsx2qa-compiler/src/utils/getListItem.js
@@ -1,0 +1,22 @@
+const traverse = require('./traverseNodePath');
+const t = require('@babel/types');
+
+module.exports = function getListItem(ast) {
+  let listItem = null;
+  if (t.isIdentifier(ast)) {
+    if (ast.__listItem) {
+      return ast;
+    }
+    return null;
+  }
+  // List item has been replaced in list module
+  traverse(ast, {
+    Identifier(path) {
+      const { node } = path;
+      if (node.__listItem) {
+        listItem = node;
+      }
+    }
+  });
+  return listItem;
+};

--- a/packages/jsx2qa-compiler/src/utils/getParentListPath.js
+++ b/packages/jsx2qa-compiler/src/utils/getParentListPath.js
@@ -1,0 +1,17 @@
+const genExpression = require('../codegen/genExpression');
+const quickAppConst = require('../const');
+/**
+ * Get parent list path
+ * @param {NodePath} path - current node path
+ * @param {object} adapter
+ * @return {NodePath} parent list path
+ */
+module.exports = function(path) {
+  return path.findParent(parentPath => {
+    if (parentPath.isJSXElement()) {
+      const attributes = parentPath.node.openingElement.attributes;
+      return attributes.some(attr => genExpression(attr.name) === quickAppConst.for);
+    }
+    return false;
+  });
+};

--- a/packages/jsx2qa-compiler/src/utils/getProgramPath.js
+++ b/packages/jsx2qa-compiler/src/utils/getProgramPath.js
@@ -1,0 +1,15 @@
+const traverse = require('./traverseNodePath');
+
+/**
+ * Get program path.
+ * @param ast
+ */
+module.exports = function getProgramPath(ast) {
+  let programPath = null;
+  traverse(ast, {
+    Program(path) {
+      programPath = path;
+    },
+  });
+  return programPath;
+};

--- a/packages/jsx2qa-compiler/src/utils/getReturnElementPath.js
+++ b/packages/jsx2qa-compiler/src/utils/getReturnElementPath.js
@@ -1,0 +1,20 @@
+const traverse = require('./traverseNodePath');
+
+/**
+ * Get reutrn statement element.
+ */
+function getReturnElementPath(ast) {
+  let result = null;
+
+  traverse(ast, {
+    ReturnStatement: {
+      exit(returnStatementPath) {
+        result = returnStatementPath;
+      }
+    },
+  });
+
+  return result;
+}
+
+module.exports = getReturnElementPath;

--- a/packages/jsx2qa-compiler/src/utils/handleList.js
+++ b/packages/jsx2qa-compiler/src/utils/handleList.js
@@ -23,7 +23,7 @@ const CodeError = require('./CodeError');
  * */
 module.exports = function(
   containerPath, valueNode, parentPath, forItem,
-  originalIndex, renamedIndex, properties, dynamicBinding, code, adapter) {
+  originalIndex, renamedIndex, properties, dynamicBinding, code) {
   const isAttr = parentPath.isJSXAttribute();
   const { node } = parentPath;
   // Check attribute name wheather is ref
@@ -57,7 +57,7 @@ module.exports = function(
         t.stringLiteral(createIncrement()), renamedIndexNode);
       if (targetPath.isJSXExpressionContainer()) {
         handleRef(loopFnBody,
-          handleRefAttr(targetPath.parentPath, targetPath.node.expression, propertyValue, adapter, renamedIndexNode)
+          handleRefAttr(targetPath.parentPath, targetPath.node.expression, propertyValue, renamedIndexNode)
         );
       } else {
         throw new CodeError(code, node, targetPath.loc, "Ref's type must be JSXExpressionContainer, like <View ref = { scrollRef }/>");

--- a/packages/jsx2qa-compiler/src/utils/handleListJSXExpressionContainer.js
+++ b/packages/jsx2qa-compiler/src/utils/handleListJSXExpressionContainer.js
@@ -1,0 +1,26 @@
+const t = require('@babel/types');
+const handleList = require('./handleList');
+const findIndex = require('./findIndex');
+
+/**
+ * @param {NodePath} path - jsx attribute path
+ * @param {Node} forItem - for item node
+ * @param {string} originalIndex - original for index name
+ * @param {string} renamedIndex - renamed index name
+ * @param {Array} properties - map return properties
+ * @param {object} dynamicBinding - dynamic style generator
+ */
+module.exports = function(path, ...args) {
+  const node = path.node;
+  // Out of the map
+  if (!(t.isCallExpression(node.expression) && t.isIdentifier(node.expression.callee.property, { name: 'map' }))) {
+    // Mark current loop
+    path.node.__index = args[2];
+    if (node.__originalExpression) {
+      const propertyIndex = findIndex(node.__properties, (property) => property === node.__originalExpression);
+      node.__properties.splice(propertyIndex, 1);
+      node.expression = node.__originalExpression;
+    }
+    handleList(null, node.expression, path, ...args);
+  }
+};

--- a/packages/jsx2qa-compiler/src/utils/handleListProps.js
+++ b/packages/jsx2qa-compiler/src/utils/handleListProps.js
@@ -1,0 +1,34 @@
+const t = require('@babel/types');
+const { isEventHandlerAttr, BINDING_REG } = require('./checkAttr');
+const handleList = require('./handleList');
+const genExpression = require('../codegen/genExpression');
+const findIndex = require('./findIndex');
+
+/**
+ * @param {NodePath} path - jsx attribute path
+ * @param {Node} forItem - for item node
+ * @param {string} originalIndex - original for index name
+ * @param {string} renamedIndex - renamed index name
+ * @param {Array} properties - map return properties
+ * @param {object} dynamicBinding - dynamic style generator
+ * @param {string} code - original code
+ * @param {object} adapter - adapter
+ * */
+module.exports = function(...args) {
+  const path = args[0];
+  const { node } = path;
+  const attrName = node.name.name;
+  if (attrName !== 'style' && attrName !== 'x-for' && !isEventHandlerAttr(attrName)) {
+    if (t.isJSXExpressionContainer(node.value)) {
+      handleList(null, node.value.expression, ...args);
+    } else if (t.isStringLiteral(node.value)) {
+      // override prev level list value
+      if (BINDING_REG.test(node.value.value) && node.value.__originalExpression) {
+        const propertyIndex = findIndex(node.value.__properties, (property) => property === node.value.__originalExpression);
+        node.value.__properties.splice(propertyIndex, 1);
+        node.value = t.jsxExpressionContainer(node.value.__originalExpression);
+        handleList(null, node.value.expression, ...args);
+      }
+    }
+  }
+};

--- a/packages/jsx2qa-compiler/src/utils/handleListStyle.js
+++ b/packages/jsx2qa-compiler/src/utils/handleListStyle.js
@@ -1,0 +1,39 @@
+const t = require('@babel/types');
+const handleList = require('./handleList');
+const CodeError = require('./CodeError');
+const findIndex = require('./findIndex');
+
+/**
+ * @param {NodePath} mapFnBodyPath - map function path
+ * @param {NodePath} path - jsx attribute path
+ * @param {Node} forItem - for item node
+ * @param {string} originalIndex - original for index name
+ * @param {string} renamedIndex - renamed index name
+ * @param {Array} properties - map return properties
+ * @param {object} dynamicStyle - dynamic style generator
+ * @param {string} code - original code
+ * @return {boolean} useCreateStyle
+ * */
+module.exports = function(mapFnBodyPath, ...args) {
+  let useCreateStyle = false;
+  const path = args[0];
+  const code = args[6];
+  const { node } = path;
+  if (t.isJSXIdentifier(node.name, {
+    name: 'style'
+  })) {
+    if (!t.isJSXExpressionContainer(node.value)) {
+      if (node.value.__originalExpression) {
+        const propertyIndex = findIndex(node.value.__properties, (property) => property === node.value.__originalExpression);
+        node.value.__properties.splice(propertyIndex, 1);
+        node.value = t.jsxExpressionContainer(node.value.__originalExpression);
+      } else {
+        throw new CodeError(code, node.value, node.loc,
+          "Style property's value should be JSXExpressionContainer, like <View style={styles.container}></View>.");
+      }
+    }
+    useCreateStyle = true;
+    handleList(mapFnBodyPath, t.callExpression(t.identifier('__create_style__'), [node.value.expression]), ...args);
+  }
+  return useCreateStyle;
+};

--- a/packages/jsx2qa-compiler/src/utils/handleParentListReturn.js
+++ b/packages/jsx2qa-compiler/src/utils/handleParentListReturn.js
@@ -1,0 +1,115 @@
+const t = require('@babel/types');
+const getListItem = require('./getListItem');
+const CodeError = require('./CodeError');
+const genExpression = require('../codegen/genExpression');
+const handleValidIdentifier = require('./handleValidIdentifier');
+const traverse = require('./traverseNodePath');
+
+/**
+ * Assign an new object to item
+ * item: { ...item, info: item.info.map(i => {})
+ * @param {Expression} mapExpression map function expression
+ * @param {Node} forNode
+ * @params {object} parentList parent list info
+ * @return {Array} [forNode, parentList]
+ * */
+module.exports = function(mapCallExpression, forNode, parentList, dynamicValue, code) {
+  if (!parentList) return mapCallExpression;
+  const parentListItemNode = getListItem(forNode);
+  const { loopFnBody } = parentList;
+  const loopFnBodyLength = loopFnBody.body.length;
+  const properties = loopFnBody.body[loopFnBodyLength - 1].argument.properties;
+  let forItem;
+  const parentListItem = parentList.args[0].name;
+  const propertyRelatedMapFn = getProperty(forNode, properties);
+  if (parentListItemNode && (isItemAsProperty(forNode, parentListItem) || propertyRelatedMapFn) ) {
+    if (propertyRelatedMapFn) {
+      propertyRelatedMapFn.value = mapCallExpression;
+    } else {
+      forItem = properties.find(({ key, value }) => key.name === parentListItem);
+
+      if (t.isIdentifier(forNode)) {
+        forItem.value = mapCallExpression;
+      }
+
+      if (t.isMemberExpression(forNode) || t.isCallExpression(forNode)) {
+        switch (forItem.value.type) {
+          case 'Identifier':
+            if (t.isIdentifier(forNode.object)) {
+              forItem.value = t.objectExpression([
+                t.spreadElement(forItem.value),
+                t.objectProperty(forNode.property, mapCallExpression)
+              ]);
+            } else if (t.isCallExpression(forNode)) {
+              // handle list.filter().map()
+              if (!t.isIdentifier(forNode.callee.object)) {
+                throw new CodeError(code, forNode, forNode.loc, "Currently doesn't support render list by multilevel object, like item.info.list.");
+              }
+              forItem.value = t.objectExpression([
+                t.spreadElement(forItem.value),
+                t.objectProperty(forNode.property, mapCallExpression)
+              ]);
+              forNode = parentListItemNode;
+            } else {
+              throw new CodeError(code, forNode, forNode.loc, "Currently doesn't support render list by multilevel object, like item.info.list.");
+            }
+            break;
+          case 'ObjectExpression':
+            forItem.value.properties.push(
+              t.objectProperty(forNode.property, mapCallExpression)
+            );
+            break;
+        }
+      }
+    }
+  } else {
+    const name = dynamicValue.add({ expression: forNode });
+    forNode = t.identifier(name);
+    // Mark as list item
+    forNode.__listItem = {
+      item: parentListItem
+    };
+    forItem = t.objectProperty(t.identifier(name), mapCallExpression);
+    properties.push(forItem);
+  }
+
+  return forNode;
+};
+
+/**
+ * Check item wheather is property, like item.a.map() or item().map() or item[xxx].map
+ * @param {Node} forNode looped node
+ * @param {string} item parent list item
+ */
+function isItemAsProperty(forNode, item) {
+  const code = genExpression(forNode);
+  // ^item(\.|\[|\())
+  const regExp = new RegExp('^' + item + '(\\.|\\(|\\[)');
+  return regExp.test(code) || code === item;
+}
+
+/**
+ * Get property which is from parent list map funtion
+ * @param {Node} forNode looped node
+ * @param {object} properties parent list return properties
+ */
+function getProperty(forNode, properties) {
+  let propertyRelatedMapFn;
+  if (t.isIdentifier(forNode)) {
+    propertyRelatedMapFn = getPropertyRelatedMapFn(forNode, properties);
+  } else {
+    traverse(forNode, {
+      Identifier(innerPath) {
+        handleValidIdentifier(innerPath, () => {
+          propertyRelatedMapFn = getPropertyRelatedMapFn(innerPath.node, properties);
+        });
+        if (propertyRelatedMapFn) return;
+      }
+    });
+  }
+  return propertyRelatedMapFn;
+}
+
+function getPropertyRelatedMapFn(identier, properties) {
+  return properties.find(({key}) => key.name === identier.name && key.__isFromMapFn);
+}

--- a/packages/jsx2qa-compiler/src/utils/handleRefAttr.js
+++ b/packages/jsx2qa-compiler/src/utils/handleRefAttr.js
@@ -1,0 +1,52 @@
+const t = require('@babel/types');
+const isNativeComponent = require('./isNativeComponent');
+const generateId = require('./generateId');
+const createBinding = require('./createBinding');
+
+/**
+ * @param {NodePath} attrPath - ref attribute path
+ * @param {Node} childExpression - attr value's child expression
+ * @param {Node} refName - ref name
+ * @param {object} adapter - adapter
+ * @param {Node} loopIndex - list index
+ * @return {object} refInfo - ref information
+ */
+module.exports = function(attrPath, childExpression, refName, loopIndex) {
+  const { node } = attrPath;
+  const refInfo = {
+    name: refName,
+    method: childExpression,
+    type: t.stringLiteral('native')
+  };
+  const attributes = attrPath.parent.attributes;
+  const componentNameNode = attrPath.parent.name;
+  const isNative = isNativeComponent(attrPath);
+  // Get all attributes
+  let idAttr = attributes.find(attr =>
+    t.isJSXIdentifier(attr.name, { name: 'id' })
+  );
+  refInfo.id = idAttr && idAttr.value;
+  if (!idAttr) {
+    // Insert progressive increase id
+    const id = generateId();
+    if (loopIndex) {
+      // id="id_0{{index}}"
+      idAttr = t.jsxAttribute(
+        t.jsxIdentifier('id'),
+        t.stringLiteral(id + createBinding(loopIndex.name))
+      );
+      // id: "id_0" + index
+      refInfo.id = t.binaryExpression('+', t.stringLiteral(id), loopIndex);
+    } else {
+      idAttr = t.jsxAttribute(
+        t.jsxIdentifier('id'),
+        t.stringLiteral(id)
+      );
+      refInfo.id = idAttr.value;
+    }
+    attributes.push(idAttr);
+  }
+
+  node.__transformed = true;
+  return refInfo;
+};

--- a/packages/jsx2qa-compiler/src/utils/handleValidIdentifier.js
+++ b/packages/jsx2qa-compiler/src/utils/handleValidIdentifier.js
@@ -1,0 +1,23 @@
+/**
+ * If parent expression is a.b,
+ * b is an invaild identifier, because it's the value of the MemberExpression
+ */
+module.exports = function(identifierPath, callback) {
+  switch (identifierPath.parent.type) {
+    case 'ObjectProperty':
+      if (identifierPath.parent.key !== identifierPath.node) {
+        callback();
+      }
+      break;
+    case 'MemberExpression':
+      // For list[index]
+      if (identifierPath.parent.computed) {
+        callback();
+      } else if (identifierPath.parent.property !== identifierPath.node) {
+        callback();
+      }
+      break;
+    default:
+      callback();
+  }
+};

--- a/packages/jsx2qa-compiler/src/utils/invokeModules.js
+++ b/packages/jsx2qa-compiler/src/utils/invokeModules.js
@@ -1,0 +1,15 @@
+/**
+ * Invoke modules.
+ * @param modules
+ * @param key
+ * @param args Remain arguments.
+ */
+module.exports = function invokeModules(modules, key, ...args) {
+  if (Array.isArray(modules)) {
+    for (let i = 0, l = modules.length; i < l; i ++) {
+      if (typeof modules[i][key] === 'function') {
+        modules[i][key].apply(modules[i], args);
+      }
+    }
+  }
+};

--- a/packages/jsx2qa-compiler/src/utils/isClassComponent.js
+++ b/packages/jsx2qa-compiler/src/utils/isClassComponent.js
@@ -1,0 +1,47 @@
+const t = require('@babel/types');
+
+const RAX_PACKAGE = 'rax';
+const RAX_COMPONENT = 'Component';
+
+/**
+ * Judge a NodePath is a Rax JSX class declaration.
+ * @param path {NodePath}
+ * eg:
+ *  1. class xxx extends *.Component {}
+ *  2. class xxx extends Component {}
+ */
+module.exports = function isClassComponent(path) {
+  if (!path) return false;
+
+  const { node, scope } = path;
+
+  if (!node) return false;
+
+  if (t.isIdentifier(node)) {
+    const binding = scope.getBinding(node.name);
+    if (t.isVariableDeclarator(binding.path.node)) {
+      return isClassComponent(binding.path.get('init'));
+    } else {
+      return isClassComponent(binding.path);
+    }
+  } else {
+    if (t.isMemberExpression(node.superClass)) {
+      // Case 1
+      // Step 1: judge property name is Component.
+      if (!t.isIdentifier(node.superClass.property, { name: RAX_COMPONENT })) return false;
+      // Step2: find `object` is import from 'rax'.
+      const importModuleBinding = scope.getBinding(node.superClass.object.name);
+      if (importModuleBinding && importModuleBinding.kind === 'module') {
+        const bindingPath = importModuleBinding.path.parentPath;
+        if (t.isImportDeclaration(bindingPath.node)) {
+          return t.isStringLiteral(bindingPath.node.source, { value: RAX_PACKAGE });
+        }
+      }
+    } else if (t.isIdentifier(node.superClass)) {
+      // Case 2
+      return path.isClassDeclaration() || path.isClassExpression();
+    }
+
+    return false;
+  }
+};

--- a/packages/jsx2qa-compiler/src/utils/isFunctionComponent.js
+++ b/packages/jsx2qa-compiler/src/utils/isFunctionComponent.js
@@ -1,0 +1,31 @@
+const t = require('@babel/types');
+
+/**
+ * Judge a NodePath is a Rax JSX function component.
+ * @param path {NodePath}
+ * eg:
+ *  1. function foo(props) {
+ *    return (<view></view>);
+ *  }
+ *  2. const foo = function(props) {
+ *    return  (view></view>)
+ *  }
+ *  3. const foo = (props) => (<view></view>)
+ */
+module.exports = function isFunctionComponent(path) {
+  if (!path) return false;
+
+  const { node, scope } = path;
+  if (t.isIdentifier(node)) {
+    const binding = scope.getBinding(node.name);
+    if (t.isVariableDeclarator(binding.path.node)) {
+      return isFunctionComponent(binding.path.get('init'));
+    } else {
+      return isFunctionComponent(binding.path);
+    }
+  } else if (node == null) {
+    return false;
+  } else {
+    return t.isFunction(node);
+  }
+};

--- a/packages/jsx2qa-compiler/src/utils/isNativeComponent.js
+++ b/packages/jsx2qa-compiler/src/utils/isNativeComponent.js
@@ -1,0 +1,8 @@
+const getCompiledComponents = require('../getCompiledComponents');
+
+module.exports = function isNativeComponent(path) {
+  const {
+    node: { name: tagName }
+  } = path.parentPath.get('name');
+  return !!getCompiledComponents[tagName];
+};

--- a/packages/jsx2qa-compiler/src/utils/moduleResolve.js
+++ b/packages/jsx2qa-compiler/src/utils/moduleResolve.js
@@ -1,0 +1,123 @@
+const { sep, join, dirname } = require('path');
+const { existsSync, statSync, readFileSync } = require('fs-extra');
+const { normalizeLocalFilePath } = require('../utils/pathHelper');
+
+function startsWith(prevString, nextString) {
+  return prevString.indexOf(nextString) === 0;
+}
+
+function startsWithArr(prevString, nextStringArr = []) {
+  return nextStringArr.some(nextString => startsWith(prevString, nextString));
+}
+
+function loadAsFile(module, extension) {
+  if (existsSync(module + extension) && statSync(module + extension).isFile()) {
+    return module + extension;
+  }
+
+  if (existsSync(module) && statSync(module).isFile()) {
+    return module;
+  }
+}
+
+function loadAsDirectory(module, extension) {
+  if (!existsSync(module)) {
+    return;
+  }
+
+  let stat = statSync(module);
+
+  if (stat.isDirectory()) {
+    const packagePath = join(module, 'package.json');
+    const indexFile = join(module, 'index' + extension);
+
+    if (existsSync(packagePath) && statSync(packagePath).isFile()) {
+      let pkg = JSON.parse(readFileSync(packagePath, 'utf-8'));
+      let main = join(module, pkg.main || 'index' + extension);
+      return loadAsFile(main) || loadAsDirectory(main);
+    } else if (existsSync(indexFile) && statSync(indexFile).isFile()) {
+      return indexFile;
+    }
+  } else if (stat.isFile()) {
+    return loadAsFile(module, extension);
+  }
+}
+
+function nodeModulesPaths(start) {
+  let parts = start.split(sep);
+
+  if (!parts[parts.length - 1]) {
+    parts.pop();
+  }
+
+  let i = parts.length - 1;
+  let dirs = [];
+  while (i >= 0) {
+    if ('node_modules' === parts[i]) {
+      i -= 1;
+      continue;
+    }
+    let dir = join(parts.slice(0, i + 1).join(sep) || sep, 'node_modules');
+    dirs.push(dir);
+    i -= 1;
+  }
+  return dirs;
+}
+
+function loadNpmModules(module, start, extension) {
+  let target;
+  let paths = nodeModulesPaths(start);
+
+  for (let i = 0; i < paths.length; ++i) {
+    let dependencyPath = join(paths[i], module);
+    target = loadAsFile(dependencyPath, extension) || loadAsDirectory(dependencyPath, extension);
+
+    if (target) {
+      break;
+    }
+  }
+  return target;
+}
+
+/**
+ * Resolve node path.
+ * @param {string} script
+ * @param {string} dependency
+ * @param {string} extension
+ * @return {*}
+ */
+function moduleResolve(script, dependency, extension = '.js') {
+  let target;
+  const normalizedScript = normalizeLocalFilePath(script);
+  const normalizedDependency = normalizeLocalFilePath(dependency);
+  if (startsWithArr(normalizedDependency, [sep, `.${sep}`, `..${sep}`])) {
+    let dependencyPath = join(dirname(normalizedScript), normalizedDependency);
+    target = loadAsFile(dependencyPath, extension) || loadAsDirectory(dependencyPath, extension);
+  } else {
+    target = loadNpmModules(normalizedDependency, dirname(normalizedScript), extension);
+  }
+  return target;
+};
+
+/**
+ *
+ *
+ * @param {string} script
+ * @param {string} dependency
+ * @param {array<string>} [extensions=[]]
+ * @returns
+ */
+function multipleModuleResolve(script, dependency, extensions = []) {
+  for (let extension of extensions) {
+    const target = moduleResolve(script, dependency, extension);
+    if (target) {
+      return target;
+    }
+  }
+  return null;
+}
+
+module.exports = {
+  moduleResolve,
+  multipleModuleResolve
+};

--- a/packages/jsx2qa-compiler/src/utils/pathHelper.js
+++ b/packages/jsx2qa-compiler/src/utils/pathHelper.js
@@ -1,0 +1,46 @@
+const { sep } = require('path');
+
+function getNpmName(value) {
+  const isScopedNpm = /^_?@/.test(value);
+  return value.split(sep).slice(0, isScopedNpm ? 2 : 1).join(sep);
+}
+
+/**
+ * For that alipay build folder can not contain `@`, escape to `_`.
+ */
+function normalizeFileName(filename) {
+  return filename.replace(/@/g, '_');
+}
+
+/**
+ * Add ./ at the start of filepath
+ * @param {string} filepath
+ * @returns {string}
+ */
+function addRelativePathPrefix(filepath) {
+  return filepath[0] !== '.' ? `./${filepath}` : filepath;
+}
+
+/**
+ * Use '/' as path sep regardless of OS when outputting the path to code
+ * @param {string} filepath
+ */
+function normalizeOutputFilePath(filepath) {
+  return filepath.replace(/\\/g, '/');
+}
+
+/**
+ * use '/'(Linux/Unix) or '\'(Windows) as path sep in local file system
+ * @param {string} filepath
+ */
+function normalizeLocalFilePath(filepath) {
+  return filepath.replace(/\\|\//g, sep);
+}
+
+module.exports = {
+  getNpmName,
+  normalizeFileName,
+  addRelativePathPrefix,
+  normalizeOutputFilePath,
+  normalizeLocalFilePath
+};

--- a/packages/jsx2qa-compiler/src/utils/replaceComponentTagName.js
+++ b/packages/jsx2qa-compiler/src/utils/replaceComponentTagName.js
@@ -1,0 +1,7 @@
+module.exports = function replaceComponentTagName(path, tagNameNode) {
+  const { node, parent } = path;
+  node.name = tagNameNode;
+  if (parent.closingElement) {
+    parent.closingElement.name = tagNameNode;
+  }
+};

--- a/packages/jsx2qa-compiler/src/utils/traverseNodePath.js
+++ b/packages/jsx2qa-compiler/src/utils/traverseNodePath.js
@@ -1,0 +1,26 @@
+const { default: traverse, NodePath } = require('@babel/traverse');
+const t = require('@babel/types');
+
+/**
+ * Traverse a node path.
+ * @param nodeOrPath
+ * @param visitor
+ */
+module.exports = function traverseNodePath(nodeOrPath, visitor) {
+  if (nodeOrPath == null) return;
+
+  if (nodeOrPath instanceof NodePath) {
+    nodeOrPath.traverse(visitor);
+  } else if (t.isFile(nodeOrPath)) {
+    traverse(nodeOrPath, visitor);
+  } else if (t.isStatement(nodeOrPath)) {
+    // Only can traverse file path.
+    const file = t.file(t.program([nodeOrPath]));
+    traverse(file, visitor);
+  } else {
+    // Expression should be wrapped in expression statement.
+    // Only can traverse file path.
+    const file = t.file(t.program([t.expressionStatement(nodeOrPath)]));
+    traverse(file, visitor);
+  }
+};


### PR DESCRIPTION
### 背景
目前由于小程序 dsl 和快应用 dsl 的差异性比较大，快应用的编译器单独拉出来作为 jsx-compiler 的依赖使用，但是由于快应用编译器的主体是从 jsx-compiler 中 copy 出去，架构设计上不满足直接合入 master 的标准，需要重新设计 jsx-compiler 的架构，来兼容快应用。

### 结论
由于业务先行，以及投入产出比的问题，所以目前快应用的支持只通过 beta 版本来支持，后续重构完再合入 master。