### PR TITLE
fix: isValidElement should return boolean type

### DIFF
--- a/packages/rax-is-valid-element/src/__tests__/isValidElement.js
+++ b/packages/rax-is-valid-element/src/__tests__/isValidElement.js
@@ -1,0 +1,23 @@
+/* @jsx createElement */
+
+import isValidElement from '../';
+
+describe('isValidElement', () => {
+  it('Return type of isValidElement should be boolean type', () => {
+    expect(isValidElement()).toBe(false);
+    expect(isValidElement(null)).toBe(false);
+    expect(isValidElement({})).toBe(false);
+    expect(isValidElement({type: 'div'})).toBe(false);
+
+    expect(isValidElement({
+      type: 'div',
+      props: {}
+    })).toBe(true);
+    expect(isValidElement({
+      type: 'div',
+      props: {
+        style: {}
+      }
+    })).toBe(true);
+  });
+});

--- a/packages/rax-is-valid-element/src/index.js
+++ b/packages/rax-is-valid-element/src/index.js
@@ -1,3 +1,3 @@
 export default function isValidElement(object) {
-  return typeof object === 'object' && object !== null && object.type && !!object.props;
+  return !!(typeof object === 'object' && object !== null && object.type && object.props);
 }


### PR DESCRIPTION
fix:
```
isValidElement({}) // => undefined
```