### PR TITLE
feat(miniapp): support react render custom native component

### DIFF
--- a/examples/app-lifecycle/abc.json
+++ b/examples/app-lifecycle/abc.json
@@ -1,7 +1,0 @@
-{
-  "type": "rax",
-  "builder": "@ali/builder-rax-v1",
-  "info": {
-    "raxVersion": "1.x"
-  }
-}

--- a/examples/page-lifecycle-with-router/abc.json
+++ b/examples/page-lifecycle-with-router/abc.json
@@ -1,7 +1,0 @@
-{
-  "type": "rax",
-  "builder": "@ali/builder-rax-v1",
-  "info": {
-    "raxVersion": "1.x"
-  }
-}

--- a/examples/with-miniapp-native-custom-component/abc.json
+++ b/examples/with-miniapp-native-custom-component/abc.json
@@ -1,7 +1,0 @@
-{
-  "type": "rax",
-  "builder": "@ali/builder-rax-v1",
-  "info": {
-    "raxVersion": "1.x"
-  }
-}

--- a/examples/with-miniapp-native-page/abc.json
+++ b/examples/with-miniapp-native-page/abc.json
@@ -1,7 +1,0 @@
-{
-  "type": "rax",
-  "builder": "@ali/builder-rax-v1",
-  "info": {
-    "raxVersion": "1.x"
-  }
-}

--- a/examples/with-miniapp-plugin-component/abc.json
+++ b/examples/with-miniapp-plugin-component/abc.json
@@ -1,7 +1,0 @@
-{
-  "type": "rax",
-  "builder": "@ali/builder-rax-v1",
-  "info": {
-    "raxVersion": "1.x"
-  }
-}


### PR DESCRIPTION
#### 背景
- 所有 `on` 开头的属性均为事件绑定，ReactDOM 在给 DOM 绑定事件的时候，会有一个白名单校验，这就导致小程序原生自定义组件上的事件无法通过属性名校验，以 `mini-ali-ui` title 组件的 `onActionTap` 为例，此时就会导致框架报错和事件绑定失效。
- ReactDOM 会校验属性名不允许是驼峰命名

#### 解法
- 在构建预编译阶段扫描到原生组件的时候，将 `onActionTap` 转译为 `action-tap`，将  `hasLine` 转译为 `has-line`，同时存储映射关系供模板生成使用
- 在 `CustomComponent` 类进行 `setAttribute` 的时候，对属性值类型进行校验，如果为 `function` 且属性名在预编译分析的事件名列表中，则调用 `this.addEvenetListener` 添加事件监听
