### PR TITLE
fix: should not throw error by default

### DIFF
--- a/packages/driver-universal/package.json
+++ b/packages/driver-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "driver-universal",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Driver for Universal App.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/driver-universal/src/index.js
+++ b/packages/driver-universal/src/index.js
@@ -14,7 +14,7 @@ if (isWeex) {
 } else if (isMiniApp || isWeChatMiniProgram) {
   currentDriver = MiniAppDriver;
 } else {
-  throw new Error('Your environment was not supported by driver-universal.');
+  console.warn('Warning: Your environment was not supported by driver-universal.');
 }
 
 export default currentDriver;


### PR DESCRIPTION
在一些 SSR 场景下，如果共用入口，会引入 driver-universal, 虽然没执行但会直接抛错，阻断了后续流程
