### PR TITLE
fix(miniapp): path cache

### DIFF
--- a/packages/miniapp-render/src/node/root.js
+++ b/packages/miniapp-render/src/node/root.js
@@ -102,9 +102,10 @@ class RootElement extends Element {
         const ElementNode = renderTask.item;
         const simplifiedNode = traverseTree(ElementNode, simplify);
         renderTask.item = simplifiedNode;
+        // path cache should save lastest taskInfo value
         pathCache.push({
           path: renderTask.path,
-          value: renderTask.item
+          value: taskInfo.value
         });
       }
 


### PR DESCRIPTION
在判断父节点是否已经在视图中渲染的逻辑中，应该 cache 的是通过 `_internal.data` 获取到的值，而不是本次更新需要更新的值，具体见代码变更。