### PR TITLE
fix: compat react bundle path

### DIFF
--- a/packages/rax/CHANGELOG.md
+++ b/packages/rax/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### 1.2.2
+
+- fix: `lib/compat` bundle error path
+
 ### 1.2.1
 
 - refactor: change output result format, avoid mixing `IIFE` and `CJS`

--- a/packages/rax/package.json
+++ b/packages/rax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A universal React-compatible render engine.",
   "license": "BSD-3-Clause",
   "main": "index.js",

--- a/scripts/dist-core.js
+++ b/scripts/dist-core.js
@@ -183,6 +183,6 @@ build({
   entry: 'src/compat/index.js',
   outputPath: './packages/rax/lib/compat/index.js',
   format: CJS,
-  external: ['../..index', 'rax-children', 'rax-is-valid-element', 'rax-create-factory', 'rax-clone-element'],
+  external: ['../../index', 'rax-children', 'rax-is-valid-element', 'rax-create-factory', 'rax-clone-element'],
   replaceValues: { 'process.env.RAX_VERSION': raxVersion },
 });

--- a/scripts/dist-core.js
+++ b/scripts/dist-core.js
@@ -177,6 +177,7 @@ buildCorePackages({
 
 // Build rax compat react version to rax/lib/compat/index.js
 // It needs external ../../index, which won't bundle rax into lib/compat/index.js
+// If bundle rax into lib/compat/index.js, it will exist multiple version rax in the project with rax and react are used together
 build({
   packageName: 'rax',
   name: 'Rax',

--- a/scripts/dist-core.js
+++ b/scripts/dist-core.js
@@ -176,12 +176,13 @@ buildCorePackages({
 });
 
 // Build rax compat react version to rax/lib/compat/index.js
+// It needs external ../../index, which won't bundle rax into lib/compat/index.js
 build({
   packageName: 'rax',
   name: 'Rax',
   entry: 'src/compat/index.js',
   outputPath: './packages/rax/lib/compat/index.js',
   format: CJS,
-  external: ['rax-children', 'rax-is-valid-element', 'rax-create-factory', 'rax-clone-element'],
+  external: ['../..index', 'rax-children', 'rax-is-valid-element', 'rax-create-factory', 'rax-clone-element'],
   replaceValues: { 'process.env.RAX_VERSION': raxVersion },
 });


### PR DESCRIPTION
The wrong result: https://unpkg.alibaba-inc.com/browse/rax@1.2.1/lib/compat/index.js
The expected result: https://unpkg.alibaba-inc.com/browse/rax@1.2.2-beta.2/lib/compat/index.js