### PR TITLE
[RELEASE] miniapp-compiler 0910

### DIFF
--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/src/modules/code.js
+++ b/packages/jsx-compiler/src/modules/code.js
@@ -584,7 +584,7 @@ function addRegisterRefs(refs, renderFunctionPath) {
  */
 function ensureIndexInPath(value, resourcePath) {
   const target = resolveModule.sync(resolve(dirname(resourcePath), value), {
-    extensions: ['.js', '.ts']
+    extensions: ['.js', '.ts', 'jsx', 'tsx']
   });
   const result = relative(dirname(resourcePath), target);
   return removeJSExtension(addRelativePathPrefix(normalizeOutputFilePath(result)));

--- a/packages/jsx-compiler/src/modules/code.js
+++ b/packages/jsx-compiler/src/modules/code.js
@@ -584,7 +584,7 @@ function addRegisterRefs(refs, renderFunctionPath) {
  */
 function ensureIndexInPath(value, resourcePath) {
   const target = resolveModule.sync(resolve(dirname(resourcePath), value), {
-    extensions: ['.js', '.ts', 'jsx', 'tsx']
+    extensions: ['.js', '.ts', '.jsx', '.tsx']
   });
   const result = relative(dirname(resourcePath), target);
   return removeJSExtension(addRelativePathPrefix(normalizeOutputFilePath(result)));

--- a/packages/jsx2mp-runtime/package.json
+++ b/packages/jsx2mp-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-runtime",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Runtime for jsx2mp.",
   "miniprogram": {
     "ali": "dist/jsx2mp-runtime.ali.esm.js",

--- a/packages/jsx2mp-runtime/src/updater.js
+++ b/packages/jsx2mp-runtime/src/updater.js
@@ -72,6 +72,7 @@ export function updateChildProps(trigger, instanceId, nextUpdateProps) {
       /**
        * updateChildProps may execute  before setComponentInstance
        */
+      nextPropsMap[instanceId] = nextUpdateProps;
       updateChildPropsCallbacks[instanceId] = updateChildProps.bind(
         null,
         trigger,


### PR DESCRIPTION
- 修复微信小程序通过 updateChildProps 获取父组件传递过来的 props 的时候，要晚于组件实例创建，导致 constructor 阶段无法拿到预期的 props
- 无法解析 jsx/tsx 后缀