### PR TITLE
[RELEASE] jsx2mp @0608

### DIFF
--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/src/adapter.js
+++ b/packages/jsx-compiler/src/adapter.js
@@ -32,7 +32,7 @@ const parserAdapters = {
     for: 'a:for',
     forItem: 'a:for-item',
     forIndex: 'a:for-index',
-    key: 'a:key',
+    key: 'key',
 
     view: {
       ...componentCommonProps.ali,

--- a/packages/jsx-compiler/src/modules/__tests__/attribute.js
+++ b/packages/jsx-compiler/src/modules/__tests__/attribute.js
@@ -10,7 +10,7 @@ describe('Transform JSX Attribute', () => {
     const code = '<View key={1}>test</View>';
     const ast = parseExpression(code);
     _transformAttribute(ast, code, adapter);
-    expect(genCode(ast).code).toEqual('<View a:key={1}>test</View>');
+    expect(genCode(ast).code).toEqual('<View key={1}>test</View>');
   });
   it('should transform attribute name is className', () => {
     const code = '<rax-view className="box">test</rax-view>';

--- a/packages/jsx2mp-runtime/package.json
+++ b/packages/jsx2mp-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-runtime",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Runtime for jsx2mp.",
   "miniprogram": {
     "ali": "dist/jsx2mp-runtime.ali.esm.js",

--- a/packages/jsx2mp-runtime/src/adapter/getComponentBaseConfig.js
+++ b/packages/jsx2mp-runtime/src/adapter/getComponentBaseConfig.js
@@ -20,7 +20,7 @@ export default function() {
         outerProps: null
       },
       options: {
-        addGlobalClass: true,
+        styleIsolation: 'shared',
         multipleSlots: true
       }
     };

--- a/packages/jsx2mp-runtime/src/bridge.js
+++ b/packages/jsx2mp-runtime/src/bridge.js
@@ -66,7 +66,8 @@ function getPageCycles(Klass) {
       this.instance._mountComponent();
     },
     unmount() {
-      this.instance._unmountComponent();
+      // Ensure that instance exists
+      this.instance && this.instance._unmountComponent();
     },
     show() {
       if (this.instance && this.instance.__mounted) {
@@ -121,7 +122,7 @@ function getComponentCycles(Klass) {
       }
     },
     unmount: function() {
-      this.instance._unmountComponent();
+      this.instance && this.instance._unmountComponent();
     }
   });
 }
@@ -196,7 +197,7 @@ function createProxyMethods(events) {
               proxyedArgs[index] = dataset[key];
 
               if (!contextInfo.changed && idx !== index) {
-              // event does not exist on dataset
+                // event does not exist on dataset
                 proxyedArgs[idx] = event;
               }
             }
@@ -207,7 +208,7 @@ function createProxyMethods(events) {
            * when onClick={handleClick.bind(this, 1)}
            * or onClick={handleClick}
            */
-          if (contextInfo.changed || !proxyedArgs.length) {
+          if (contextInfo.changed || !proxyedArgs.includes(event)) {
             proxyedArgs.push(event);
           }
         } else {

--- a/packages/jsx2mp-runtime/src/component.js
+++ b/packages/jsx2mp-runtime/src/component.js
@@ -234,7 +234,7 @@ export default class Component {
     // Step1: propTypes check, now skipped.
     // Step2: make props to prevProps, and trigger willReceiveProps
     const nextProps = this.nextProps || this.props; // actually this is nextProps
-    const prevProps = this.props = this.prevProps || this.props;
+    const prevProps = this.prevProps || this.props;
 
     if (!shallowEqual(prevProps, nextProps)) {
       this._trigger(COMPONENT_WILL_RECEIVE_PROPS, nextProps);
@@ -277,6 +277,8 @@ export default class Component {
       this.__forceUpdate = false;
       this._trigger(RENDER);
       this._trigger(COMPONENT_DID_UPDATE, prevProps, prevState);
+      // Reset __shouldUpdate
+      this.__shouldUpdate = false;
     }
   }
 
@@ -369,20 +371,15 @@ export default class Component {
       // Use setData update
       const normalData = {};
       for (let key in data) {
-        if (
-          Array.isArray(data[key]) &&
-          diffArray(currentData[key], data[key])
-        ) {
+        if (isArray(data[key]) && isArray(currentData[key]) && isAppendArray(currentData[key], data[key])) {
           arrayData[key] = [currentData[key].length, 0].concat(
             data[key].slice(currentData[key].length)
           );
-        } else {
-          if (diffData(currentData[key], data[key])) {
-            if (isPlainObject(data[key])) {
-              normalData[key] = Object.assign({}, currentData[key], data[key]);
-            } else {
-              normalData[key] = data[key] === undefined ? null : data[key]; // Make undefined value compatible with Alibaba MiniApp incase that data is not sync in render and worker thread
-            }
+        } else if (isDifferentData(currentData[key], data[key])) {
+          if (isPlainObject(data[key])) {
+            normalData[key] = Object.assign({}, currentData[key], data[key]);
+          } else {
+            normalData[key] = data[key] === undefined ? null : data[key]; // Make undefined value compatible with Alibaba MiniApp incase that data is not sync in render and worker thread
           }
         }
       }
@@ -406,7 +403,7 @@ export default class Component {
           }
           if (!(key in this._internal)) {
             this._internal.$set(key, data[key]);
-          } else if (diffData(this._internal, data)) {
+          } else if (isDifferentData(this._internal, data)) {
             this._internal[key] = data[key];
           }
         }
@@ -415,7 +412,7 @@ export default class Component {
     } else {
       const normalData = {};
       for (let key in data) {
-        if (diffData(this._internal.data[key], data[key])) {
+        if (isDifferentData(this._internal.data[key], data[key])) {
           normalData[key] = data[key];
         }
       }
@@ -461,20 +458,22 @@ function triggerCallbacks(callbacks) {
   }
 }
 
-function diffArray(prev, next) {
-  if (!isArray(prev)) return false;
+function isAppendArray(prev, next) {
   // Only concern about list append case
   if (next.length === 0) return false;
   if (prev.length === 0) return true;
   // When item's type is object, they have differrent reference, so should use shallowEqual
-  return next.slice(0, prev.length).every((val, index) => shallowEqual(prev[index], val));
+  return next.length > prev.length && next.slice(0, prev.length).every((val, index) => shallowEqual(prev[index], val));
 }
 
-function diffData(prevData, nextData) {
+function isDifferentData(prevData, nextData) {
   const prevType = typeof prevData;
   const nextType = typeof nextData;
   if (prevType !== nextType) return true;
   if (prevType === 'object' && !isNull(prevData) && !isNull(nextData)) {
+    if (isArray(prevData) && isArray(nextData) && prevData.length === nextData.length) {
+      return nextData.some((val, index) => !shallowEqual(prevData[index], val));
+    }
     return !shallowEqual(prevData, nextData);
   } else {
     return prevData !== nextData;

--- a/packages/jsx2mp-runtime/src/component.js
+++ b/packages/jsx2mp-runtime/src/component.js
@@ -381,7 +381,7 @@ export default class Component {
             if (isPlainObject(data[key])) {
               normalData[key] = Object.assign({}, currentData[key], data[key]);
             } else {
-              normalData[key] = data[key];
+              normalData[key] = data[key] === undefined ? null : data[key]; // Make undefined value compatible with Alibaba MiniApp incase that data is not sync in render and worker thread
             }
           }
         }
@@ -422,7 +422,10 @@ export default class Component {
       if (!isEmptyObj(normalData)) {
         setDataTask.push((callback) => {
           $ready = normalData.$ready;
-          this._internal.setData(normalData, callback);
+          this._internal.setData(normalData, () => {
+            Object.assign(this._internal.data, normalData); // In Wechat MiniProgram, `this._internal.data` refers to its old val here, so it needs to be merged manually
+            callback();
+          });
         });
       }
     }


### PR DESCRIPTION
- 修复支付宝、微信小程序各自数据更新时潜在的 bug
- 修复支付宝小程序列表 key 值编译成 a:key 不生效的问题
- 设置微信端自定义组件样式和页面样式互相影响，表现与支付宝小程序对齐
- 修复微信端 rax-view/rax-text 上点击事件失效的 bug
- 页面 unmount 执行销毁实例方法时添加兜底
- 修复绑定事件传递 event 对象时，出现漏传的问题