### PR TITLE
chore: avoid update falsy node

### DIFF
--- a/.github/workflows/auto-publisher.yml
+++ b/.github/workflows/auto-publisher.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - run: npm install
       - run: npm run setup

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - name: Setup Chrome and chromedriver
         uses: ./.github/actions/setup-chrome

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
     steps:
     - uses: actions/checkout@v2
     - name: Set branch name

--- a/packages/rax/src/types.js
+++ b/packages/rax/src/types.js
@@ -26,5 +26,9 @@ export function isNumber(string) {
   return typeof string === 'number';
 }
 
+export function isFalsy(val) {
+  return !Boolean(val);
+}
+
 export const NOOP = () => {};
 export const EMPTY_OBJECT = {};

--- a/packages/rax/src/vdom/__tests__/empty.js
+++ b/packages/rax/src/vdom/__tests__/empty.js
@@ -111,4 +111,28 @@ describe('EmptyComponent', function() {
 
     expect(emptyNode1).toBe(emptyNode2);
   });
+
+  it('empty node is created by falsy element should be replaced normally', () => {
+    class Foo extends PureComponent {
+      state = {
+        alwaysShowUndefined: false
+      };
+      render() {
+        return (
+          this.state.alwaysShowUndefined ? undefined : <label key="hello" text="hello" />
+        );
+      }
+    }
+    const el = createNodeElement('div');
+    let component = render(<Foo />, el);
+    jest.runAllTimers();
+    expect(el.childNodes.length).toBe(3);
+    const originEmptyNode = el.childNodes[1];
+
+    component.setState({alwaysShowNULL: false});
+    jest.runAllTimers();
+    const emptyNode1 = el.childNodes[1];
+    expect(el.childNodes.length).toBe(3);
+    expect(originEmptyNode).not.toBe(emptyNode1);
+  });
 });

--- a/packages/rax/src/vdom/__tests__/empty.js
+++ b/packages/rax/src/vdom/__tests__/empty.js
@@ -126,13 +126,16 @@ describe('EmptyComponent', function() {
     const el = createNodeElement('div');
     let component = render(<Foo />, el);
     jest.runAllTimers();
-    expect(el.childNodes.length).toBe(3);
-    const originEmptyNode = el.childNodes[1];
+    expect(el.childNodes.length).toBe(1);
+    const originEmptyNode = el.childNodes[0];
 
-    component.setState({alwaysShowNULL: false});
+    component.setState({
+      alwaysShowUndefined: true
+    });
+
     jest.runAllTimers();
-    const emptyNode1 = el.childNodes[1];
-    expect(el.childNodes.length).toBe(3);
+    const emptyNode1 = el.childNodes[0];
+    expect(el.childNodes.length).toBe(1);
     expect(originEmptyNode).not.toBe(emptyNode1);
   });
 });

--- a/packages/rax/src/vdom/__tests__/empty.js
+++ b/packages/rax/src/vdom/__tests__/empty.js
@@ -84,4 +84,31 @@ describe('EmptyComponent', function() {
     expect(el.childNodes.length).toBe(3);
     expect(originEmptyNode).not.toBe(emptyNode1);
   });
+
+  it('empty node is created by falsy element should not be rebuilt', () => {
+    class Foo extends PureComponent {
+      state = {
+        alwaysShowUndefined: false
+      };
+      render() {
+        return (
+          this.state.alwaysShowUndefined ? undefined : undefined
+        );
+      }
+    }
+    const el = createNodeElement('div');
+    let component = render(<Foo />, el);
+    jest.runAllTimers();
+
+    component.setState({alwaysShowUndefined: !component.state.alwaysShowUndefined});
+    jest.runAllTimers();
+    const emptyNode1 = el.childNodes[0];
+
+    component.setState({alwaysShowUndefined: !component.state.alwaysShowUndefined});
+    jest.runAllTimers();
+    const emptyNode2 = el.childNodes[0];
+
+
+    expect(emptyNode1).toBe(emptyNode2);
+  });
 });

--- a/packages/rax/src/vdom/shouldUpdateComponent.js
+++ b/packages/rax/src/vdom/shouldUpdateComponent.js
@@ -1,10 +1,10 @@
-import {isArray, isString, isNumber, isObject, isNull} from '../types';
+import {isArray, isString, isNumber, isObject, isFalsy} from '../types';
 
 function shouldUpdateComponent(prevElement, nextElement) {
-  let prevEmpty = isNull(prevElement);
-  let nextEmpty = isNull(nextElement);
-  if (prevEmpty || nextEmpty) {
-    return prevEmpty === nextEmpty;
+  let prevFalsy = isFalsy(prevElement);
+  let nextFalsy = isFalsy(nextElement);
+  if (prevFalsy || nextFalsy) {
+    return prevFalsy === nextFalsy;
   }
 
   if (isArray(prevElement) && isArray(nextElement)) {

--- a/scripts/bench/package.json
+++ b/scripts/bench/package.json
@@ -16,7 +16,7 @@
     "debug": "^4.1.1",
     "http-server": "^0.10.0",
     "jstat": "^1.7.1",
-    "lighthouse": "latest",
+    "lighthouse": "^8.0.0",
     "ramda": "^0.26.1",
     "selenium-webdriver": "^4.0.0-alpha.1",
     "yargs": "^13.2.2"


### PR DESCRIPTION
Replay code:

```js
import { createElement, render, useState, Fragment } from 'rax';
import Driver from 'driver-universal';

let index = 0;

function Home() {
  const [arr, setArr] = useState([1, 2, 3, 4, 5, 6]);
  function click() {
    switch (index) {
      case 0:
        setArr([4, 5, 6]);
        break;
      case 1:
        setArr([1]);
        break;
      default:
        break;
    }
    index++;
  }
  return (
    <div onClick={click}>
      {new Array(6).fill(1).map((v, index) => (
        <Fragment key={index}>{arr[index]}</Fragment>
      ))}
    </div>
  );
}
render(<Home />, document.getElementById('root'), { driver: Driver });
```

More simple case, u can see the added test cases.