### PR TITLE
feat: support for contextType

### DIFF
--- a/packages/rax/src/__tests__/createContext.js
+++ b/packages/rax/src/__tests__/createContext.js
@@ -608,4 +608,30 @@ describe('createContext', () => {
     render(<App />, container);
     expect(container.childNodes[1].childNodes[0].data).toEqual('light');
   });
+
+  it('should get context with contextType', function() {
+    let container = createNodeElement('div');
+    const MyContext = createContext();
+
+    class MyComponent extends Component {
+      static contextType = MyContext;
+
+      render() {
+        return <div>{this.context.foo}</div>;
+      }
+    }
+
+    class Parent extends Component {
+      render() {
+        return (
+          <MyContext.Provider value={{foo: 'bar'}}>
+            <MyComponent />
+          </MyContext.Provider>
+        );
+      }
+    }
+
+    render(<Parent />, container);
+    expect(container.childNodes[0].childNodes[0].data).toBe('bar');
+  });
 });

--- a/packages/rax/src/createContext.js
+++ b/packages/rax/src/createContext.js
@@ -21,8 +21,7 @@ export default function createContext(defaultValue) {
     __off(handler) {
       this.__handlers = this.__handlers.filter(h => h !== handler);
     }
-    // Like getChildContext but called in SSR
-    _getChildContext() {
+    getChildContext() {
       return {
         [contextID]: this
       };

--- a/packages/rax/src/vdom/__tests__/context.js
+++ b/packages/rax/src/vdom/__tests__/context.js
@@ -7,7 +7,6 @@ import Host from '../host';
 import render from '../../render';
 import { flush } from '../scheduler';
 import ServerDriver from 'driver-server';
-import createContext from '../../createContext';
 
 describe('Context', function() {
   function createNodeElement(tagName) {
@@ -29,32 +28,6 @@ describe('Context', function() {
   afterEach(function() {
     Host.driver = null;
     jest.useRealTimers();
-  });
-
-  it('should get context with contextType', function() {
-    let container = createNodeElement('div');
-    const MyContext = createContext();
-
-    class MyComponent extends Component {
-      static contextType = MyContext;
-
-      render() {
-        return <div>{this.context.foo}</div>;
-      }
-    }
-
-    class Parent extends Component {
-      render() {
-        return (
-          <MyContext.Provider value={{foo: 'bar'}}>
-            <MyComponent />
-          </MyContext.Provider>
-        );
-      }
-    }
-
-    render(<Parent />, container);
-    expect(container.childNodes[0].childNodes[0].data).toBe('bar');
   });
 
   it('should pass context when rendering subtree elsewhere', function() {

--- a/packages/rax/src/vdom/__tests__/context.js
+++ b/packages/rax/src/vdom/__tests__/context.js
@@ -7,6 +7,7 @@ import Host from '../host';
 import render from '../../render';
 import { flush } from '../scheduler';
 import ServerDriver from 'driver-server';
+import createContext from '../../createContext';
 
 describe('Context', function() {
   function createNodeElement(tagName) {
@@ -28,6 +29,32 @@ describe('Context', function() {
   afterEach(function() {
     Host.driver = null;
     jest.useRealTimers();
+  });
+
+  it('should get context with contextType', function() {
+    let container = createNodeElement('div');
+    const MyContext = createContext();
+
+    class MyComponent extends Component {
+      static contextType = MyContext;
+
+      render() {
+        return <div>{this.context.foo}</div>;
+      }
+    }
+
+    class Parent extends Component {
+      render() {
+        return (
+          <MyContext.Provider value={{foo: 'bar'}}>
+            <MyComponent />
+          </MyContext.Provider>
+        );
+      }
+    }
+
+    render(<Parent />, container);
+    expect(container.childNodes[0].childNodes[0].data).toBe('bar');
   });
 
   it('should pass context when rendering subtree elsewhere', function() {

--- a/packages/rax/src/vdom/composite.js
+++ b/packages/rax/src/vdom/composite.js
@@ -221,6 +221,15 @@ class CompositeComponent extends BaseComponent {
       }
     }
 
+    if (Component.contextType) {
+      const contextID = Component.contextType._contextID;
+      if (context[contextID]) {
+        return context[contextID].getValue();
+      } else {
+        return context._defaultValue;
+      }
+    }
+
     return maskedContext;
   }
 


### PR DESCRIPTION
Support for `Assign a contextType to read the current theme context` 

https://reactjs.org/docs/context.html

```jsx
// Context lets us pass a value deep into the component tree
// without explicitly threading it through every component.
// Create a context for the current theme (with "light" as the default).
const ThemeContext = createContext('light');

class App extends Component {
  render() {
    // Use a Provider to pass the current theme to the tree below.
    // Any component can read it, no matter how deep it is.
    // In this example, we're passing "dark" as the current value.
    return (
      <ThemeContext.Provider value="dark">
        <Toolbar />
      </ThemeContext.Provider>
    );
  }
}

// A component in the middle doesn't have to
// pass the theme down explicitly anymore.
function Toolbar() {
  return (
    <div>
      <ThemedButton />
    </div>
  );
}

class ThemedButton extends Component {
  // Assign a contextType to read the current theme context.
  // React will find the closest theme Provider above and use its value.
  // In this example, the current theme is "dark".
  static contextType = ThemeContext;
  render() {
    return <Button theme={this.context} />;
  }
}
```