### PR TITLE
Fix: hydrate node with dangerouslySetInnerHTML

### DIFF
--- a/packages/driver-dom/package.json
+++ b/packages/driver-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "driver-dom",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "DOM driver for Rax",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/driver-dom/src/__tests__/hydrate.js
+++ b/packages/driver-dom/src/__tests__/hydrate.js
@@ -119,7 +119,7 @@ describe('Hydrate', () => {
     expect(container.childNodes[0].childNodes[2].tagName).toBe('DIV');
   });
 
-  it('should not recolect hydration child with innerHtml', () => {
+  it('should not compare and delete hydration child with innerHTML', () => {
     const Component = () => {
       return (
         <div className="container" dangerouslySetInnerHTML={{__html: '<div>About Rax</div><div>Docs</div>'}} />

--- a/packages/driver-dom/src/__tests__/hydrate.js
+++ b/packages/driver-dom/src/__tests__/hydrate.js
@@ -118,4 +118,18 @@ describe('Hydrate', () => {
 
     expect(container.childNodes[0].childNodes[2].tagName).toBe('DIV');
   });
+
+  it('should not recolect hydration child with innerHtml', () => {
+    const Component = () => {
+      return (
+        <div className="container" dangerouslySetInnerHTML={{__html: `<div>About Rax</div><div>Docs</div>`}} />
+      );
+    };
+
+    render(<Component />, container, { driver: DriverDOM, hydrate: true });
+
+    jest.runAllTimers();
+
+    expect(container.childNodes[0].childNodes[0].tagName).toBe('DIV');
+  });
 });

--- a/packages/driver-dom/src/__tests__/hydrate.js
+++ b/packages/driver-dom/src/__tests__/hydrate.js
@@ -122,7 +122,7 @@ describe('Hydrate', () => {
   it('should not recolect hydration child with innerHtml', () => {
     const Component = () => {
       return (
-        <div className="container" dangerouslySetInnerHTML={{__html: `<div>About Rax</div><div>Docs</div>`}} />
+        <div className="container" dangerouslySetInnerHTML={{__html: '<div>About Rax</div><div>Docs</div>'}} />
       );
     };
 

--- a/packages/driver-dom/src/index.js
+++ b/packages/driver-dom/src/index.js
@@ -371,7 +371,6 @@ export function removeAttribute(node, propKey) {
 
 export function setAttribute(node, propKey, propValue, isSvg) {
   if (propKey === DANGEROUSLY_SET_INNER_HTML) {
-
     // For reduce innerHTML operation to improve performance.
     if (node[INNER_HTML] !== propValue[HTML]) {
       node[INNER_HTML] = propValue[HTML];


### PR DESCRIPTION
When hydrate node with  dangerouslySetInnerHTML :

```jsx
<div className="container" dangerouslySetInnerHTML={{__html: `<div>About Rax</div><div>Docs</div>`}} />
```

It will trigger `recolectHydrationChild`  and clear innerHtml.

Result is `<div class="container"></div>` rather than `<div class="container" ><div>About Rax</div><div>Docs</div></div>`