### PR TITLE
Fix hydrate style in iOS 10

### DIFF
--- a/packages/driver-dom/CHANGELOG.md
+++ b/packages/driver-dom/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v2.2.1
 
-- Fix hyrate style with with webkit prefix in iOS 10
+- Fix hydrate style with webkit prefix in iOS 10
 
 ### v2.2.1
 

--- a/packages/driver-dom/CHANGELOG.md
+++ b/packages/driver-dom/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### v2.2.1
 
+- Fix hyrate style with with webkit prefix in iOS 10
+
+### v2.2.1
+
 - Bump version
 
 ### v2.2.0

--- a/packages/driver-dom/package.json
+++ b/packages/driver-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "driver-dom",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "DOM driver for Rax",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/driver-dom/src/index.js
+++ b/packages/driver-dom/src/index.js
@@ -201,8 +201,8 @@ export function createElement(type, props, component, __shouldConvertUnitlessToR
             for (let l = hydrationChild.style.length; 0 < l; l--) {
               // Prop name get from node style is hyphenated, eg: background-color
               let stylePropName = hydrationChild.style[l - 1];
-              // In iOS 10, when set transition-timing-function to be empty, it will also delete -webkit-transition-timing-function.
-              // So, stylePropName may be undefined.
+              // Style with webkit prefix, will cause stylePropName be undefined in iOS 10.
+              // Eg. when set transition-timing-function to be empty, it will also delete -webkit-transition-timing-function.
               if (stylePropName) {
                 let camelizedStyleName = camelizeStyleName(stylePropName);
                 if (propValue[camelizedStyleName] == null) {

--- a/packages/driver-dom/src/index.js
+++ b/packages/driver-dom/src/index.js
@@ -200,11 +200,11 @@ export function createElement(type, props, component, __shouldConvertUnitlessToR
             // Set style to empty will change the index of style, so here need to traverse style backwards
             for (let l = hydrationChild.style.length; 0 < l; l--) {
               // Prop name get from node style is hyphenated, eg: background-color
-              let stylePropName = hydrationChild.style[l - 1];
-              // Style with webkit prefix, will cause stylePropName be undefined in iOS 10.
+              const stylePropName = hydrationChild.style[l - 1];
+              // Style with webkit prefix, will cause stylePropName be undefined in iOS 10.1 and 10.2.
               // Eg. when set transition-timing-function to be empty, it will also delete -webkit-transition-timing-function.
               if (stylePropName) {
-                let camelizedStyleName = camelizeStyleName(stylePropName);
+                const camelizedStyleName = camelizeStyleName(stylePropName);
                 if (propValue[camelizedStyleName] == null) {
                   hydrationChild.style[camelizedStyleName] = EMPTY;
                 }

--- a/packages/driver-dom/src/index.js
+++ b/packages/driver-dom/src/index.js
@@ -201,9 +201,13 @@ export function createElement(type, props, component, __shouldConvertUnitlessToR
             for (let l = hydrationChild.style.length; 0 < l; l--) {
               // Prop name get from node style is hyphenated, eg: background-color
               let stylePropName = hydrationChild.style[l - 1];
-              let camelizedStyleName = camelizeStyleName(stylePropName);
-              if (propValue[camelizedStyleName] == null) {
-                hydrationChild.style[camelizedStyleName] = EMPTY;
+              // In iOS 10, when set transition-timing-function to be empty, it will also delete -webkit-transition-timing-function.
+              // So, stylePropName may be undefined.
+              if (stylePropName) {
+                let camelizedStyleName = camelizeStyleName(stylePropName);
+                if (propValue[camelizedStyleName] == null) {
+                  hydrationChild.style[camelizedStyleName] = EMPTY;
+                }
               }
             }
           }


### PR DESCRIPTION
iOS 10 下，对节点增加 `transition-timing-function` 的样式，会同时追加 `-webkit-transition-timing-function` 属性。同样的，删除其中一个样式属性，另外一个也会被随之删除。在 Hydrate 样式的时候，会因为拿到的样式名为 undefined ，导致执行错误，所以需要增加兼容处理。
![image](https://user-images.githubusercontent.com/1303018/118089695-38709e80-b3fb-11eb-9465-d6f140bea036.png)


