### PR TITLE
chore: create app container

### DIFF
--- a/packages/rax-app/package.json
+++ b/packages/rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-app",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "Rax application framework for univesal app.",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -18,7 +18,7 @@
     "miniapp-renderer": "^0.1.0",
     "rax-app-renderer": "^0.1.0",
     "driver-universal": "^3.1.0",
-    "rax-pwa": "^2.0.0",
+    "create-app-container": "^0.1.1",
     "rax-use-router": "^3.0.0",
     "universal-env": "^3.0.0"
   },

--- a/packages/rax-app/src/App.js
+++ b/packages/rax-app/src/App.js
@@ -1,9 +1,21 @@
 import { createElement, useState, useEffect, Fragment } from 'rax';
 import { useRouter } from 'rax-use-router';
 import { isWeb } from 'universal-env';
-import { Navigation, TabBar } from 'rax-pwa';
+import { createNavigation, createTabBar } from 'create-app-container';
 
 const initialDataFromSSR = global.__INITIAL_DATA__;
+let AppNavigation, TabBar;
+
+if (isWeb) {
+  AppNavigation = createNavigation({
+    createElement,
+    useEffect,
+    useState,
+    Fragment
+  });
+} else {
+  TabBar = createTabBar({ createElement, useEffect, useState, Fragment });
+}
 
 function _isNullableComponent(component) {
   return !component || Array.isArray(component) && component.length === 0;
@@ -11,7 +23,11 @@ function _isNullableComponent(component) {
 
 export default function App(props) {
   const { appConfig, history, routes, pageProps, InitialComponent } = props;
-  const { component } = useRouter(() => ({ history, routes, InitialComponent }));
+  const { component } = useRouter(() => ({
+    history,
+    routes,
+    InitialComponent,
+  }));
 
   if (_isNullableComponent(component)) {
     // Return null directly if not matched.
@@ -19,52 +35,92 @@ export default function App(props) {
   } else {
     const [pageInitialProps, setPageInitialProps] = useState(
       // If SSR is enabled, set pageInitialProps: {pagePath: pageData}
-      initialDataFromSSR ? { [initialDataFromSSR.pagePath || '']: initialDataFromSSR.pageData || {} } : {}
+      initialDataFromSSR
+        ? {
+          [initialDataFromSSR.pagePath || '']:
+              initialDataFromSSR.pageData || {},
+        }
+        : {}
     );
 
     // If SSR is enabled, process getInitialProps method
-    if (isWeb && initialDataFromSSR && component.getInitialProps && !pageInitialProps[component.__path]) {
+    if (
+      isWeb &&
+      initialDataFromSSR &&
+      component.getInitialProps &&
+      !pageInitialProps[component.__path]
+    ) {
       useEffect(() => {
         const getInitialPropsPromise = component.getInitialProps();
 
         // Check getInitialProps returns promise.
         if (process.env.NODE_ENV !== 'production') {
           if (!getInitialPropsPromise.then) {
-            throw new Error('getInitialProps should be async function or return a promise. See detail at "' + component.name + '".');
+            throw new Error(
+              'getInitialProps should be async function or return a promise. See detail at "' +
+                component.name +
+                '".'
+            );
           }
         }
 
-        getInitialPropsPromise.then((nextDefaultProps) => {
-          if (nextDefaultProps) {
-            // Process pageData from SSR
-            const pageData = initialDataFromSSR && initialDataFromSSR.pagePath === component.__path ? initialDataFromSSR.pageData : {};
-            // Do not cache getInitialPropsPromise result
-            setPageInitialProps(Object.assign({}, { [component.__path]: Object.assign({}, pageData, nextDefaultProps) }));
-          }
-        }).catch((error) => {
-          // In case of uncaught promise.
-          throw error;
-        });
+        getInitialPropsPromise
+          .then((nextDefaultProps) => {
+            if (nextDefaultProps) {
+              // Process pageData from SSR
+              const pageData =
+                initialDataFromSSR &&
+                initialDataFromSSR.pagePath === component.__path
+                  ? initialDataFromSSR.pageData
+                  : {};
+              // Do not cache getInitialPropsPromise result
+              setPageInitialProps(
+                Object.assign(
+                  {},
+                  {
+                    [component.__path]: Object.assign(
+                      {},
+                      pageData,
+                      nextDefaultProps
+                    ),
+                  }
+                )
+              );
+            }
+          })
+          .catch((error) => {
+            // In case of uncaught promise.
+            throw error;
+          });
       });
       // Early return null if initialProps were not get.
       return null;
     }
 
     if (isWeb) {
-      return createElement(
-        Navigation,
-        Object.assign(
-          { appConfig, component, history, location: history.location, routes, InitialComponent },
-          pageInitialProps[component.__path],
-          pageProps
-        )
-      );
+      return createElement(AppNavigation, {
+        staticConfig: appConfig,
+        component,
+        history,
+        location: history.location,
+        routes,
+        InitialComponent,
+        ...pageInitialProps[component.__path],
+        ...pageProps,
+      });
     }
 
     return createElement(
       Fragment,
       {},
-      createElement(component, Object.assign({ history, location: history.location, routes, InitialComponent }, pageInitialProps[component.__path], pageProps)),
+      createElement(
+        component,
+        Object.assign(
+          { history, location: history.location, routes, InitialComponent },
+          pageInitialProps[component.__path],
+          pageProps
+        )
+      ),
       createElement(TabBar, { history, config: appConfig.tabBar })
     );
   }


### PR DESCRIPTION
移除 rax-app 2.x 对 `rax-pwa` 的依赖，改为依赖框架中台提供的 `create-app-container`