### PR TITLE
chore(miniapp): root node use custom component

### DIFF
--- a/packages/miniapp-render/src/createConfig/element.js
+++ b/packages/miniapp-render/src/createConfig/element.js
@@ -1,17 +1,27 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { isMiniApp } from 'universal-env';
 import createEventProxy from '../bridge/createEventProxy';
 
 export default function() {
-  const config = {
-    properties: {
-      r: {
-        type: Object,
-        value: {}
-      }
-    },
-    options: {
-      styleIsolation: 'shared'
-    },
-    methods: createEventProxy()
-  };
-  return config;
+  if (isMiniApp) {
+    return {
+      props: {
+        r: {}
+      },
+      methods: createEventProxy()
+    };
+  } else {
+    return {
+      properties: {
+        r: {
+          type: Object,
+          value: {}
+        }
+      },
+      options: {
+        styleIsolation: 'shared'
+      },
+      methods: createEventProxy()
+    };
+  }
 }


### PR DESCRIPTION
页面根节点通过自定义组件渲染，从而避免在使用到原生组件时，将 `root.axml` 每次都写入每个页面造成小程序体积过大