### PR TITLE
fix(miniapp): miss methods binded to element

### DIFF
--- a/packages/miniapp-render/src/utils/cache.js
+++ b/packages/miniapp-render/src/utils/cache.js
@@ -100,9 +100,8 @@ function setElementMethods(methodName, methodFn) {
     elementsCache.forEach(element => {
       element[methodName] = methodFn;
     });
-  } else {
-    elementMethodsCache.set(methodName, methodFn);
   }
+  elementMethodsCache.set(methodName, methodFn);
 }
 
 export default {


### PR DESCRIPTION
- 无论是否有已创建的自定义组件 element，当有新的自定义组件事件设置时，都应该储存至 elementMethodsCache。否则后续有新的 element 创建时，会出现事件丢失的情况