### PR TITLE
fix(rax): add lacked input argument of getDerivedStateFromError (fix #2211)

### DIFF
--- a/packages/rax/src/vdom/__tests__/composite.js
+++ b/packages/rax/src/vdom/__tests__/composite.js
@@ -762,6 +762,46 @@ describe('CompositeComponent', function() {
     expect(container.childNodes[0].childNodes[0].data).toBe('Something went wrong.');
   });
 
+  it('should catch the exact error with getDerivedStateFromError.', () => {
+    let caughtError;
+    let exampleError = new Error('Example error message');
+    let container = createNodeElement('div');
+
+    class ErrorBoundary extends Component {
+      constructor(props) {
+        super(props);
+        this.state = { hasError: false, error: null };
+      }
+
+      static getDerivedStateFromError(error) {
+        caughtError = error;
+        return { hasError: true, error };
+      }
+
+      render() {
+        if (this.state.hasError) {
+          return <h1>{this.state.error.message}</h1>;
+        }
+
+        return this.props.children;
+      }
+    }
+
+    function BrokenRender(props) {
+      throw exampleError;
+    }
+
+    render(
+      <ErrorBoundary>
+        <BrokenRender />
+      </ErrorBoundary>, container);
+
+    jest.runAllTimers();
+
+    expect(caughtError).toBe(exampleError);
+    expect(container.childNodes[0].childNodes[0].data).toBe('Example error message');
+  });
+
   it('should render correct when prevRenderedComponent did not generate nodes', () => {
     let container = createNodeElement('div');
     class Frag extends Component {

--- a/packages/rax/src/vdom/performInSandbox.js
+++ b/packages/rax/src/vdom/performInSandbox.js
@@ -39,7 +39,7 @@ export function handleError(instance, error) {
 
           // Update state to the next render to show the fallback UI.
           if (boundary.constructor && boundary.constructor.getDerivedStateFromError) {
-            const state = boundary.constructor.getDerivedStateFromError();
+            const state = boundary.constructor.getDerivedStateFromError(error);
             boundary.setState(state);
           }
         }, boundaryInternal.__parentInstance);


### PR DESCRIPTION
Fix bug: [The input argument of getDerivedStateFromError of class component is missing #2211
](https://github.com/alibaba/rax/issues/2211)

*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).
5. Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.
