### PR TITLE
Fix failure to set attribute by DOM properties

### DIFF
--- a/packages/driver-dom/package.json
+++ b/packages/driver-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "driver-dom",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "DOM driver for Rax",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/driver-dom/src/__tests__/attributes.js
+++ b/packages/driver-dom/src/__tests__/attributes.js
@@ -53,7 +53,7 @@ describe('attributes', () => {
       });
 
       let node = container.children[0];
-      expect(node.getAttribute('hidden')).toBe('true');
+      expect(node.getAttribute('hidden')).toBe('');
     });
 
     it('render boolean prop with false value', () => {
@@ -64,7 +64,7 @@ describe('attributes', () => {
       });
 
       let node = container.children[0];
-      expect(node.getAttribute('hidden')).toBe('false');
+      expect(node.getAttribute('hidden')).toBe(null);
     });
 
     it('render boolean prop with self value', () => {
@@ -75,7 +75,7 @@ describe('attributes', () => {
       });
 
       let node = container.children[0];
-      expect(node.getAttribute('hidden')).toBe('hidden');
+      expect(node.getAttribute('hidden')).toBe('');
     });
   });
 

--- a/packages/driver-dom/src/__tests__/attributes.js
+++ b/packages/driver-dom/src/__tests__/attributes.js
@@ -1,0 +1,105 @@
+import { createElement, render } from 'rax';
+import * as DriverDOM from '../';
+
+describe('attributes', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    (document.body || document.documentElement).appendChild(container);
+  });
+
+  describe('string properties', () => {
+    it('render string prop with simple numbers', () => {
+      render((
+        <div width={30} />
+      ), container, {
+        driver: DriverDOM
+      });
+
+      let node = container.children[0];
+      expect(node.getAttribute('width')).toBe('30');
+    });
+
+    it('render string prop with true value', () => {
+      render((
+        <a href={true} />
+      ), container, {
+        driver: DriverDOM
+      });
+
+      let node = container.children[0];
+      expect(node.getAttribute('href')).toBe('true');
+    });
+
+    it('render string prop with object value', () => {
+      render((
+        <input type="checkbox" data={{foo: 'bar'}} />
+      ), container, {
+        driver: DriverDOM
+      });
+
+      let node = container.children[0];
+      expect(node.getAttribute('data')).toBe('[object Object]');
+    });
+  });
+
+  describe('boolean properties', () => {
+    it('render boolean prop with true value', () => {
+      render((
+        <div hidden={true} />
+      ), container, {
+        driver: DriverDOM
+      });
+
+      let node = container.children[0];
+      expect(node.getAttribute('hidden')).toBe('true');
+    });
+
+    it('render boolean prop with false value', () => {
+      render((
+        <div hidden={false} />
+      ), container, {
+        driver: DriverDOM
+      });
+
+      let node = container.children[0];
+      expect(node.getAttribute('hidden')).toBe('false');
+    });
+
+    it('render boolean prop with self value', () => {
+      render((
+        <div hidden={'hidden'} />
+      ), container, {
+        driver: DriverDOM
+      });
+
+      let node = container.children[0];
+      expect(node.getAttribute('hidden')).toBe('hidden');
+    });
+  });
+
+  describe('properties must set with property', () => {
+    it('render boolean prop with true', () => {
+      render((
+        <input type="checkbox" checked={true} />
+      ), container, {
+        driver: DriverDOM
+      });
+
+      let node = container.children[0];
+      expect(node.checked).toBe(true);
+    });
+
+    it('render boolean prop with false', () => {
+      render((
+        <input type="checkbox" checked={false} />
+      ), container, {
+        driver: DriverDOM
+      });
+
+      let node = container.children[0];
+      expect(node.checked).toBe(false);
+    });
+  });
+});

--- a/packages/driver-dom/src/__tests__/svg.js
+++ b/packages/driver-dom/src/__tests__/svg.js
@@ -31,7 +31,7 @@ describe('svg', () => {
     expect(tspanNode.namespaceURI).toEqual('http://www.w3.org/2000/svg');
   });
 
-  it('should render transform', () => {
+  it('should set transform as attribute', () => {
     render((
       <svg height="90" width="200">
         <text transform="scale(1 0.5)" test={true}>

--- a/packages/driver-dom/src/__tests__/svg.js
+++ b/packages/driver-dom/src/__tests__/svg.js
@@ -30,4 +30,22 @@ describe('svg', () => {
     let tspanNode = textNode.children[0];
     expect(tspanNode.namespaceURI).toEqual('http://www.w3.org/2000/svg');
   });
+
+  it('should render transform', () => {
+    render((
+      <svg height="90" width="200">
+        <text transform="scale(1 0.5)" test={true}>
+          <tspan x="10" y="45">First line.</tspan>
+        </text>
+        Sorry, your browser does not support inline SVG.
+      </svg>
+    ), container, {
+      driver: DriverDOM
+    });
+
+    let svgNode = container.children[0];
+    let textNode = svgNode.children[0];
+
+    expect(textNode.getAttribute('transform')).toEqual('scale(1 0.5)');
+  });
 });

--- a/packages/driver-dom/src/index.js
+++ b/packages/driver-dom/src/index.js
@@ -45,6 +45,16 @@ const HYDRATION_INDEX = '__i';
 const HYDRATION_APPEND = '__a';
 const __DEV__ = process.env.NODE_ENV !== 'production';
 
+// These are all booleans.
+// Should be set as DOM properties rather than attributes.
+// If you 'setAttribute' {false} to these property, it will be a string 'false'.
+const MUST_USE_PROPERTIES = {
+  'checked': true,
+  'multiple': true,
+  'muted': true,
+  'selected': true
+};
+
 let tagNamePrefix = EMPTY;
 // Flag indicating if the diff is currently within an SVG
 let isSVGMode = false;
@@ -366,13 +376,8 @@ export function setAttribute(node, propKey, propValue) {
 
   if (propKey === CLASS_NAME) propKey = CLASS;
 
-  if (propKey in node) {
-    try {
-      // Some node property is readonly when in strict mode
-      node[propKey] = propValue;
-    } catch (e) {
-      node[SET_ATTRIBUTE](propKey, propValue);
-    }
+  if (MUST_USE_PROPERTIES[propKey]) {
+    node[propKey] = propValue;
   } else {
     node[SET_ATTRIBUTE](propKey, propValue);
   }

--- a/packages/driver-dom/src/index.js
+++ b/packages/driver-dom/src/index.js
@@ -376,6 +376,7 @@ export function setAttribute(node, propKey, propValue, isSvg) {
 
   if (propKey === CLASS_NAME) propKey = CLASS;
 
+  // Prop for svg can only be set by attribute
   if (!isSvg && propKey in node) {
     try {
       // Some node property is readonly when in strict mode


### PR DESCRIPTION
When set some attribute such as 'transform'  to DOM by `node[propKey] = propValue`,  it will fail and do not throw error in none strict mode.