### PR TITLE
fix(jsx2mp): style isolated in component in wechat

### DIFF
--- a/packages/jsx2mp-runtime/src/adapter/getComponentBaseConfig.js
+++ b/packages/jsx2mp-runtime/src/adapter/getComponentBaseConfig.js
@@ -20,7 +20,7 @@ export default function() {
         outerProps: null
       },
       options: {
-        addGlobalClass: true,
+        styleIsolation: 'shared',
         multipleSlots: true
       }
     };


### PR DESCRIPTION
- 设置微信端自定义组件样式和页面样式互相影响，表现与支付宝小程序对齐