### PR TITLE
fix(jsx2mp): wechat miniprogram constructor props receive

### DIFF
--- a/packages/jsx2mp-runtime/package.json
+++ b/packages/jsx2mp-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-runtime",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Runtime for jsx2mp.",
   "miniprogram": {
     "ali": "dist/jsx2mp-runtime.ali.esm.js",

--- a/packages/jsx2mp-runtime/src/updater.js
+++ b/packages/jsx2mp-runtime/src/updater.js
@@ -72,6 +72,7 @@ export function updateChildProps(trigger, instanceId, nextUpdateProps) {
       /**
        * updateChildProps may execute  before setComponentInstance
        */
+      nextPropsMap[instanceId] = nextUpdateProps;
       updateChildPropsCallbacks[instanceId] = updateChildProps.bind(
         null,
         trigger,


### PR DESCRIPTION
修复微信小程序通过 `updateChildProps` 获取父组件传递过来的 `props` 的时候，要晚于组件实例创建，导致 `constructor` 阶段无法拿到预期的 `props`